### PR TITLE
feat(agent): add codex reasoning effort config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _old/
 shared/
 .design
 _prompts/
+TODOS.md
 
 # Cargo lock (keep for binaries, ignore for libraries — this is a binary)
 # Cargo.lock  # uncomment to ignore

--- a/qa/QA_CASES.md
+++ b/qa/QA_CASES.md
@@ -56,7 +56,7 @@ Cases are split into focused modules under [`cases/`](./cases/):
 
 | Module | Cases |
 | ------ | ----- |
-| [`cases/agents.md`](./cases/agents.md) | ENV-001, AGT-001, AGT-002, AGT-003, PRF-001, LFC-001, LFC-002, ACT-001, ACT-002, NAV-001, WRK-001, REC-001, REC-002 |
+| [`cases/agents.md`](./cases/agents.md) | ENV-001, AGT-001, AGT-002, AGT-003, AGT-004, PRF-001, LFC-001, LFC-002, ACT-001, ACT-002, NAV-001, WRK-001, REC-001, REC-002 |
 | [`cases/channels.md`](./cases/channels.md) | CHN-001, CHN-002, CHN-003, CHN-004 |
 | [`cases/messaging.md`](./cases/messaging.md) | MSG-001, MSG-002, MSG-003, MSG-004, HIS-001, ATT-001, ERR-001 |
 | [`cases/tasks.md`](./cases/tasks.md) | TSK-001, TSK-002 |

--- a/qa/cases/agents.md
+++ b/qa/cases/agents.md
@@ -55,6 +55,7 @@
 - Goal:
   - verify every runtime and model pair currently exposed in the UI can be created and is stored correctly
   - verify duplicate agent names are rejected consistently
+  - verify runtime-specific controls appear only when applicable, especially Codex reasoning effort
 - Preconditions:
   - fresh data dir
   - current runtime/model matrix captured from the create-agent modal before execution
@@ -73,21 +74,30 @@
     - `gpt-5.1-codex-mini`
 - Steps:
   1. Open the create-agent modal and record the runtime and model options actually shown in the build under test.
-  2. Create one disposable agent for every runtime/model pair using a stable naming scheme such as `matrix-<runtime>-<model>`.
-  3. After each creation, verify the new agent appears in the sidebar.
-  4. Open the new agent profile and verify the runtime badge and model badge match the selected pair exactly.
-  5. Verify creation does not silently fall back to a different runtime or model.
-  6. Attempt to create one duplicate name using the exact same config.
-  7. Attempt to create the same duplicate name again with a different runtime or model.
-  8. Verify both duplicate-name attempts fail with a clear error and do not create extra records.
+  2. Switch between Claude and Codex in the create-agent modal.
+  3. Verify the reasoning-effort control is hidden for Claude and visible for Codex.
+  4. For at least one Codex model, choose a non-default reasoning effort and create the agent.
+  5. Create one disposable agent for every runtime/model pair using a stable naming scheme such as `matrix-<runtime>-<model>`.
+  6. After each creation, verify the new agent appears in the sidebar.
+  7. Open the new agent profile and verify the runtime badge and model badge match the selected pair exactly.
+  8. For Codex agents created with a non-default reasoning effort, verify the profile reflects the selected reasoning effort exactly.
+  9. Verify creation does not silently fall back to a different runtime, model, or Codex reasoning effort.
+  10. Attempt to create one duplicate name using the exact same config.
+  11. Attempt to create the same duplicate name again with a different runtime or model.
+  12. Verify both duplicate-name attempts fail with a clear error and do not create extra records.
 - Expected:
   - every visible runtime/model pair is creatable
   - stored runtime and model match the selected values exactly
+  - Codex shows a reasoning-effort control and persists the chosen value exactly
+  - Claude does not show a meaningless reasoning-effort control
   - duplicate names are rejected regardless of runtime or model
   - failures are attributable to a specific pair, not hidden behind a generic fallback
 - Common failure signals:
   - one runtime/model pair cannot be created
   - created agent shows a different model than requested
+  - reasoning-effort control is missing for Codex
+  - reasoning-effort control appears for Claude
+  - created Codex agent ignores the selected reasoning effort
   - runtime picker and stored runtime disagree
   - duplicate name is accepted
   - duplicate name creates partial sidebar or DB state
@@ -135,23 +145,28 @@
   - a shared channel or DM contains at least one visible historical message from that agent before delete
 - Steps:
   1. Open a test agent profile and record its runtime, model, and current role text.
-  2. Use the edit control to change the role text and add one environment variable.
-  3. Save the change and verify the profile reflects the new role and environment state.
-  4. Use the restart control in plain `Restart` mode and verify the agent returns to a usable state without losing workspace files.
-  5. Use the restart control in `Reset Session & Restart` mode and verify the agent still has workspace files but behaves like a fresh conversation session.
-  6. Send at least one visible message from the agent in a channel or DM so there is history to inspect after delete.
-  7. Delete the agent using the `keep workspace` option.
-  8. Verify the agent disappears from navigation, the workspace files still exist, and historical messages remain readable with deleted styling.
-  9. Recreate an agent with the same name if the product still allows clean name reuse after delete.
-  10. Verify the recreated agent does not silently remove the deleted styling from the old history rows.
+  2. If the test agent runtime is Codex, verify the edit control shows a reasoning-effort selector; if the runtime is Claude, verify it does not.
+  3. Use the edit control to change the role text and add one environment variable.
+  4. If the runtime is Codex, also change the reasoning effort.
+  5. Save the change and verify the profile reflects the new role, environment state, and Codex reasoning effort when applicable.
+  6. Use the restart control in plain `Restart` mode and verify the agent returns to a usable state without losing workspace files.
+  7. Use the restart control in `Reset Session & Restart` mode and verify the agent still has workspace files but behaves like a fresh conversation session.
+  8. Send at least one visible message from the agent in a channel or DM so there is history to inspect after delete.
+  9. Delete the agent using the `keep workspace` option.
+  10. Verify the agent disappears from navigation, the workspace files still exist, and historical messages remain readable with deleted styling.
+  11. Recreate an agent with the same name if the product still allows clean name reuse after delete.
+  12. Verify the recreated agent does not silently remove the deleted styling from the old history rows.
 - Expected:
   - profile edit persists correctly
+  - Codex reasoning effort is editable and persisted correctly
+  - Claude does not expose Codex-only reasoning controls
   - restart modes behave differently but coherently
   - delete removes the live record while preserving readable history
   - deleted messages remain attributed but visibly historical
   - name reuse does not reattach old messages to the recreated live identity
 - Common failure signals:
   - edit saves but does not actually apply
+  - Codex reasoning effort is missing, ignored, or shown for Claude
   - restart mode effects are indistinguishable
   - workspace keep/delete choice is ignored
   - deleted history rows lose attribution or look live
@@ -249,15 +264,15 @@
 - Steps:
   1. Open `bot-a` activity tab.
   2. Verify the most recent entries include all of these row types when they occurred in the run:
-     - status changes
-     - received messages
-     - sent messages
-     - tool or tool-like work
-     - thinking or output text when available
+    - status changes
+    - received messages
+    - sent messages
+    - tool or tool-like work
+    - thinking or output text when available
   3. Pick one received-message row and verify:
-     - sender name is shown
-     - target label is shown
-     - content preview is recognizable and not empty
+    - sender name is shown
+    - target label is shown
+    - content preview is recognizable and not empty
   4. Pick one sent-message row and verify the target label matches where the message was actually sent.
   5. Pick one tool row and verify the label is specific enough to distinguish waiting, checking, sending, or file/tool work.
   6. Verify entries are visually distinguishable at a glance.
@@ -288,12 +303,12 @@
   1. Open the activity tab for the agent used in `MSG-004`.
   2. Locate the portion of the timeline covering the DM-triggered wake-up.
   3. Verify the sequence is coherent, for example:
-     - non-active or offline state
-     - startup or working state
-     - received message
-     - tool/check/wait work
-     - sent reply
-     - idle or waiting state
+    - non-active or offline state
+    - startup or working state
+    - received message
+    - tool/check/wait work
+    - sent reply
+    - idle or waiting state
   4. Verify the triggering DM content preview appears before or alongside the follow-up send, not after unrelated work.
   5. Verify the sent-reply row content matches the DM reply that was actually rendered in chat.
   6. If the case includes a server restart, verify the timeline does not fabricate phantom active periods after the restart.
@@ -348,9 +363,9 @@
   4. Expand `notes/` and select a markdown file such as `notes/work-log.md`.
   5. Verify the selected row is visibly highlighted.
   6. Verify the right pane header shows:
-     - the relative file path
-     - file size
-     - modified timestamp
+    - the relative file path
+    - file size
+    - modified timestamp
   7. Toggle `Raw` and `Preview`.
   8. Verify `Raw` shows the literal file contents.
   9. Verify `Preview` renders markdown formatting for `.md` files.
@@ -415,3 +430,4 @@
   - disappearing messages
   - activity entries missing for one agent
   - stale tab content during live updates
+

--- a/qa/cases/agents.md
+++ b/qa/cases/agents.md
@@ -123,6 +123,40 @@
   - recreated agent inherits stale profile or channel state
   - name cannot be reused after successful delete
 
+### AGT-004 Agent Control Center Edit, Restart, Delete, And Deleted History
+
+- Tier: 1
+- Release-sensitive: yes when touching profile controls, agent edit flows, restart modes, delete flows, environment variables, or deleted-agent history rendering
+- Execution mode: browser
+- Goal:
+  - verify the profile control center can edit config, run each restart mode coherently, delete an agent with explicit workspace handling, and preserve deleted-history attribution
+- Preconditions:
+  - at least one test agent exists
+  - a shared channel or DM contains at least one visible historical message from that agent before delete
+- Steps:
+  1. Open a test agent profile and record its runtime, model, and current role text.
+  2. Use the edit control to change the role text and add one environment variable.
+  3. Save the change and verify the profile reflects the new role and environment state.
+  4. Use the restart control in plain `Restart` mode and verify the agent returns to a usable state without losing workspace files.
+  5. Use the restart control in `Reset Session & Restart` mode and verify the agent still has workspace files but behaves like a fresh conversation session.
+  6. Send at least one visible message from the agent in a channel or DM so there is history to inspect after delete.
+  7. Delete the agent using the `keep workspace` option.
+  8. Verify the agent disappears from navigation, the workspace files still exist, and historical messages remain readable with deleted styling.
+  9. Recreate an agent with the same name if the product still allows clean name reuse after delete.
+  10. Verify the recreated agent does not silently remove the deleted styling from the old history rows.
+- Expected:
+  - profile edit persists correctly
+  - restart modes behave differently but coherently
+  - delete removes the live record while preserving readable history
+  - deleted messages remain attributed but visibly historical
+  - name reuse does not reattach old messages to the recreated live identity
+- Common failure signals:
+  - edit saves but does not actually apply
+  - restart mode effects are indistinguishable
+  - workspace keep/delete choice is ignored
+  - deleted history rows lose attribution or look live
+  - recreated agent makes old deleted history look active again
+
 ### PRF-001 Agent Profile Accuracy During Lifecycle Changes
 
 - Tier: 0

--- a/src/agent_manager.rs
+++ b/src/agent_manager.rs
@@ -88,7 +88,7 @@ impl AgentManager {
             runtime: agent.runtime.clone(),
             model: agent.model.clone(),
             session_id: resumable_session_id,
-            env_vars: None,
+            env_vars: agent.env_vars.clone(),
         };
 
         let agent_data_dir = self.data_dir.join(agent_name);
@@ -662,7 +662,7 @@ mod tests {
             runtime: "codex".to_string(),
             model: "gpt-5.4-mini".to_string(),
             session_id: session_id.map(str::to_string),
-            env_vars: None,
+            env_vars: Vec::new(),
         }
     }
 

--- a/src/agent_manager.rs
+++ b/src/agent_manager.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Child;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -181,7 +181,12 @@ impl AgentManager {
         let _ = running.process.kill();
         self.store
             .update_agent_status(agent_name, AgentStatus::Inactive)?;
-        activity_log::set_activity_state(&self.activity_logs, agent_name, "offline", "Process stopped");
+        activity_log::set_activity_state(
+            &self.activity_logs,
+            agent_name,
+            "offline",
+            "Process stopped",
+        );
         Ok(())
     }
 
@@ -634,8 +639,8 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::process::{Command, Stdio};
-    use std::time::Duration;
     use std::sync::Arc;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     struct FakeDriver;

--- a/src/agent_manager.rs
+++ b/src/agent_manager.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Child;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -14,6 +15,7 @@ use crate::server::AgentLifecycle;
 use crate::store::Store;
 
 struct RunningAgent {
+    instance_id: u64,
     process: Child,
     driver: Arc<dyn Driver>,
     session_id: Option<String>,
@@ -28,6 +30,7 @@ pub struct AgentManager {
     data_dir: PathBuf,
     bridge_binary: String,
     server_url: String,
+    next_instance_id: AtomicU64,
 }
 
 fn get_driver(runtime: &str) -> anyhow::Result<Arc<dyn Driver>> {
@@ -52,6 +55,7 @@ impl AgentManager {
             data_dir,
             bridge_binary,
             server_url,
+            next_instance_id: AtomicU64::new(1),
         }
     }
 
@@ -139,11 +143,14 @@ impl AgentManager {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
 
+        let instance_id = self.next_instance_id.fetch_add(1, Ordering::Relaxed);
+
         {
             let mut agents = self.agents.lock().await;
             agents.insert(
                 agent_name.to_string(),
                 RunningAgent {
+                    instance_id,
                     process: child,
                     driver: driver.clone(),
                     session_id: running_session_id,
@@ -157,7 +164,7 @@ impl AgentManager {
             .update_agent_status(agent_name, AgentStatus::Active)?;
         activity_log::set_activity_state(&self.activity_logs, agent_name, "working", "Starting…");
 
-        self.spawn_output_reader(agent_name.to_string(), stdout, driver);
+        self.spawn_output_reader(agent_name.to_string(), stdout, driver, instance_id);
         Ok(())
     }
 
@@ -173,6 +180,7 @@ impl AgentManager {
         let _ = running.process.kill();
         self.store
             .update_agent_status(agent_name, AgentStatus::Inactive)?;
+        activity_log::set_activity_state(&self.activity_logs, agent_name, "offline", "Process stopped");
         Ok(())
     }
 
@@ -189,6 +197,7 @@ impl AgentManager {
         let _ = running.process.kill();
         self.store
             .update_agent_status(agent_name, AgentStatus::Sleeping)?;
+        activity_log::set_activity_state(&self.activity_logs, agent_name, "offline", "Sleeping");
         Ok(())
     }
 
@@ -263,6 +272,7 @@ impl AgentManager {
         agent_name: String,
         stdout: std::process::ChildStdout,
         driver: Arc<dyn Driver>,
+        instance_id: u64,
     ) {
         let agents = self.agents.clone();
         let activity_logs = self.activity_logs.clone();
@@ -294,12 +304,21 @@ impl AgentManager {
                 }
             }
 
-            info!(agent = %name, "stdout reader ended — checking exit status");
-            activity_log::set_activity_state(&activity_logs, &name, "offline", "Process stopped");
-
             let rt = tokio::runtime::Handle::current();
             rt.block_on(async {
                 let mut agents_map = agents.lock().await;
+                let Some(current) = agents_map.get(&name) else {
+                    info!(agent = %name, instance_id, "stdout reader ended for stale process");
+                    return;
+                };
+                if current.instance_id != instance_id {
+                    info!(agent = %name, stale_instance = instance_id, current_instance = current.instance_id, "stdout reader ended after agent restart");
+                    return;
+                }
+
+                info!(agent = %name, "stdout reader ended — checking exit status");
+                activity_log::set_activity_state(&activity_logs, &name, "offline", "Process stopped");
+
                 if let Some(mut running) = agents_map.remove(&name) {
                     match running.process.wait() {
                         Ok(status) => {
@@ -613,6 +632,10 @@ fn truncate_prompt_text(text: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+    use std::sync::Arc;
+    use tempfile::tempdir;
 
     struct FakeDriver;
 
@@ -716,5 +739,89 @@ mod tests {
         assert!(prompt.contains("BASE PROMPT"));
         assert!(prompt.contains("Treat this preview as wake-up context only."));
         assert!(prompt.contains("Target: #general"));
+    }
+
+    #[tokio::test]
+    async fn stale_output_reader_does_not_remove_restarted_agent() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("chorus.db");
+        let store = Arc::new(Store::open(db_path.to_str().unwrap()).unwrap());
+        store
+            .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
+            .unwrap();
+
+        let manager = AgentManager::new(
+            store,
+            dir.path().join("agents"),
+            "chorus".to_string(),
+            "http://127.0.0.1:3001".to_string(),
+        );
+        let driver: Arc<dyn Driver> = Arc::new(FakeDriver);
+
+        let mut first = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let first_stdout = first.stdout.take().unwrap();
+        {
+            let mut agents = manager.agents.lock().await;
+            agents.insert(
+                "bot1".to_string(),
+                RunningAgent {
+                    instance_id: 1,
+                    process: first,
+                    driver: driver.clone(),
+                    session_id: None,
+                    is_in_receive_message: false,
+                    pending_notification_count: 0,
+                },
+            );
+        }
+        manager.spawn_output_reader("bot1".to_string(), first_stdout, driver.clone(), 1);
+
+        {
+            let mut agents = manager.agents.lock().await;
+            agents.remove("bot1").unwrap();
+        }
+
+        let second = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        {
+            let mut agents = manager.agents.lock().await;
+            agents.insert(
+                "bot1".to_string(),
+                RunningAgent {
+                    instance_id: 2,
+                    process: second,
+                    driver,
+                    session_id: None,
+                    is_in_receive_message: false,
+                    pending_notification_count: 0,
+                },
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let contains_restarted_agent = manager.agents.lock().await.contains_key("bot1");
+        if contains_restarted_agent {
+            if let Some(mut running) = manager.agents.lock().await.remove("bot1") {
+                let _ = running.process.kill();
+                let _ = running.process.wait();
+            }
+        }
+
+        assert!(
+            contains_restarted_agent,
+            "stale stdout reader removed the restarted agent from the running map"
+        );
     }
 }

--- a/src/agent_manager.rs
+++ b/src/agent_manager.rs
@@ -92,6 +92,7 @@ impl AgentManager {
             runtime: agent.runtime.clone(),
             model: agent.model.clone(),
             session_id: resumable_session_id,
+            reasoning_effort: agent.reasoning_effort.clone(),
             env_vars: agent.env_vars.clone(),
         };
 
@@ -685,6 +686,7 @@ mod tests {
             runtime: "codex".to_string(),
             model: "gpt-5.4-mini".to_string(),
             session_id: session_id.map(str::to_string),
+            reasoning_effort: None,
             env_vars: Vec::new(),
         }
     }

--- a/src/agent_workspace.rs
+++ b/src/agent_workspace.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+
+/// Filesystem helper for per-agent workspace operations.
+pub struct AgentWorkspace<'a> {
+    agents_dir: &'a Path,
+}
+
+impl<'a> AgentWorkspace<'a> {
+    pub fn new(agents_dir: &'a Path) -> Self {
+        Self { agents_dir }
+    }
+
+    /// Resolve the stable workspace path for an agent's persisted files.
+    pub fn path_for(&self, agent_name: &str) -> PathBuf {
+        self.agents_dir.join(agent_name)
+    }
+
+    /// Remove the workspace directory if it exists.
+    pub fn delete_if_exists(&self, agent_name: &str) -> std::io::Result<()> {
+        let path = self.path_for(agent_name);
+        if path.exists() {
+            std::fs::remove_dir_all(path)?;
+        }
+        Ok(())
+    }
+}

--- a/src/drivers/claude.rs
+++ b/src/drivers/claude.rs
@@ -60,10 +60,8 @@ impl Driver for ClaudeDriver {
 
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
         env_vars.insert("FORCE_COLOR".to_string(), "0".to_string());
-        if let Some(ref extra) = ctx.config.env_vars {
-            for (k, v) in extra {
-                env_vars.insert(k.clone(), v.clone());
-            }
+        for extra in &ctx.config.env_vars {
+            env_vars.insert(extra.key.clone(), extra.value.clone());
         }
         env_vars.remove("CLAUDECODE");
 

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -6,6 +6,57 @@ use crate::models::AgentConfig;
 
 pub struct CodexDriver;
 
+fn build_codex_args(ctx: &SpawnContext) -> anyhow::Result<Vec<String>> {
+    let bridge_binary_json = serde_json::to_string(&ctx.bridge_binary)?;
+    let bridge_args_json = serde_json::to_string(&vec![
+        "bridge",
+        "--agent-id",
+        &ctx.agent_id,
+        "--server-url",
+        &ctx.server_url,
+    ])?;
+
+    let mut args = vec!["exec".to_string()];
+
+    if let Some(ref session_id) = ctx.config.session_id {
+        args.push("resume".to_string());
+        args.push(session_id.clone());
+    }
+
+    args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+    args.push("--json".to_string());
+
+    args.push("-c".to_string());
+    args.push(format!("mcp_servers.chat.command={bridge_binary_json}"));
+    args.push("-c".to_string());
+    args.push(format!("mcp_servers.chat.args={bridge_args_json}"));
+    args.push("-c".to_string());
+    args.push("mcp_servers.chat.startup_timeout_sec=30".to_string());
+    args.push("-c".to_string());
+    args.push("mcp_servers.chat.tool_timeout_sec=300".to_string());
+    args.push("-c".to_string());
+    args.push("mcp_servers.chat.enabled=true".to_string());
+    args.push("-c".to_string());
+    args.push("mcp_servers.chat.required=true".to_string());
+
+    if let Some(reasoning_effort) = ctx.config.reasoning_effort.as_deref() {
+        args.push("-c".to_string());
+        args.push(format!(
+            "model_reasoning_effort={}",
+            serde_json::to_string(reasoning_effort)?
+        ));
+    }
+
+    if !ctx.config.model.is_empty() {
+        args.push("-m".to_string());
+        args.push(ctx.config.model.clone());
+    }
+
+    args.push(ctx.prompt.clone());
+
+    Ok(args)
+}
+
 impl Driver for CodexDriver {
     fn id(&self) -> &str {
         "codex"
@@ -57,45 +108,7 @@ impl Driver for CodexDriver {
                 .status()?;
         }
 
-        let bridge_binary_json = serde_json::to_string(&ctx.bridge_binary)?;
-        let bridge_args_json = serde_json::to_string(&vec![
-            "bridge",
-            "--agent-id",
-            &ctx.agent_id,
-            "--server-url",
-            &ctx.server_url,
-        ])?;
-
-        let mut args = vec!["exec".to_string()];
-
-        if let Some(ref session_id) = ctx.config.session_id {
-            args.push("resume".to_string());
-            args.push(session_id.clone());
-        }
-
-        args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
-        args.push("--json".to_string());
-
-        args.push("-c".to_string());
-        args.push(format!("mcp_servers.chat.command={bridge_binary_json}"));
-        args.push("-c".to_string());
-        args.push(format!("mcp_servers.chat.args={bridge_args_json}"));
-        args.push("-c".to_string());
-        args.push("mcp_servers.chat.startup_timeout_sec=30".to_string());
-        args.push("-c".to_string());
-        args.push("mcp_servers.chat.tool_timeout_sec=300".to_string());
-        args.push("-c".to_string());
-        args.push("mcp_servers.chat.enabled=true".to_string());
-        args.push("-c".to_string());
-        args.push("mcp_servers.chat.required=true".to_string());
-
-        if !ctx.config.model.is_empty() {
-            args.push("-m".to_string());
-            args.push(ctx.config.model.clone());
-        }
-
-        // Prompt is the last positional arg
-        args.push(ctx.prompt.clone());
+        let args = build_codex_args(ctx)?;
 
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
         env_vars.insert("FORCE_COLOR".to_string(), "0".to_string());
@@ -434,5 +447,35 @@ impl Driver for CodexDriver {
             "mcp_chat_upload_file" => str_field("file_path"),
             _ => String::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_args_include_reasoning_effort_override_when_configured() {
+        let ctx = SpawnContext {
+            agent_id: "bot1".to_string(),
+            agent_name: "bot1".to_string(),
+            config: AgentConfig {
+                name: "bot1".to_string(),
+                display_name: "Bot 1".to_string(),
+                description: Some("test".to_string()),
+                runtime: "codex".to_string(),
+                model: "gpt-5.4-mini".to_string(),
+                session_id: None,
+                reasoning_effort: Some("low".to_string()),
+                env_vars: Vec::new(),
+            },
+            prompt: "hello".to_string(),
+            working_directory: "/tmp".to_string(),
+            bridge_binary: "chorus".to_string(),
+            server_url: "http://127.0.0.1:3001".to_string(),
+        };
+
+        let args = build_codex_args(&ctx).unwrap();
+        assert!(args.contains(&"model_reasoning_effort=\"low\"".to_string()));
     }
 }

--- a/src/drivers/codex.rs
+++ b/src/drivers/codex.rs
@@ -100,10 +100,8 @@ impl Driver for CodexDriver {
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
         env_vars.insert("FORCE_COLOR".to_string(), "0".to_string());
         env_vars.insert("NO_COLOR".to_string(), "1".to_string());
-        if let Some(ref extra) = ctx.config.env_vars {
-            for (k, v) in extra {
-                env_vars.insert(k.clone(), v.clone());
-            }
+        for extra in &ctx.config.env_vars {
+            env_vars.insert(extra.key.clone(), extra.value.clone());
         }
 
         let child = Command::new("codex")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod activity_log;
 pub mod agent_manager;
+pub mod agent_workspace;
 pub mod bridge;
 pub mod drivers;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
                         description.as_deref(),
                         &runtime,
                         &model,
+                        &[],
                     )?;
                     // Join default channels
                     for ch in store.list_channels()? {

--- a/src/models.rs
+++ b/src/models.rs
@@ -154,9 +154,17 @@ pub struct Agent {
     pub description: Option<String>,
     pub runtime: String,
     pub model: String,
+    pub env_vars: Vec<AgentEnvVar>,
     pub status: AgentStatus,
     pub session_id: Option<String>,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentEnvVar {
+    pub key: String,
+    pub value: String,
+    pub position: i64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -207,7 +215,7 @@ pub struct AgentConfig {
     pub runtime: String,
     pub model: String,
     pub session_id: Option<String>,
-    pub env_vars: Option<std::collections::HashMap<String, String>>,
+    pub env_vars: Vec<AgentEnvVar>,
 }
 
 // ── API request/response types ──
@@ -277,6 +285,8 @@ pub struct HistoryMessage {
     pub sender_type: String,
     #[serde(rename = "createdAt")]
     pub created_at: String,
+    #[serde(rename = "senderDeleted")]
+    pub sender_deleted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<AttachmentRef>>,
     #[serde(rename = "replyCount", skip_serializing_if = "Option::is_none")]
@@ -329,6 +339,19 @@ pub struct AgentInfo {
     pub activity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activity_detail: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AgentDetailResponse {
+    pub agent: AgentInfo,
+    #[serde(rename = "envVars")]
+    pub env_vars: Vec<AgentEnvVarPayload>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AgentEnvVarPayload {
+    pub key: String,
+    pub value: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -445,4 +468,65 @@ pub struct ActivityLogResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
     pub error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateAgentRequest {
+    pub name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default = "default_runtime")]
+    pub runtime: String,
+    #[serde(default = "default_model")]
+    pub model: String,
+    #[serde(default, rename = "envVars")]
+    pub env_vars: Vec<AgentEnvVarPayload>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateAgentRequest {
+    pub display_name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default = "default_runtime")]
+    pub runtime: String,
+    #[serde(default = "default_model")]
+    pub model: String,
+    #[serde(default, rename = "envVars")]
+    pub env_vars: Vec<AgentEnvVarPayload>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RestartAgentRequest {
+    pub mode: RestartMode,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RestartMode {
+    Restart,
+    ResetSession,
+    FullReset,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteAgentRequest {
+    pub mode: DeleteMode,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeleteMode {
+    PreserveWorkspace,
+    DeleteWorkspace,
+}
+
+fn default_runtime() -> String {
+    "claude".to_string()
+}
+
+fn default_model() -> String {
+    "sonnet".to_string()
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -154,6 +154,7 @@ pub struct Agent {
     pub description: Option<String>,
     pub runtime: String,
     pub model: String,
+    pub reasoning_effort: Option<String>,
     pub env_vars: Vec<AgentEnvVar>,
     pub status: AgentStatus,
     pub session_id: Option<String>,
@@ -215,6 +216,7 @@ pub struct AgentConfig {
     pub runtime: String,
     pub model: String,
     pub session_id: Option<String>,
+    pub reasoning_effort: Option<String>,
     pub env_vars: Vec<AgentEnvVar>,
 }
 
@@ -332,6 +334,8 @@ pub struct AgentInfo {
     pub runtime: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(rename = "reasoningEffort", skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// Live activity state: online | thinking | working | offline
@@ -481,6 +485,8 @@ pub struct CreateAgentRequest {
     pub runtime: String,
     #[serde(default = "default_model")]
     pub model: String,
+    #[serde(default, rename = "reasoningEffort")]
+    pub reasoning_effort: Option<String>,
     #[serde(default, rename = "envVars")]
     pub env_vars: Vec<AgentEnvVarPayload>,
 }
@@ -494,6 +500,8 @@ pub struct UpdateAgentRequest {
     pub runtime: String,
     #[serde(default = "default_model")]
     pub model: String,
+    #[serde(default, rename = "reasoningEffort")]
+    pub reasoning_effort: Option<String>,
     #[serde(default, rename = "envVars")]
     pub env_vars: Vec<AgentEnvVarPayload>,
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use super::AgentLifecycle;
 use crate::agent_workspace::AgentWorkspace;
 use crate::models::*;
-use crate::store::Store;
+use crate::store::{AgentRecordUpsert, Store};
 
 pub type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
 
@@ -556,7 +556,9 @@ pub async fn handle_create_channel(
 
 // ── Agent management ──
 
-fn normalize_agent_env_vars(env_vars: &[AgentEnvVarPayload]) -> Result<Vec<AgentEnvVar>, (StatusCode, Json<ErrorResponse>)> {
+fn normalize_agent_env_vars(
+    env_vars: &[AgentEnvVarPayload],
+) -> Result<Vec<AgentEnvVar>, (StatusCode, Json<ErrorResponse>)> {
     if env_vars.len() > 100 {
         return Err(api_err("too many environment variables"));
     }
@@ -572,7 +574,9 @@ fn normalize_agent_env_vars(env_vars: &[AgentEnvVarPayload]) -> Result<Vec<Agent
             return Err(api_err("environment variable key/value is too large"));
         }
         if !seen.insert(key.clone()) {
-            return Err(api_err(format!("duplicate environment variable key: {key}")));
+            return Err(api_err(format!(
+                "duplicate environment variable key: {key}"
+            )));
         }
         normalized.push(AgentEnvVar {
             key,
@@ -650,15 +654,15 @@ pub async fn handle_create_agent(
     let env_vars = normalize_agent_env_vars(&req.env_vars)?;
     state
         .store
-        .create_agent_record_with_reasoning(
-            &name,
-            &display_name,
+        .create_agent_record_with_reasoning(&AgentRecordUpsert {
+            name: &name,
+            display_name: &display_name,
             description,
-            &req.runtime,
-            &req.model,
-            reasoning_effort.as_deref(),
-            &env_vars,
-        )
+            runtime: &req.runtime,
+            model: &req.model,
+            reasoning_effort: reasoning_effort.as_deref(),
+            env_vars: &env_vars,
+        })
         .map_err(|e| api_err(e.to_string()))?;
     for channel in state
         .store
@@ -731,15 +735,15 @@ pub async fn handle_update_agent(
 
     state
         .store
-        .update_agent_record_with_reasoning(
-            &name,
-            &display_name,
+        .update_agent_record_with_reasoning(&AgentRecordUpsert {
+            name: &name,
+            display_name: &display_name,
             description,
-            &req.runtime,
-            &req.model,
-            reasoning_effort.as_deref(),
-            &env_vars,
-        )
+            runtime: &req.runtime,
+            model: &req.model,
+            reasoning_effort: reasoning_effort.as_deref(),
+            env_vars: &env_vars,
+        })
         .map_err(|e| api_err(e.to_string()))?;
 
     if existing.status == AgentStatus::Active && requires_restart {
@@ -847,9 +851,9 @@ pub async fn handle_delete_agent(
     if matches!(req.mode, DeleteMode::DeleteWorkspace) {
         let agents_dir = state.store.agents_dir();
         let workspace = AgentWorkspace::new(&agents_dir);
-        workspace
-            .delete_if_exists(&name)
-            .map_err(|e| internal_err(format!("agent deleted but failed to delete workspace: {e}")))?;
+        workspace.delete_if_exists(&name).map_err(|e| {
+            internal_err(format!("agent deleted but failed to delete workspace: {e}"))
+        })?;
     }
 
     Ok(Json(serde_json::json!({ "ok": true })))

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 use axum::extract::{Multipart, Path, Query, State};
 use axum::http::{header, StatusCode};
@@ -9,6 +10,7 @@ use tracing::{debug, info};
 use uuid::Uuid;
 
 use super::AgentLifecycle;
+use crate::agent_workspace::AgentWorkspace;
 use crate::models::*;
 use crate::store::Store;
 
@@ -19,6 +21,7 @@ pub type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
 pub struct AppState {
     pub store: Arc<Store>,
     pub lifecycle: Arc<dyn AgentLifecycle>,
+    pub transitioning_agents: Arc<Mutex<HashSet<String>>>,
 }
 
 fn api_err(msg: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
@@ -33,6 +36,45 @@ fn internal_err(msg: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(ErrorResponse { error: msg.into() }),
     )
+}
+
+fn conflict_err(msg: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::CONFLICT,
+        Json(ErrorResponse { error: msg.into() }),
+    )
+}
+
+struct TransitionGuard {
+    agent_name: String,
+    transitioning_agents: Arc<Mutex<HashSet<String>>>,
+}
+
+impl Drop for TransitionGuard {
+    fn drop(&mut self) {
+        if let Ok(mut transitioning) = self.transitioning_agents.lock() {
+            transitioning.remove(&self.agent_name);
+        }
+    }
+}
+
+fn acquire_transition(
+    state: &AppState,
+    agent_name: &str,
+) -> Result<TransitionGuard, (StatusCode, Json<ErrorResponse>)> {
+    let mut transitioning = state
+        .transitioning_agents
+        .lock()
+        .map_err(|_| internal_err("failed to lock transition state"))?;
+    if !transitioning.insert(agent_name.to_string()) {
+        return Err(conflict_err(
+            "agent lifecycle operation already in progress; retry when the current action completes",
+        ));
+    }
+    Ok(TransitionGuard {
+        agent_name: agent_name.to_string(),
+        transitioning_agents: state.transitioning_agents.clone(),
+    })
 }
 
 fn strip_channel_prefix(s: &str) -> &str {
@@ -514,24 +556,49 @@ pub async fn handle_create_channel(
 
 // ── Agent management ──
 
-#[derive(Deserialize)]
-pub struct CreateAgentRequest {
-    name: String,
-    #[serde(default)]
-    display_name: String,
-    #[serde(default)]
-    description: String,
-    #[serde(default = "default_runtime")]
-    runtime: String,
-    #[serde(default = "default_model")]
-    model: String,
+fn normalize_agent_env_vars(env_vars: &[AgentEnvVarPayload]) -> Result<Vec<AgentEnvVar>, (StatusCode, Json<ErrorResponse>)> {
+    if env_vars.len() > 100 {
+        return Err(api_err("too many environment variables"));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut normalized = Vec::with_capacity(env_vars.len());
+    for (index, env_var) in env_vars.iter().enumerate() {
+        let key = env_var.key.trim().to_string();
+        if key.is_empty() {
+            return Err(api_err("environment variable key is required"));
+        }
+        if key.len() > 8_192 || env_var.value.len() > 8_192 {
+            return Err(api_err("environment variable key/value is too large"));
+        }
+        if !seen.insert(key.clone()) {
+            return Err(api_err(format!("duplicate environment variable key: {key}")));
+        }
+        normalized.push(AgentEnvVar {
+            key,
+            value: env_var.value.clone(),
+            position: index as i64,
+        });
+    }
+    Ok(normalized)
 }
 
-fn default_runtime() -> String {
-    "claude".to_string()
-}
-fn default_model() -> String {
-    "sonnet".to_string()
+fn agent_info_from_agent(agent: &Agent) -> AgentInfo {
+    AgentInfo {
+        name: agent.name.clone(),
+        status: match agent.status {
+            AgentStatus::Active => "active".to_string(),
+            AgentStatus::Sleeping => "sleeping".to_string(),
+            AgentStatus::Inactive => "inactive".to_string(),
+        },
+        display_name: Some(agent.display_name.clone()),
+        description: agent.description.clone(),
+        runtime: Some(agent.runtime.clone()),
+        model: Some(agent.model.clone()),
+        session_id: agent.session_id.clone(),
+        activity: None,
+        activity_detail: None,
+    }
 }
 
 pub async fn handle_create_agent(
@@ -552,9 +619,17 @@ pub async fn handle_create_agent(
     } else {
         Some(req.description.as_str())
     };
+    let env_vars = normalize_agent_env_vars(&req.env_vars)?;
     state
         .store
-        .create_agent_record(&name, &display_name, description, &req.runtime, &req.model)
+        .create_agent_record(
+            &name,
+            &display_name,
+            description,
+            &req.runtime,
+            &req.model,
+            &env_vars,
+        )
         .map_err(|e| api_err(e.to_string()))?;
     for channel in state
         .store
@@ -572,10 +647,186 @@ pub async fn handle_create_agent(
     Ok(Json(serde_json::json!({ "name": name })))
 }
 
+pub async fn handle_get_agent(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> ApiResult<AgentDetailResponse> {
+    let agent = state
+        .store
+        .get_agent(&name)
+        .map_err(|e| api_err(e.to_string()))?
+        .ok_or_else(|| api_err("agent not found"))?;
+    Ok(Json(AgentDetailResponse {
+        agent: agent_info_from_agent(&agent),
+        env_vars: agent
+            .env_vars
+            .iter()
+            .map(|env_var| AgentEnvVarPayload {
+                key: env_var.key.clone(),
+                value: env_var.value.clone(),
+            })
+            .collect(),
+    }))
+}
+
+pub async fn handle_update_agent(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<UpdateAgentRequest>,
+) -> ApiResult<serde_json::Value> {
+    let _transition = acquire_transition(&state, &name)?;
+    let existing = state
+        .store
+        .get_agent(&name)
+        .map_err(|e| api_err(e.to_string()))?
+        .ok_or_else(|| api_err("agent not found"))?;
+
+    let env_vars = normalize_agent_env_vars(&req.env_vars)?;
+    let display_name = if req.display_name.trim().is_empty() {
+        existing.name.clone()
+    } else {
+        req.display_name.trim().to_string()
+    };
+    let description = if req.description.trim().is_empty() {
+        None
+    } else {
+        Some(req.description.trim())
+    };
+
+    let requires_restart = existing.runtime != req.runtime
+        || existing.model != req.model
+        || existing.env_vars != env_vars;
+
+    state
+        .store
+        .update_agent_record(
+            &name,
+            &display_name,
+            description,
+            &req.runtime,
+            &req.model,
+            &env_vars,
+        )
+        .map_err(|e| api_err(e.to_string()))?;
+
+    if existing.status == AgentStatus::Active && requires_restart {
+        state
+            .lifecycle
+            .stop_agent(&name)
+            .await
+            .map_err(|e| internal_err(e.to_string()))?;
+        if let Err(err) = state.lifecycle.start_agent(&name, None).await {
+            let _ = state
+                .store
+                .update_agent_status(&name, AgentStatus::Inactive);
+            return Err(internal_err(format!(
+                "agent updated but restart failed: {err}"
+            )));
+        }
+    }
+
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "restarted": existing.status == AgentStatus::Active && requires_restart
+    })))
+}
+
+pub async fn handle_restart_agent(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<RestartAgentRequest>,
+) -> ApiResult<serde_json::Value> {
+    let _transition = acquire_transition(&state, &name)?;
+    let agent = state
+        .store
+        .get_agent(&name)
+        .map_err(|e| api_err(e.to_string()))?
+        .ok_or_else(|| api_err("agent not found"))?;
+    let agents_dir = state.store.agents_dir();
+    let workspace = AgentWorkspace::new(&agents_dir);
+
+    state
+        .lifecycle
+        .stop_agent(&name)
+        .await
+        .map_err(|e| internal_err(e.to_string()))?;
+
+    match req.mode {
+        RestartMode::Restart => {}
+        RestartMode::ResetSession => {
+            state
+                .store
+                .update_agent_session(&name, None)
+                .map_err(|e| internal_err(e.to_string()))?;
+        }
+        RestartMode::FullReset => {
+            state
+                .store
+                .update_agent_session(&name, None)
+                .map_err(|e| internal_err(e.to_string()))?;
+            workspace
+                .delete_if_exists(&name)
+                .map_err(|e| internal_err(format!("failed to delete workspace: {e}")))?;
+        }
+    }
+
+    if let Err(err) = state.lifecycle.start_agent(&name, None).await {
+        let _ = state
+            .store
+            .update_agent_status(&name, AgentStatus::Inactive);
+        return Err(internal_err(format!("restart failed: {err}")));
+    }
+
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "mode": req.mode,
+        "agent": agent.name
+    })))
+}
+
+pub async fn handle_delete_agent(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<DeleteAgentRequest>,
+) -> ApiResult<serde_json::Value> {
+    let _transition = acquire_transition(&state, &name)?;
+    state
+        .store
+        .get_agent(&name)
+        .map_err(|e| api_err(e.to_string()))?
+        .ok_or_else(|| api_err("agent not found"))?;
+
+    state
+        .lifecycle
+        .stop_agent(&name)
+        .await
+        .map_err(|e| internal_err(e.to_string()))?;
+
+    state
+        .store
+        .mark_agent_messages_deleted(&name)
+        .map_err(|e| internal_err(e.to_string()))?;
+    state
+        .store
+        .delete_agent_record(&name)
+        .map_err(|e| internal_err(e.to_string()))?;
+
+    if matches!(req.mode, DeleteMode::DeleteWorkspace) {
+        let agents_dir = state.store.agents_dir();
+        let workspace = AgentWorkspace::new(&agents_dir);
+        workspace
+            .delete_if_exists(&name)
+            .map_err(|e| internal_err(format!("agent deleted but failed to delete workspace: {e}")))?;
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
 pub async fn handle_agent_start(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> ApiResult<serde_json::Value> {
+    let _transition = acquire_transition(&state, &name)?;
     info!(agent = %name, "starting agent");
     state
         .lifecycle
@@ -590,6 +841,7 @@ pub async fn handle_agent_stop(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> ApiResult<serde_json::Value> {
+    let _transition = acquire_transition(&state, &name)?;
     info!(agent = %name, "stopping agent");
     state
         .lifecycle

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -583,6 +583,31 @@ fn normalize_agent_env_vars(env_vars: &[AgentEnvVarPayload]) -> Result<Vec<Agent
     Ok(normalized)
 }
 
+fn normalize_reasoning_effort(
+    runtime: &str,
+    reasoning_effort: Option<&str>,
+) -> Result<Option<String>, (StatusCode, Json<ErrorResponse>)> {
+    if runtime != "codex" {
+        return Ok(None);
+    }
+
+    let Some(reasoning_effort) = reasoning_effort.map(str::trim) else {
+        return Ok(None);
+    };
+    if reasoning_effort.is_empty() || reasoning_effort == "default" {
+        return Ok(None);
+    }
+
+    match reasoning_effort {
+        "none" | "minimal" | "low" | "medium" | "high" | "xhigh" => {
+            Ok(Some(reasoning_effort.to_string()))
+        }
+        _ => Err(api_err(format!(
+            "unsupported Codex reasoning effort: {reasoning_effort}"
+        ))),
+    }
+}
+
 fn agent_info_from_agent(agent: &Agent) -> AgentInfo {
     AgentInfo {
         name: agent.name.clone(),
@@ -595,6 +620,7 @@ fn agent_info_from_agent(agent: &Agent) -> AgentInfo {
         description: agent.description.clone(),
         runtime: Some(agent.runtime.clone()),
         model: Some(agent.model.clone()),
+        reasoning_effort: agent.reasoning_effort.clone(),
         session_id: agent.session_id.clone(),
         activity: None,
         activity_detail: None,
@@ -619,15 +645,18 @@ pub async fn handle_create_agent(
     } else {
         Some(req.description.as_str())
     };
+    let reasoning_effort =
+        normalize_reasoning_effort(&req.runtime, req.reasoning_effort.as_deref())?;
     let env_vars = normalize_agent_env_vars(&req.env_vars)?;
     state
         .store
-        .create_agent_record(
+        .create_agent_record_with_reasoning(
             &name,
             &display_name,
             description,
             &req.runtime,
             &req.model,
+            reasoning_effort.as_deref(),
             &env_vars,
         )
         .map_err(|e| api_err(e.to_string()))?;
@@ -692,19 +721,23 @@ pub async fn handle_update_agent(
     } else {
         Some(req.description.trim())
     };
+    let reasoning_effort =
+        normalize_reasoning_effort(&req.runtime, req.reasoning_effort.as_deref())?;
 
     let requires_restart = existing.runtime != req.runtime
         || existing.model != req.model
+        || existing.reasoning_effort != reasoning_effort
         || existing.env_vars != env_vars;
 
     state
         .store
-        .update_agent_record(
+        .update_agent_record_with_reasoning(
             &name,
             &display_name,
             description,
             &req.runtime,
             &req.model,
+            reasoning_effort.as_deref(),
             &env_vars,
         )
         .map_err(|e| api_err(e.to_string()))?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,6 +3,7 @@ mod handlers;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::{collections::HashSet, sync::Mutex};
 
 use axum::routing::{get, post};
 use axum::Router;
@@ -103,7 +104,11 @@ pub fn build_router_with_lifecycle(
         .allow_methods(Any)
         .allow_headers(Any);
 
-    let state = AppState { store, lifecycle };
+    let state = AppState {
+        store,
+        lifecycle,
+        transitioning_agents: Arc::new(Mutex::new(HashSet::new())),
+    };
 
     Router::new()
         // Agent bridge endpoints (called by MCP bridge subprocess)
@@ -142,8 +147,11 @@ pub fn build_router_with_lifecycle(
         .route("/api/whoami", get(handle_whoami))
         .route("/api/channels", post(handle_create_channel))
         .route("/api/agents", post(handle_create_agent))
+        .route("/api/agents/{name}", get(handle_get_agent).patch(handle_update_agent))
         .route("/api/agents/{name}/start", post(handle_agent_start))
         .route("/api/agents/{name}/stop", post(handle_agent_stop))
+        .route("/api/agents/{name}/restart", post(handle_restart_agent))
+        .route("/api/agents/{name}/delete", post(handle_delete_agent))
         .route("/api/agents/{name}/activity", get(handle_agent_activity))
         .route(
             "/api/agents/{name}/activity-log",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -147,7 +147,10 @@ pub fn build_router_with_lifecycle(
         .route("/api/whoami", get(handle_whoami))
         .route("/api/channels", post(handle_create_channel))
         .route("/api/agents", post(handle_create_agent))
-        .route("/api/agents/{name}", get(handle_get_agent).patch(handle_update_agent))
+        .route(
+            "/api/agents/{name}",
+            get(handle_get_agent).patch(handle_update_agent),
+        )
         .route("/api/agents/{name}/start", post(handle_agent_start))
         .route("/api/agents/{name}/stop", post(handle_agent_stop))
         .route("/api/agents/{name}/restart", post(handle_restart_agent))

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -15,11 +15,32 @@ impl Store {
         model: &str,
         env_vars: &[AgentEnvVar],
     ) -> Result<String> {
+        self.create_agent_record_with_reasoning(
+            name,
+            display_name,
+            description,
+            runtime,
+            model,
+            None,
+            env_vars,
+        )
+    }
+
+    pub fn create_agent_record_with_reasoning(
+        &self,
+        name: &str,
+        display_name: &str,
+        description: Option<&str>,
+        runtime: &str,
+        model: &str,
+        reasoning_effort: Option<&str>,
+        env_vars: &[AgentEnvVar],
+    ) -> Result<String> {
         let conn = self.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO agents (id, name, display_name, description, runtime, model) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![id, name, display_name, description, runtime, model],
+            "INSERT INTO agents (id, name, display_name, description, runtime, model, reasoning_effort) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![id, name, display_name, description, runtime, model, reasoning_effort],
         )?;
         Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
         Ok(id)
@@ -39,7 +60,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let rows = conn
             .prepare(
-                "SELECT id, name, display_name, description, runtime, model, status, session_id, created_at FROM agents ORDER BY name",
+                "SELECT id, name, display_name, description, runtime, model, reasoning_effort, status, session_id, created_at FROM agents ORDER BY name",
             )?
             .query_map([], |row| {
                 Ok(Agent {
@@ -49,10 +70,11 @@ impl Store {
                     description: row.get(3)?,
                     runtime: row.get(4)?,
                     model: row.get(5)?,
+                    reasoning_effort: row.get(6)?,
                     env_vars: Vec::new(),
-                    status: parse_agent_status(&row.get::<_, String>(6)?),
-                    session_id: row.get(7)?,
-                    created_at: parse_datetime(&row.get::<_, String>(8)?),
+                    status: parse_agent_status(&row.get::<_, String>(7)?),
+                    session_id: row.get(8)?,
+                    created_at: parse_datetime(&row.get::<_, String>(9)?),
                 })
             })?
             .filter_map(|r| r.ok())
@@ -67,7 +89,7 @@ impl Store {
     pub fn get_agent(&self, name: &str) -> Result<Option<Agent>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, display_name, description, runtime, model, status, session_id, created_at FROM agents WHERE name = ?1",
+            "SELECT id, name, display_name, description, runtime, model, reasoning_effort, status, session_id, created_at FROM agents WHERE name = ?1",
         )?;
         let mut rows = stmt.query_map(params![name], |row| {
             Ok(Agent {
@@ -77,10 +99,11 @@ impl Store {
                 description: row.get(3)?,
                 runtime: row.get(4)?,
                 model: row.get(5)?,
+                reasoning_effort: row.get(6)?,
                 env_vars: Vec::new(),
-                status: parse_agent_status(&row.get::<_, String>(6)?),
-                session_id: row.get(7)?,
-                created_at: parse_datetime(&row.get::<_, String>(8)?),
+                status: parse_agent_status(&row.get::<_, String>(7)?),
+                session_id: row.get(8)?,
+                created_at: parse_datetime(&row.get::<_, String>(9)?),
             })
         })?;
         let mut agent = rows.next().transpose()?;
@@ -99,10 +122,31 @@ impl Store {
         model: &str,
         env_vars: &[AgentEnvVar],
     ) -> Result<()> {
+        self.update_agent_record_with_reasoning(
+            name,
+            display_name,
+            description,
+            runtime,
+            model,
+            None,
+            env_vars,
+        )
+    }
+
+    pub fn update_agent_record_with_reasoning(
+        &self,
+        name: &str,
+        display_name: &str,
+        description: Option<&str>,
+        runtime: &str,
+        model: &str,
+        reasoning_effort: Option<&str>,
+        env_vars: &[AgentEnvVar],
+    ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "UPDATE agents SET display_name = ?1, description = ?2, runtime = ?3, model = ?4 WHERE name = ?5",
-            params![display_name, description, runtime, model, name],
+            "UPDATE agents SET display_name = ?1, description = ?2, runtime = ?3, model = ?4, reasoning_effort = ?5 WHERE name = ?6",
+            params![display_name, description, runtime, model, reasoning_effort, name],
         )?;
         Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
         Ok(())

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -13,6 +13,7 @@ impl Store {
         description: Option<&str>,
         runtime: &str,
         model: &str,
+        env_vars: &[AgentEnvVar],
     ) -> Result<String> {
         let conn = self.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
@@ -20,6 +21,7 @@ impl Store {
             "INSERT INTO agents (id, name, display_name, description, runtime, model) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![id, name, display_name, description, runtime, model],
         )?;
+        Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
         Ok(id)
     }
 
@@ -47,12 +49,17 @@ impl Store {
                     description: row.get(3)?,
                     runtime: row.get(4)?,
                     model: row.get(5)?,
+                    env_vars: Vec::new(),
                     status: parse_agent_status(&row.get::<_, String>(6)?),
                     session_id: row.get(7)?,
                     created_at: parse_datetime(&row.get::<_, String>(8)?),
                 })
             })?
             .filter_map(|r| r.ok())
+            .map(|mut agent: Agent| {
+                agent.env_vars = Self::list_agent_env_vars_inner(&conn, &agent.name).unwrap_or_default();
+                agent
+            })
             .collect();
         Ok(rows)
     }
@@ -70,12 +77,35 @@ impl Store {
                 description: row.get(3)?,
                 runtime: row.get(4)?,
                 model: row.get(5)?,
+                env_vars: Vec::new(),
                 status: parse_agent_status(&row.get::<_, String>(6)?),
                 session_id: row.get(7)?,
                 created_at: parse_datetime(&row.get::<_, String>(8)?),
             })
         })?;
-        Ok(rows.next().transpose()?)
+        let mut agent = rows.next().transpose()?;
+        if let Some(ref mut agent) = agent {
+            agent.env_vars = Self::list_agent_env_vars_inner(&conn, &agent.name)?;
+        }
+        Ok(agent)
+    }
+
+    pub fn update_agent_record(
+        &self,
+        name: &str,
+        display_name: &str,
+        description: Option<&str>,
+        runtime: &str,
+        model: &str,
+        env_vars: &[AgentEnvVar],
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE agents SET display_name = ?1, description = ?2, runtime = ?3, model = ?4 WHERE name = ?5",
+            params![display_name, description, runtime, model, name],
+        )?;
+        Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
+        Ok(())
     }
 
     pub fn update_agent_status(&self, name: &str, status: AgentStatus) -> Result<()> {
@@ -89,6 +119,46 @@ impl Store {
             "UPDATE agents SET status = ?1 WHERE name = ?2",
             params![s, name],
         )?;
+        Ok(())
+    }
+
+    pub fn list_agent_env_vars(&self, name: &str) -> Result<Vec<AgentEnvVar>> {
+        let conn = self.conn.lock().unwrap();
+        Self::list_agent_env_vars_inner(&conn, name)
+    }
+
+    fn list_agent_env_vars_inner(
+        conn: &rusqlite::Connection,
+        name: &str,
+    ) -> Result<Vec<AgentEnvVar>> {
+        let rows = conn
+            .prepare(
+                "SELECT key, value, position FROM agent_env_vars WHERE agent_name = ?1 ORDER BY position ASC, key ASC",
+            )?
+            .query_map(params![name], |row| {
+                Ok(AgentEnvVar {
+                    key: row.get(0)?,
+                    value: row.get(1)?,
+                    position: row.get(2)?,
+                })
+            })?
+            .filter_map(|row| row.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    fn replace_agent_env_vars_inner(
+        conn: &rusqlite::Connection,
+        name: &str,
+        env_vars: &[AgentEnvVar],
+    ) -> Result<()> {
+        conn.execute("DELETE FROM agent_env_vars WHERE agent_name = ?1", params![name])?;
+        for env_var in env_vars {
+            conn.execute(
+                "INSERT INTO agent_env_vars (agent_name, key, value, position) VALUES (?1, ?2, ?3, ?4)",
+                params![name, env_var.key, env_var.value, env_var.position],
+            )?;
+        }
         Ok(())
     }
 

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -5,6 +5,17 @@ use uuid::Uuid;
 use super::{parse_agent_status, parse_datetime, Store};
 use crate::models::*;
 
+/// Shared persisted agent configuration used by store create/update helpers.
+pub struct AgentRecordUpsert<'a> {
+    pub name: &'a str,
+    pub display_name: &'a str,
+    pub description: Option<&'a str>,
+    pub runtime: &'a str,
+    pub model: &'a str,
+    pub reasoning_effort: Option<&'a str>,
+    pub env_vars: &'a [AgentEnvVar],
+}
+
 impl Store {
     pub fn create_agent_record(
         &self,
@@ -15,34 +26,36 @@ impl Store {
         model: &str,
         env_vars: &[AgentEnvVar],
     ) -> Result<String> {
-        self.create_agent_record_with_reasoning(
+        self.create_agent_record_with_reasoning(&AgentRecordUpsert {
             name,
             display_name,
             description,
             runtime,
             model,
-            None,
+            reasoning_effort: None,
             env_vars,
-        )
+        })
     }
 
     pub fn create_agent_record_with_reasoning(
         &self,
-        name: &str,
-        display_name: &str,
-        description: Option<&str>,
-        runtime: &str,
-        model: &str,
-        reasoning_effort: Option<&str>,
-        env_vars: &[AgentEnvVar],
+        record: &AgentRecordUpsert<'_>,
     ) -> Result<String> {
         let conn = self.conn.lock().unwrap();
         let id = Uuid::new_v4().to_string();
         conn.execute(
             "INSERT INTO agents (id, name, display_name, description, runtime, model, reasoning_effort) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![id, name, display_name, description, runtime, model, reasoning_effort],
+            params![
+                id,
+                record.name,
+                record.display_name,
+                record.description,
+                record.runtime,
+                record.model,
+                record.reasoning_effort
+            ],
         )?;
-        Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
+        Self::replace_agent_env_vars_inner(&conn, record.name, record.env_vars)?;
         Ok(id)
     }
 
@@ -122,33 +135,31 @@ impl Store {
         model: &str,
         env_vars: &[AgentEnvVar],
     ) -> Result<()> {
-        self.update_agent_record_with_reasoning(
+        self.update_agent_record_with_reasoning(&AgentRecordUpsert {
             name,
             display_name,
             description,
             runtime,
             model,
-            None,
+            reasoning_effort: None,
             env_vars,
-        )
+        })
     }
 
-    pub fn update_agent_record_with_reasoning(
-        &self,
-        name: &str,
-        display_name: &str,
-        description: Option<&str>,
-        runtime: &str,
-        model: &str,
-        reasoning_effort: Option<&str>,
-        env_vars: &[AgentEnvVar],
-    ) -> Result<()> {
+    pub fn update_agent_record_with_reasoning(&self, record: &AgentRecordUpsert<'_>) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "UPDATE agents SET display_name = ?1, description = ?2, runtime = ?3, model = ?4, reasoning_effort = ?5 WHERE name = ?6",
-            params![display_name, description, runtime, model, reasoning_effort, name],
+            params![
+                record.display_name,
+                record.description,
+                record.runtime,
+                record.model,
+                record.reasoning_effort,
+                record.name
+            ],
         )?;
-        Self::replace_agent_env_vars_inner(&conn, name, env_vars)?;
+        Self::replace_agent_env_vars_inner(&conn, record.name, record.env_vars)?;
         Ok(())
     }
 
@@ -196,7 +207,10 @@ impl Store {
         name: &str,
         env_vars: &[AgentEnvVar],
     ) -> Result<()> {
-        conn.execute("DELETE FROM agent_env_vars WHERE agent_name = ?1", params![name])?;
+        conn.execute(
+            "DELETE FROM agent_env_vars WHERE agent_name = ?1",
+            params![name],
+        )?;
         for env_var in env_vars {
             conn.execute(
                 "INSERT INTO agent_env_vars (agent_name, key, value, position) VALUES (?1, ?2, ?3, ?4)",

--- a/src/store/messages.rs
+++ b/src/store/messages.rs
@@ -31,7 +31,7 @@ impl Store {
         let st = sender_type_str(sender_type);
 
         conn.execute(
-            "INSERT INTO messages (id, channel_id, thread_parent_id, sender_name, sender_type, content, seq) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO messages (id, channel_id, thread_parent_id, sender_name, sender_type, sender_deleted, content, seq) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7)",
             params![msg_id, channel.id, thread_parent_id, sender_name, st, content, seq],
         )?;
 
@@ -255,7 +255,7 @@ impl Store {
         }
 
         let sql = format!(
-            "SELECT id, seq, content, sender_name, sender_type, created_at \
+            "SELECT id, seq, content, sender_name, sender_type, sender_deleted, created_at \
              FROM messages WHERE channel_id = ?1 {thread_clause} {cursor_clause} \
              ORDER BY seq {order} LIMIT {fetch_limit}"
         );
@@ -271,7 +271,8 @@ impl Store {
                 content: row.get(2)?,
                 sender_name: row.get(3)?,
                 sender_type: row.get(4)?,
-                created_at: row.get(5)?,
+                sender_deleted: row.get::<_, i64>(5)? > 0,
+                created_at: row.get(6)?,
                 attachments: None,
                 reply_count: None,
             })
@@ -315,6 +316,15 @@ impl Store {
         }
 
         Ok((msgs, has_more))
+    }
+
+    pub fn mark_agent_messages_deleted(&self, name: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE messages SET sender_deleted = 1 WHERE sender_type = 'agent' AND sender_name = ?1",
+            params![name],
+        )?;
+        Ok(())
     }
 
     pub fn get_last_read_seq(&self, channel_name: &str, member_name: &str) -> Result<i64> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -72,6 +72,7 @@ impl Store {
                 thread_parent_id TEXT,
                 sender_name TEXT NOT NULL,
                 sender_type TEXT NOT NULL,
+                sender_deleted INTEGER NOT NULL DEFAULT 0,
                 content TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 seq INTEGER NOT NULL,
@@ -92,6 +93,14 @@ impl Store {
                 status TEXT NOT NULL DEFAULT 'inactive',
                 session_id TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS agent_env_vars (
+                agent_name TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                PRIMARY KEY (agent_name, key),
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
             );
             CREATE TABLE IF NOT EXISTS humans (
                 name TEXT PRIMARY KEY,
@@ -145,6 +154,11 @@ impl Store {
             END;
             ",
         )?;
+        conn.execute(
+            "ALTER TABLE messages ADD COLUMN sender_deleted INTEGER NOT NULL DEFAULT 0",
+            [],
+        )
+        .ok();
         Ok(())
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -90,6 +90,7 @@ impl Store {
                 description TEXT,
                 runtime TEXT NOT NULL,
                 model TEXT NOT NULL,
+                reasoning_effort TEXT,
                 status TEXT NOT NULL DEFAULT 'inactive',
                 session_id TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -159,6 +160,8 @@ impl Store {
             [],
         )
         .ok();
+        conn.execute("ALTER TABLE agents ADD COLUMN reasoning_effort TEXT", [])
+            .ok();
         Ok(())
     }
 
@@ -279,7 +282,7 @@ impl Store {
             .collect();
 
         let mut ag_stmt = conn.prepare(
-            "SELECT name, display_name, description, runtime, model, status, session_id FROM agents ORDER BY name",
+            "SELECT name, display_name, description, runtime, model, reasoning_effort, status, session_id FROM agents ORDER BY name",
         )?;
         let agents: Vec<AgentInfo> = ag_stmt
             .query_map([], |row| {
@@ -289,8 +292,9 @@ impl Store {
                     description: row.get(2)?,
                     runtime: row.get(3)?,
                     model: row.get(4)?,
-                    status: row.get(5)?,
-                    session_id: row.get(6)?,
+                    reasoning_effort: row.get(5)?,
+                    status: row.get(6)?,
+                    session_id: row.get(7)?,
                     activity: None,
                     activity_detail: None,
                 })

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -4,6 +4,8 @@ mod knowledge;
 mod messages;
 mod tasks;
 
+pub use agents::AgentRecordUpsert;
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -13,7 +13,7 @@ fn test_claude_prompt_uses_split_message_tools() {
         runtime: "claude".to_string(),
         model: "sonnet".to_string(),
         session_id: None,
-        env_vars: None,
+        env_vars: Vec::new(),
     };
 
     let prompt = driver.build_system_prompt(&config, "agent-id");
@@ -42,7 +42,7 @@ fn test_codex_prompt_uses_split_message_tools() {
         runtime: "codex".to_string(),
         model: "gpt-5.4-mini".to_string(),
         session_id: None,
-        env_vars: None,
+        env_vars: Vec::new(),
     };
 
     let prompt = driver.build_system_prompt(&config, "agent-id");

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -13,6 +13,7 @@ fn test_claude_prompt_uses_split_message_tools() {
         runtime: "claude".to_string(),
         model: "sonnet".to_string(),
         session_id: None,
+        reasoning_effort: None,
         env_vars: Vec::new(),
     };
 
@@ -42,6 +43,7 @@ fn test_codex_prompt_uses_split_message_tools() {
         runtime: "codex".to_string(),
         model: "gpt-5.4-mini".to_string(),
         session_id: None,
+        reasoning_effort: None,
         env_vars: Vec::new(),
     };
 

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -29,7 +29,7 @@ async fn test_human_to_agent_message_flow() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -68,7 +68,7 @@ async fn test_agent_reply_in_history() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -109,7 +109,7 @@ async fn test_blocking_receive_wakes_on_message() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -161,7 +161,7 @@ async fn test_task_board_e2e() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -234,7 +234,7 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -309,7 +309,7 @@ async fn test_dm_and_thread_flow() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
 
     // Agent sends DM to testuser
@@ -369,10 +369,10 @@ async fn test_multi_agent_channel_communication() {
     let client = reqwest::Client::new();
 
     store
-        .create_agent_record("claude_bot", "Claude", None, "claude", "sonnet")
+        .create_agent_record("claude_bot", "Claude", None, "claude", "sonnet", &[])
         .unwrap();
     store
-        .create_agent_record("codex_bot", "Codex", None, "codex", "o3")
+        .create_agent_record("codex_bot", "Codex", None, "codex", "o3", &[])
         .unwrap();
     store
         .join_channel("general", "claude_bot", SenderType::Agent)

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -582,7 +582,8 @@ async fn test_delete_agent_marks_history_and_preserves_workspace() {
                 .uri("/api/agents/bot1/delete")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    serde_json::to_vec(&serde_json::json!({ "mode": "preserve_workspace" })).unwrap(),
+                    serde_json::to_vec(&serde_json::json!({ "mode": "preserve_workspace" }))
+                        .unwrap(),
                 ))
                 .unwrap(),
         )

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -528,7 +528,7 @@ async fn test_get_and_update_agent_via_api() {
 
 #[tokio::test]
 async fn test_restart_agent_reset_session_preserves_workspace() {
-    let (store, app, dir) = setup_with_data_dir();
+    let (store, _app, dir) = setup_with_data_dir();
     store
         .update_agent_session("bot1", Some("thread-123"))
         .unwrap();
@@ -558,7 +558,7 @@ async fn test_restart_agent_reset_session_preserves_workspace() {
 
 #[tokio::test]
 async fn test_delete_agent_marks_history_and_preserves_workspace() {
-    let (store, app, dir) = setup_with_data_dir();
+    let (store, _app, dir) = setup_with_data_dir();
     let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
     std::fs::create_dir_all(&workspace_dir).unwrap();
     std::fs::write(workspace_dir.join("plan.md"), "hello").unwrap();

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -494,12 +494,18 @@ async fn test_get_and_update_agent_via_api() {
         .await
         .unwrap();
     assert_eq!(detail_resp.status(), StatusCode::OK);
+    let detail_body = axum::body::to_bytes(detail_resp.into_body(), 1_000_000)
+        .await
+        .unwrap();
+    let detail: AgentDetailResponse = serde_json::from_slice(&detail_body).unwrap();
+    assert_eq!(detail.agent.reasoning_effort, None);
 
     let update_req = serde_json::json!({
         "display_name": "Updated Bot",
         "description": "Updated role",
         "runtime": "codex",
         "model": "gpt-5.4",
+        "reasoningEffort": "low",
         "envVars": [{"key": "DEBUG", "value": "1"}]
     });
     let update_resp = app
@@ -520,6 +526,7 @@ async fn test_get_and_update_agent_via_api() {
     assert_eq!(agent.display_name, "Updated Bot");
     assert_eq!(agent.runtime, "codex");
     assert_eq!(agent.model, "gpt-5.4");
+    assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
     assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -27,7 +27,7 @@ fn setup() -> (Arc<Store>, axum::Router) {
         .join_channel("general", "alice", SenderType::Human)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -48,7 +48,7 @@ fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
         .join_channel("general", "alice", SenderType::Human)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -60,6 +60,7 @@ fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
 #[derive(Default)]
 struct MockLifecycle {
     started: Mutex<Vec<(String, Option<ReceivedMessage>)>>,
+    stopped: Mutex<Vec<String>>,
     notified: Mutex<Vec<String>>,
     activity_logs: ActivityLogMap,
 }
@@ -80,6 +81,10 @@ impl MockLifecycle {
 
     fn started_calls(&self) -> Vec<(String, Option<ReceivedMessage>)> {
         self.started.lock().unwrap().clone()
+    }
+
+    fn stopped_names(&self) -> Vec<String> {
+        self.stopped.lock().unwrap().clone()
     }
 }
 
@@ -110,9 +115,12 @@ impl AgentLifecycle for MockLifecycle {
 
     fn stop_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        agent_name: &'a str,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
+        Box::pin(async move {
+            self.stopped.lock().unwrap().push(agent_name.to_string());
+            Ok(())
+        })
     }
 
     fn get_activity_log_data(
@@ -142,7 +150,7 @@ fn setup_with_lifecycle() -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
         .join_channel("general", "alice", SenderType::Human)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -469,10 +477,136 @@ async fn test_create_agent_via_api() {
 }
 
 #[tokio::test]
+async fn test_get_and_update_agent_via_api() {
+    let (store, app, lifecycle) = setup_with_lifecycle();
+    store
+        .update_agent_status("bot1", AgentStatus::Active)
+        .unwrap();
+
+    let detail_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/agents/bot1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(detail_resp.status(), StatusCode::OK);
+
+    let update_req = serde_json::json!({
+        "display_name": "Updated Bot",
+        "description": "Updated role",
+        "runtime": "codex",
+        "model": "gpt-5.4",
+        "envVars": [{"key": "DEBUG", "value": "1"}]
+    });
+    let update_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/agents/bot1")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&update_req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(update_resp.status(), StatusCode::OK);
+
+    let agent = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(agent.display_name, "Updated Bot");
+    assert_eq!(agent.runtime, "codex");
+    assert_eq!(agent.model, "gpt-5.4");
+    assert_eq!(agent.env_vars.len(), 1);
+    assert_eq!(agent.env_vars[0].key, "DEBUG");
+    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
+    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+}
+
+#[tokio::test]
+async fn test_restart_agent_reset_session_preserves_workspace() {
+    let (store, app, dir) = setup_with_data_dir();
+    store
+        .update_agent_session("bot1", Some("thread-123"))
+        .unwrap();
+    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    std::fs::create_dir_all(&workspace_dir).unwrap();
+    std::fs::write(workspace_dir.join("plan.md"), "hello").unwrap();
+
+    let app = build_router_with_lifecycle(store.clone(), Arc::new(MockLifecycle::default()));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/agents/bot1/restart")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({ "mode": "reset_session" })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let agent = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(agent.session_id, None);
+    assert!(workspace_dir.join("plan.md").exists());
+}
+
+#[tokio::test]
+async fn test_delete_agent_marks_history_and_preserves_workspace() {
+    let (store, app, dir) = setup_with_data_dir();
+    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    std::fs::create_dir_all(&workspace_dir).unwrap();
+    std::fs::write(workspace_dir.join("plan.md"), "hello").unwrap();
+    store
+        .send_message("general", None, "bot1", SenderType::Agent, "hello", &[])
+        .unwrap();
+
+    let app = build_router_with_lifecycle(store.clone(), Arc::new(MockLifecycle::default()));
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/agents/bot1/delete")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({ "mode": "preserve_workspace" })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(store.get_agent("bot1").unwrap().is_none());
+    assert!(workspace_dir.join("plan.md").exists());
+
+    let history_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/internal/agent/alice/history?channel=%23general&limit=10")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(history_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(history_response.into_body(), 1_000_000)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["messages"][0]["senderDeleted"], true);
+}
+
+#[tokio::test]
 async fn test_send_starts_inactive_agent_recipients() {
     let (store, app, lifecycle) = setup_with_lifecycle();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
         .unwrap();
     store
         .join_channel("general", "bot2", SenderType::Agent)
@@ -502,7 +636,7 @@ async fn test_send_starts_inactive_agent_recipients() {
 async fn test_thread_send_only_starts_parent_author_agent() {
     let (store, app, lifecycle) = setup_with_lifecycle();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
         .unwrap();
     store
         .join_channel("general", "bot2", SenderType::Agent)
@@ -549,13 +683,13 @@ async fn test_thread_send_only_starts_parent_author_agent() {
 async fn test_thread_send_starts_parent_author_and_existing_thread_repliers() {
     let (store, app, lifecycle) = setup_with_lifecycle();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
         .unwrap();
     store
         .join_channel("general", "bot2", SenderType::Agent)
         .unwrap();
     store
-        .create_agent_record("bot3", "Bot 3", None, "claude", "sonnet")
+        .create_agent_record("bot3", "Bot 3", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot3", SenderType::Agent)
@@ -612,7 +746,7 @@ async fn test_thread_send_starts_parent_author_and_existing_thread_repliers() {
 async fn test_agent_thread_reply_to_human_parent_does_not_start_unrelated_agents() {
     let (store, app, lifecycle) = setup_with_lifecycle();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
         .unwrap();
     store
         .join_channel("general", "bot2", SenderType::Agent)
@@ -1021,7 +1155,7 @@ fn setup_knowledge() -> (Arc<Store>, axum::Router) {
         .join_channel("general", "alice", SenderType::Human)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -1090,7 +1224,7 @@ async fn knowledge_remember_channel_missing() {
         .unwrap();
     store.add_human("alice").unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     let router = build_router(store.clone());
 

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1,5 +1,5 @@
 use chorus::models::*;
-use chorus::store::Store;
+use chorus::store::{AgentRecordUpsert, Store};
 use tempfile::tempdir;
 
 fn make_store() -> (Store, tempfile::TempDir) {
@@ -128,30 +128,30 @@ fn test_agent_env_vars_persist_in_agent_record() {
 fn test_agent_reasoning_effort_persists_in_agent_record() {
     let (store, _dir) = make_store();
     store
-        .create_agent_record_with_reasoning(
-            "bot1",
-            "Bot 1",
-            None,
-            "codex",
-            "gpt-5.4-mini",
-            Some("low"),
-            &[],
-        )
+        .create_agent_record_with_reasoning(&AgentRecordUpsert {
+            name: "bot1",
+            display_name: "Bot 1",
+            description: None,
+            runtime: "codex",
+            model: "gpt-5.4-mini",
+            reasoning_effort: Some("low"),
+            env_vars: &[],
+        })
         .unwrap();
 
     let agent = store.get_agent("bot1").unwrap().unwrap();
     assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
 
     store
-        .update_agent_record_with_reasoning(
-            "bot1",
-            "Bot 1",
-            None,
-            "codex",
-            "gpt-5.4-mini",
-            Some("high"),
-            &[],
-        )
+        .update_agent_record_with_reasoning(&AgentRecordUpsert {
+            name: "bot1",
+            display_name: "Bot 1",
+            description: None,
+            runtime: "codex",
+            model: "gpt-5.4-mini",
+            reasoning_effort: Some("high"),
+            env_vars: &[],
+        })
         .unwrap();
 
     let updated = store.get_agent("bot1").unwrap().unwrap();

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -43,7 +43,7 @@ fn test_send_and_receive_messages() {
     assert!(msgs.is_empty());
 
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
@@ -99,13 +99,58 @@ fn test_message_history_pagination() {
 }
 
 #[test]
+fn test_agent_env_vars_persist_in_agent_record() {
+    let (store, _dir) = make_store();
+    store
+        .create_channel("general", None, ChannelType::Channel)
+        .unwrap();
+    let env_vars = vec![
+        AgentEnvVar {
+            key: "OPENAI_API_KEY".to_string(),
+            value: "secret".to_string(),
+            position: 0,
+        },
+        AgentEnvVar {
+            key: "DEBUG".to_string(),
+            value: "1".to_string(),
+            position: 1,
+        },
+    ];
+    store
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &env_vars)
+        .unwrap();
+
+    let agent = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(agent.env_vars, env_vars);
+}
+
+#[test]
+fn test_mark_agent_messages_deleted_marks_history_rows() {
+    let (store, _dir) = make_store();
+    store
+        .create_channel("general", None, ChannelType::Channel)
+        .unwrap();
+    store
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
+        .unwrap();
+    store
+        .send_message("general", None, "bot1", SenderType::Agent, "hello", &[])
+        .unwrap();
+
+    store.mark_agent_messages_deleted("bot1").unwrap();
+    let (history, _) = store.get_history("general", None, 10, None, None).unwrap();
+    assert_eq!(history.len(), 1);
+    assert!(history[0].sender_deleted);
+}
+
+#[test]
 fn test_tasks_crud() {
     let (store, _dir) = make_store();
     store
         .create_channel("eng", None, ChannelType::Channel)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
 
     let tasks = store
@@ -126,10 +171,10 @@ fn test_task_claim_and_status() {
         .create_channel("eng", None, ChannelType::Channel)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "o3")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "o3", &[])
         .unwrap();
     store.create_tasks("eng", "bot1", &["Task A"]).unwrap();
 
@@ -154,7 +199,7 @@ fn test_resolve_target() {
         .unwrap();
     store.add_human("alice").unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
 
     let (ch_id, thread_parent) = store.resolve_target("#general", "bot1").unwrap();
@@ -173,7 +218,7 @@ fn test_list_channels_excludes_dm() {
         .unwrap();
     store.add_human("alice").unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     // Create a DM channel via resolve_target
     store.resolve_target("dm:@alice", "bot1").unwrap();
@@ -195,10 +240,10 @@ fn test_dm_only_has_two_members() {
         .unwrap();
     store.add_human("alice").unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
-        .create_agent_record("bot2", "Bot 2", None, "claude", "sonnet")
+        .create_agent_record("bot2", "Bot 2", None, "claude", "sonnet", &[])
         .unwrap();
 
     // Create DM between alice and bot1
@@ -231,7 +276,7 @@ fn test_dm_channels() {
     let (store, _dir) = make_store();
     store.add_human("alice").unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
 
     let (ch_id, _) = store.resolve_target("dm:@alice", "bot1").unwrap();
@@ -250,13 +295,13 @@ fn test_unrelated_agents_do_not_receive_thread_messages() {
         .join_channel("general", "alice", SenderType::Human)
         .unwrap();
     store
-        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet")
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
         .unwrap();
     store
         .join_channel("general", "bot1", SenderType::Agent)
         .unwrap();
     store
-        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4")
+        .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
         .unwrap();
     store
         .join_channel("general", "bot2", SenderType::Agent)

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -125,6 +125,40 @@ fn test_agent_env_vars_persist_in_agent_record() {
 }
 
 #[test]
+fn test_agent_reasoning_effort_persists_in_agent_record() {
+    let (store, _dir) = make_store();
+    store
+        .create_agent_record_with_reasoning(
+            "bot1",
+            "Bot 1",
+            None,
+            "codex",
+            "gpt-5.4-mini",
+            Some("low"),
+            &[],
+        )
+        .unwrap();
+
+    let agent = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
+
+    store
+        .update_agent_record_with_reasoning(
+            "bot1",
+            "Bot 1",
+            None,
+            "codex",
+            "gpt-5.4-mini",
+            Some("high"),
+            &[],
+        )
+        .unwrap();
+
+    let updated = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(updated.reasoning_effort.as_deref(), Some("high"));
+}
+
+#[test]
 fn test_mark_agent_messages_deleted_marks_history_rows() {
     let (store, _dir) = make_store();
     store

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -214,6 +214,7 @@ export async function updateAgent(
     description: string
     runtime: string
     model: string
+    reasoningEffort?: string | null
     envVars: AgentEnvVar[]
   }
 ): Promise<{ ok: boolean; restarted: boolean }> {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -10,6 +10,8 @@ import type {
   ActivityLogResponse,
   WorkspaceResponse,
   WorkspaceFileResponse,
+  AgentDetailResponse,
+  AgentEnvVar,
 } from './types'
 
 const BASE = ''  // same origin in prod; Vite proxy in dev
@@ -199,4 +201,53 @@ export async function getAgentWorkspace(agentName: string): Promise<WorkspaceRes
 export async function getAgentWorkspaceFile(agentName: string, path: string): Promise<WorkspaceFileResponse> {
   const params = new URLSearchParams({ path })
   return json(await fetch(`${BASE}/api/agents/${encodeURIComponent(agentName)}/workspace/file?${params.toString()}`))
+}
+
+export async function getAgentDetail(agentName: string): Promise<AgentDetailResponse> {
+  return json(await fetch(`${BASE}/api/agents/${encodeURIComponent(agentName)}`))
+}
+
+export async function updateAgent(
+  agentName: string,
+  payload: {
+    display_name: string
+    description: string
+    runtime: string
+    model: string
+    envVars: AgentEnvVar[]
+  }
+): Promise<{ ok: boolean; restarted: boolean }> {
+  return json(
+    await fetch(`${BASE}/api/agents/${encodeURIComponent(agentName)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+  )
+}
+
+export async function restartAgent(
+  agentName: string,
+  mode: 'restart' | 'reset_session' | 'full_reset'
+): Promise<void> {
+  await json(
+    await fetch(`${BASE}/api/agents/${encodeURIComponent(agentName)}/restart`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode }),
+    })
+  )
+}
+
+export async function deleteAgent(
+  agentName: string,
+  mode: 'preserve_workspace' | 'delete_workspace'
+): Promise<void> {
+  await json(
+    await fetch(`${BASE}/api/agents/${encodeURIComponent(agentName)}/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode }),
+    })
+  )
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1,0 +1,149 @@
+import type { AgentEnvVar } from '../types'
+
+export const MODELS: Record<string, { value: string; label: string }[]> = {
+  claude: [
+    { value: 'sonnet', label: 'claude-sonnet-4-6' },
+    { value: 'opus', label: 'claude-opus-4-6' },
+    { value: 'haiku', label: 'claude-haiku-4-5' },
+  ],
+  codex: [
+    { value: 'gpt-5.4', label: 'gpt-5.4' },
+    { value: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+    { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+    { value: 'gpt-5.2-codex', label: 'gpt-5.2-codex' },
+    { value: 'gpt-5.2', label: 'gpt-5.2' },
+    { value: 'gpt-5.1-codex-max', label: 'gpt-5.1-codex-max' },
+    { value: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini' },
+  ],
+}
+
+export interface AgentConfigState {
+  name: string
+  display_name: string
+  description: string
+  runtime: string
+  model: string
+  envVars: AgentEnvVar[]
+}
+
+interface Props {
+  state: AgentConfigState
+  editableName?: boolean
+  onChange: (next: AgentConfigState) => void
+}
+
+export function AgentConfigForm({ state, editableName = false, onChange }: Props) {
+  function updateEnvVar(index: number, key: keyof AgentEnvVar, value: string) {
+    const envVars = state.envVars.map((envVar, envIndex) =>
+      envIndex === index ? { ...envVar, [key]: value } : envVar
+    )
+    onChange({ ...state, envVars })
+  }
+
+  function addEnvVar() {
+    onChange({
+      ...state,
+      envVars: [...state.envVars, { key: '', value: '' }],
+    })
+  }
+
+  function removeEnvVar(index: number) {
+    onChange({
+      ...state,
+      envVars: state.envVars.filter((_, envIndex) => envIndex !== index),
+    })
+  }
+
+  return (
+    <>
+      {editableName && (
+        <div className="modal-field">
+          <label>Name</label>
+          <input
+            value={state.name}
+            onChange={(e) => onChange({ ...state, name: e.target.value })}
+            placeholder="e.g. my-agent"
+            autoFocus
+          />
+        </div>
+      )}
+
+      <div className="modal-field">
+        <label>Display Name</label>
+        <input
+          value={state.display_name}
+          onChange={(e) => onChange({ ...state, display_name: e.target.value })}
+          placeholder={state.name || 'Agent name'}
+          autoFocus={!editableName}
+        />
+      </div>
+
+      <div className="modal-field">
+        <label>Role</label>
+        <textarea
+          value={state.description}
+          onChange={(e) => onChange({ ...state, description: e.target.value })}
+          placeholder="What does this agent do?"
+        />
+      </div>
+
+      <div className="modal-field">
+        <label>Runtime</label>
+        <select
+          value={state.runtime}
+          onChange={(e) => {
+            const runtime = e.target.value
+            const model = MODELS[runtime]?.[0]?.value ?? ''
+            onChange({ ...state, runtime, model })
+          }}
+        >
+          <option value="claude">Claude Code</option>
+          <option value="codex">Codex CLI</option>
+        </select>
+      </div>
+
+      <div className="modal-field">
+        <label>Model</label>
+        <select
+          value={state.model}
+          onChange={(e) => onChange({ ...state, model: e.target.value })}
+        >
+          {(MODELS[state.runtime] ?? []).map((model) => (
+            <option key={model.value} value={model.value}>
+              {model.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="modal-field">
+        <label>Environment Variables</label>
+        <div className="env-var-editor">
+          {state.envVars.length === 0 && (
+            <div className="env-var-editor-empty">No environment variables configured.</div>
+          )}
+          {state.envVars.map((envVar, index) => (
+            <div key={index} className="env-var-editor-row">
+              <input
+                value={envVar.key}
+                onChange={(e) => updateEnvVar(index, 'key', e.target.value)}
+                placeholder="KEY"
+              />
+              <input
+                value={envVar.value}
+                onChange={(e) => updateEnvVar(index, 'value', e.target.value)}
+                placeholder="value"
+              />
+              <button className="env-remove-btn" type="button" onClick={() => removeEnvVar(index)}>
+                ×
+              </button>
+            </div>
+          ))}
+          <button className="env-add-btn" type="button" onClick={addEnvVar}>
+            + Add variable
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -17,12 +17,23 @@ export const MODELS: Record<string, { value: string; label: string }[]> = {
   ],
 }
 
+export const REASONING_EFFORTS = [
+  { value: 'default', label: 'Default' },
+  { value: 'none', label: 'None' },
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra High' },
+]
+
 export interface AgentConfigState {
   name: string
   display_name: string
   description: string
   runtime: string
   model: string
+  reasoningEffort: string | null
   envVars: AgentEnvVar[]
 }
 
@@ -94,7 +105,12 @@ export function AgentConfigForm({ state, editableName = false, onChange }: Props
           onChange={(e) => {
             const runtime = e.target.value
             const model = MODELS[runtime]?.[0]?.value ?? ''
-            onChange({ ...state, runtime, model })
+            onChange({
+              ...state,
+              runtime,
+              model,
+              reasoningEffort: runtime === 'codex' ? state.reasoningEffort ?? 'default' : null,
+            })
           }}
         >
           <option value="claude">Claude Code</option>
@@ -115,6 +131,27 @@ export function AgentConfigForm({ state, editableName = false, onChange }: Props
           ))}
         </select>
       </div>
+
+      {state.runtime === 'codex' && (
+        <div className="modal-field">
+          <label>Reasoning</label>
+          <select
+            value={state.reasoningEffort ?? 'default'}
+            onChange={(e) =>
+              onChange({
+                ...state,
+                reasoningEffort: e.target.value,
+              })
+            }
+          >
+            {REASONING_EFFORTS.map((effort) => (
+              <option key={effort.value} value={effort.value}>
+                {effort.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div className="modal-field">
         <label>Environment Variables</label>

--- a/ui/src/components/ChatPanel.css
+++ b/ui/src/components/ChatPanel.css
@@ -96,6 +96,11 @@
   margin-top: 2px;
 }
 
+.message-deleted .message-avatar {
+  filter: saturate(0.2);
+  border: 1px dashed rgba(0,0,0,0.35);
+}
+
 .message-avatar-spacer {
   width: 36px;
   flex-shrink: 0;
@@ -140,9 +145,26 @@
   vertical-align: middle;
 }
 
+.deleted-inline-badge {
+  font-size: 9px;
+  font-weight: 700;
+  background: rgba(0,0,0,0.08);
+  color: var(--text-muted);
+  border-radius: 3px;
+  padding: 1px 4px;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
 .message-time {
   font-size: 11px;
   color: var(--text-muted);
+}
+
+.message-deleted .message-content,
+.message-deleted .message-time,
+.message-deleted .message-sender {
+  opacity: 0.78;
 }
 
 .message-content {

--- a/ui/src/components/CreateAgentModal.tsx
+++ b/ui/src/components/CreateAgentModal.tsx
@@ -14,6 +14,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
     description: '',
     runtime: 'claude',
     model: 'sonnet',
+    reasoningEffort: null,
     envVars: [],
   })
   const [creating, setCreating] = useState(false)
@@ -36,6 +37,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           description: config.description,
           runtime: config.runtime,
           model: config.model,
+          reasoningEffort: config.runtime === 'codex' ? config.reasoningEffort : null,
           envVars: config.envVars,
         }),
       })

--- a/ui/src/components/CreateAgentModal.tsx
+++ b/ui/src/components/CreateAgentModal.tsx
@@ -1,38 +1,26 @@
 import { useState } from 'react'
 import './ProfilePanel.css'  // reuses modal styles
+import { AgentConfigForm, type AgentConfigState } from './AgentConfigForm'
 
 interface Props {
   onClose: () => void
   onCreated: () => void
 }
 
-const MODELS: Record<string, { value: string; label: string }[]> = {
-  claude: [
-    { value: 'sonnet', label: 'claude-sonnet-4-6' },
-    { value: 'opus', label: 'claude-opus-4-6' },
-    { value: 'haiku', label: 'claude-haiku-4-5' },
-  ],
-  codex: [
-    { value: 'gpt-5.4', label: 'gpt-5.4' },
-    { value: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
-    { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
-    { value: 'gpt-5.2-codex', label: 'gpt-5.2-codex' },
-    { value: 'gpt-5.2', label: 'gpt-5.2' },
-    { value: 'gpt-5.1-codex-max', label: 'gpt-5.1-codex-max' },
-    { value: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini' },
-  ],
-}
-
 export function CreateAgentModal({ onClose, onCreated }: Props) {
-  const [name, setName] = useState('')
-  const [description, setDescription] = useState('')
-  const [runtime, setRuntime] = useState('claude')
-  const [model, setModel] = useState('sonnet')
+  const [config, setConfig] = useState<AgentConfigState>({
+    name: '',
+    display_name: '',
+    description: '',
+    runtime: 'claude',
+    model: 'sonnet',
+    envVars: [],
+  })
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   async function handleCreate() {
-    if (!name.trim()) {
+    if (!config.name.trim()) {
       setError('Name is required')
       return
     }
@@ -42,7 +30,14 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
       const res = await fetch('/api/agents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name.trim(), description, runtime, model }),
+        body: JSON.stringify({
+          name: config.name.trim(),
+          display_name: config.display_name.trim(),
+          description: config.description,
+          runtime: config.runtime,
+          model: config.model,
+          envVars: config.envVars,
+        }),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({ error: res.statusText }))
@@ -71,52 +66,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           </select>
         </div>
 
-        <div className="modal-field">
-          <label>Name</label>
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. my-agent"
-            autoFocus
-          />
-        </div>
-
-        <div className="modal-field">
-          <label>Description</label>
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="What does this agent do?"
-          />
-        </div>
-
-        <div className="modal-field">
-          <label>Runtime</label>
-          <select
-            value={runtime}
-            onChange={(e) => {
-              const r = e.target.value
-              setRuntime(r)
-              setModel(MODELS[r][0].value)
-            }}
-          >
-            <option value="claude">Claude Code</option>
-            <option value="codex">Codex CLI</option>
-          </select>
-        </div>
-
-        <div className="modal-field">
-          <label>Model</label>
-          <select value={model} onChange={(e) => setModel(e.target.value)}>
-            {(MODELS[runtime] ?? []).map((m) => (
-              <option key={m.value} value={m.value}>{m.label}</option>
-            ))}
-          </select>
-        </div>
-
-        <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-          Environment variables are not supported in the UI yet.
-        </div>
+        <AgentConfigForm state={config} editableName onChange={setConfig} />
 
         {error && (
           <div style={{ color: 'var(--accent)', fontSize: 13, marginTop: 8 }}>{error}</div>
@@ -127,7 +77,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           <button
             className="btn-primary"
             onClick={handleCreate}
-            disabled={creating || !name.trim()}
+            disabled={creating || !config.name.trim()}
           >
             {creating ? 'Creating...' : 'Create Agent'}
           </button>

--- a/ui/src/components/MessageItem.tsx
+++ b/ui/src/components/MessageItem.tsx
@@ -86,6 +86,7 @@ export function MessageItem({ message, currentUser, prevMessage, onReply }: Mess
   const isMe = message.senderName === currentUser
   const initial = message.senderName[0]?.toUpperCase() ?? '?'
   const color = senderColor(message.senderName)
+  const deletedClass = message.senderDeleted ? ' message-deleted' : ''
 
   // Group messages from the same sender within 5 minutes
   const isGrouped =
@@ -99,7 +100,7 @@ export function MessageItem({ message, currentUser, prevMessage, onReply }: Mess
   }
 
   return (
-    <div className={`message-item${isGrouped ? ' grouped' : ''} message-group`}>
+    <div className={`message-item${isGrouped ? ' grouped' : ''}${deletedClass} message-group`}>
       {!isGrouped && (
         <div
           className="message-avatar"
@@ -125,6 +126,7 @@ export function MessageItem({ message, currentUser, prevMessage, onReply }: Mess
               {message.senderType === 'agent' && (
                 <span className="agent-badge">BOT</span>
               )}
+              {message.senderDeleted && <span className="deleted-inline-badge">deleted</span>}
               {isMe && <span className="you-inline-badge">you</span>}
             </span>
             <span className="message-time">

--- a/ui/src/components/ProfilePanel.css
+++ b/ui/src/components/ProfilePanel.css
@@ -5,6 +5,13 @@
   background: var(--content-bg);
 }
 
+.profile-panel-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
 .profile-avatar-section {
   display: flex;
   flex-direction: column;
@@ -13,6 +20,27 @@
   padding-bottom: 24px;
   border-bottom: 1px solid var(--border);
   margin-bottom: 24px;
+}
+
+.profile-toolbar {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.profile-action-btn {
+  padding: 8px 12px;
+  border: 2px solid var(--black);
+  background: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  box-shadow: 3px 3px 0 rgba(0,0,0,0.9);
+}
+
+.profile-action-btn-danger {
+  background: #ffd8d8;
 }
 
 .profile-avatar-large {
@@ -242,6 +270,12 @@
   margin-top: 8px;
 }
 
+.env-var-editor-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
 .env-var-editor-row {
   display: flex;
   gap: 6px;
@@ -265,6 +299,16 @@
   color: var(--badge-claude);
   font-weight: 600;
   padding: 4px 0;
+}
+
+.env-remove-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--text-muted);
 }
 
 .modal-footer {
@@ -304,4 +348,47 @@
 .btn-primary:disabled {
   opacity: 0.45;
   cursor: default;
+}
+
+.btn-danger {
+  background: #d94841;
+}
+
+.modal-choice-list {
+  display: grid;
+  gap: 10px;
+}
+
+.modal-choice-card {
+  width: 100%;
+  border: 2px solid var(--border);
+  background: #fff;
+  padding: 16px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal-choice-card-active {
+  border-color: var(--black);
+  background: rgba(0, 212, 255, 0.12);
+}
+
+.modal-choice-title {
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.modal-choice-body {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.modal-error {
+  color: var(--accent);
+  font-size: 13px;
+  margin-top: 12px;
 }

--- a/ui/src/components/ProfilePanel.tsx
+++ b/ui/src/components/ProfilePanel.tsx
@@ -68,6 +68,7 @@ export function ProfilePanel() {
   const initial = agent.name[0]?.toUpperCase() ?? '?'
   const isActive = agent.status === 'active'
   const envVars = detail?.envVars ?? []
+  const reasoningEffort = agent.reasoningEffort ?? detail?.agent.reasoningEffort ?? null
 
   async function handleStartStop() {
     setBusy(true)
@@ -138,6 +139,12 @@ export function ProfilePanel() {
           <span className="badge badge-claude">{agent.runtime ?? 'claude'}</span>
           <span className="profile-config-key">Model</span>
           <span className="badge">{agent.model ?? 'sonnet'}</span>
+          {agent.runtime === 'codex' && (
+            <>
+              <span className="profile-config-key">Reasoning</span>
+              <span className="badge">{reasoningEffort ?? 'default'}</span>
+            </>
+          )}
           <span className="profile-config-key">Status</span>
           <span className="badge" style={{ background: isActive ? 'var(--lime)' : agent.status === 'sleeping' ? 'var(--orange)' : 'var(--gray-400)' }}>
             {agent.status}
@@ -170,6 +177,10 @@ export function ProfilePanel() {
             description: detail.agent.description ?? '',
             runtime: detail.agent.runtime ?? 'claude',
             model: detail.agent.model ?? 'sonnet',
+            reasoningEffort:
+              detail.agent.runtime === 'codex'
+                ? (detail.agent.reasoningEffort ?? 'default')
+                : null,
             envVars: detail.envVars,
           }}
           onClose={() => setShowEdit(false)}
@@ -230,6 +241,7 @@ function EditAgentModal({
         description: state.description,
         runtime: state.runtime,
         model: state.model,
+        reasoningEffort: state.runtime === 'codex' ? state.reasoningEffort : null,
         envVars: state.envVars.filter((envVar) => envVar.key.trim() || envVar.value),
       })
       await onSaved()

--- a/ui/src/components/ProfilePanel.tsx
+++ b/ui/src/components/ProfilePanel.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { deleteAgent, getAgentDetail, restartAgent, startAgent, stopAgent, updateAgent } from '../api'
+import type { AgentDetailResponse } from '../types'
 import { useApp } from '../store'
-import { startAgent, stopAgent } from '../api'
+import { AgentConfigForm, type AgentConfigState } from './AgentConfigForm'
 import './ProfilePanel.css'
 
 function agentColor(name: string): string {
-  const colors = ['#FF6B6B','#4ECDC4','#45B7D1','#96CEB4','#FFEAA7','#DDA0DD','#98D8C8']
+  const colors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#98D8C8']
   let h = 0
   for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff
   return colors[Math.abs(h) % colors.length]
@@ -18,34 +20,64 @@ function activityLabel(activity?: string, detail?: string): string {
 
 function activityDotColor(activity?: string): string {
   switch (activity) {
-    case 'online': return 'var(--lime)'
-    case 'thinking': return 'var(--orange)'
-    case 'working': return 'var(--orange)'
-    default: return 'var(--gray-400)'
+    case 'online':
+      return 'var(--lime)'
+    case 'thinking':
+    case 'working':
+      return 'var(--orange)'
+    default:
+      return 'var(--gray-400)'
   }
 }
 
+type RestartMode = 'restart' | 'reset_session' | 'full_reset'
+type DeleteMode = 'preserve_workspace' | 'delete_workspace'
+
 export function ProfilePanel() {
-  const { selectedAgent, refreshServerInfo } = useApp()
+  const { selectedAgent, refreshServerInfo, setSelectedAgent } = useApp()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [detail, setDetail] = useState<AgentDetailResponse | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [showEdit, setShowEdit] = useState(false)
+  const [showRestart, setShowRestart] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
+
+  useEffect(() => {
+    if (!selectedAgent) {
+      setDetail(null)
+      return
+    }
+    setDetailLoading(true)
+    getAgentDetail(selectedAgent.name)
+      .then(setDetail)
+      .catch((err) => setError(String(err)))
+      .finally(() => setDetailLoading(false))
+  }, [selectedAgent])
 
   if (!selectedAgent) {
     return (
-      <div className="profile-panel" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-muted)' }}>
+      <div className="profile-panel profile-panel-empty">
         Select an agent to view profile.
       </div>
     )
   }
 
-  const color = agentColor(selectedAgent.name)
-  const initial = selectedAgent.name[0]?.toUpperCase() ?? '?'
-  const isActive = selectedAgent.status === 'active'
+  const agent = selectedAgent
+  const color = agentColor(agent.name)
+  const initial = agent.name[0]?.toUpperCase() ?? '?'
+  const isActive = agent.status === 'active'
+  const envVars = detail?.envVars ?? []
 
-  async function handleStart() {
-    setBusy(true); setError(null)
+  async function handleStartStop() {
+    setBusy(true)
+    setError(null)
     try {
-      await startAgent(selectedAgent!.name)
+      if (isActive) {
+        await stopAgent(agent.name)
+      } else {
+        await startAgent(agent.name)
+      }
       refreshServerInfo()
     } catch (e) {
       setError(String(e))
@@ -54,74 +86,316 @@ export function ProfilePanel() {
     }
   }
 
-  async function handleStop() {
-    setBusy(true); setError(null)
-    try {
-      await stopAgent(selectedAgent!.name)
-      refreshServerInfo()
-    } catch (e) {
-      setError(String(e))
-    } finally {
-      setBusy(false)
-    }
+  async function reloadDetail() {
+    const nextDetail = await getAgentDetail(agent.name)
+    setDetail(nextDetail)
+    refreshServerInfo()
   }
 
   return (
     <div className="profile-panel">
       <div className="profile-avatar-section">
+        <div className="profile-toolbar">
+          <button className="profile-action-btn" type="button" onClick={() => setShowEdit(true)}>
+            Edit
+          </button>
+          <button className="profile-action-btn" type="button" onClick={() => setShowRestart(true)}>
+            Restart
+          </button>
+          <button className="profile-action-btn profile-action-btn-danger" type="button" onClick={() => setShowDelete(true)}>
+            Delete
+          </button>
+        </div>
+
         <div className="profile-avatar-large" style={{ background: color }}>
           {initial}
         </div>
-        <div className="profile-name">{selectedAgent.display_name ?? selectedAgent.name}</div>
-        <div className="profile-handle">@{selectedAgent.name}</div>
+        <div className="profile-name">{agent.display_name ?? agent.name}</div>
+        <div className="profile-handle">@{agent.name}</div>
         <div className="profile-activity-status">
-          <span className="profile-activity-dot" style={{ background: activityDotColor(selectedAgent.activity) }} />
-          {activityLabel(selectedAgent.activity, selectedAgent.activity_detail)}
+          <span className="profile-activity-dot" style={{ background: activityDotColor(agent.activity) }} />
+          {activityLabel(agent.activity, agent.activity_detail)}
         </div>
       </div>
 
       {error && <div className="error-banner">{error}</div>}
 
       <div className="profile-controls">
-        {isActive ? (
-          <button className="btn-brutal btn-orange" onClick={handleStop} disabled={busy}>
-            {busy ? '…' : '⏹ Stop'}
-          </button>
-        ) : (
-          <button className="btn-brutal btn-lime" onClick={handleStart} disabled={busy}>
-            {busy ? '…' : '▶ Start'}
-          </button>
-        )}
+        <button className={`btn-brutal ${isActive ? 'btn-orange' : 'btn-lime'}`} onClick={handleStartStop} disabled={busy}>
+          {busy ? '…' : isActive ? '⏹ Stop' : '▶ Start'}
+        </button>
       </div>
 
-      {selectedAgent.description && (
-        <div className="profile-section">
-          <div className="profile-section-label">Role</div>
-          <div className="profile-role-text">{selectedAgent.description}</div>
-        </div>
-      )}
+      <div className="profile-section">
+        <div className="profile-section-label">Role</div>
+        <div className="profile-role-text">{agent.description || 'No role defined.'}</div>
+      </div>
 
       <div className="profile-section">
         <div className="profile-section-label">Configuration</div>
         <div className="profile-config-grid">
           <span className="profile-config-key">Runtime</span>
-          <span className="badge badge-claude">{selectedAgent.runtime ?? 'claude'}</span>
+          <span className="badge badge-claude">{agent.runtime ?? 'claude'}</span>
           <span className="profile-config-key">Model</span>
-          <span className="badge">{selectedAgent.model ?? 'sonnet'}</span>
+          <span className="badge">{agent.model ?? 'sonnet'}</span>
           <span className="profile-config-key">Status</span>
-          <span
-            className="badge"
-            style={{
-              background:
-                selectedAgent.status === 'active'
-                  ? 'var(--lime)'
-                  : selectedAgent.status === 'sleeping'
-                  ? 'var(--orange)'
-                  : 'var(--gray-400)',
-            }}
-          >
-            {selectedAgent.status}
+          <span className="badge" style={{ background: isActive ? 'var(--lime)' : agent.status === 'sleeping' ? 'var(--orange)' : 'var(--gray-400)' }}>
+            {agent.status}
           </span>
+        </div>
+      </div>
+
+      <div className="profile-section">
+        <div className="profile-section-label">Environment Variables</div>
+        {detailLoading ? (
+          <div className="profile-role-text">Loading...</div>
+        ) : envVars.length === 0 ? (
+          <div className="profile-role-text">No environment variables configured.</div>
+        ) : (
+          envVars.map((envVar) => (
+            <div key={envVar.key} className="env-var-row">
+              <span className="env-var-key">{envVar.key}</span>
+              <span className="env-var-val">{envVar.value || '(empty)'}</span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {showEdit && detail && (
+        <EditAgentModal
+          agentName={agent.name}
+          initialState={{
+            name: agent.name,
+            display_name: detail.agent.display_name ?? agent.name,
+            description: detail.agent.description ?? '',
+            runtime: detail.agent.runtime ?? 'claude',
+            model: detail.agent.model ?? 'sonnet',
+            envVars: detail.envVars,
+          }}
+          onClose={() => setShowEdit(false)}
+          onSaved={async () => {
+            setShowEdit(false)
+            await reloadDetail()
+          }}
+        />
+      )}
+
+      {showRestart && (
+        <RestartAgentModal
+          agentName={agent.name}
+          onClose={() => setShowRestart(false)}
+          onRestarted={async () => {
+            setShowRestart(false)
+            await reloadDetail()
+          }}
+        />
+      )}
+
+      {showDelete && (
+        <DeleteAgentModal
+          agentName={agent.name}
+          onClose={() => setShowDelete(false)}
+          onDeleted={async () => {
+            setShowDelete(false)
+            setSelectedAgent(null)
+            refreshServerInfo()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function EditAgentModal({
+  agentName,
+  initialState,
+  onClose,
+  onSaved,
+}: {
+  agentName: string
+  initialState: AgentConfigState
+  onClose: () => void
+  onSaved: () => Promise<void>
+}) {
+  const [state, setState] = useState<AgentConfigState>(initialState)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      await updateAgent(agentName, {
+        display_name: state.display_name,
+        description: state.description,
+        runtime: state.runtime,
+        model: state.model,
+        envVars: state.envVars.filter((envVar) => envVar.key.trim() || envVar.value),
+      })
+      await onSaved()
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal-box">
+        <div className="modal-header">
+          <span className="modal-title">Edit Agent</span>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <AgentConfigForm state={state} onChange={setState} />
+        {error && <div className="modal-error">{error}</div>}
+        <div className="modal-footer">
+          <button className="btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn-primary" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RestartAgentModal({
+  agentName,
+  onClose,
+  onRestarted,
+}: {
+  agentName: string
+  onClose: () => void
+  onRestarted: () => Promise<void>
+}) {
+  const [mode, setMode] = useState<RestartMode>('restart')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const options = useMemo(
+    () => [
+      {
+        id: 'restart' as const,
+        title: 'Restart',
+        body: 'Stop and restart the agent process. Keeps conversation state and workspace files.',
+      },
+      {
+        id: 'reset_session' as const,
+        title: 'Reset Session & Restart',
+        body: 'Clear the saved conversation session, but keep workspace files such as MEMORY.md and notes/.',
+      },
+      {
+        id: 'full_reset' as const,
+        title: 'Full Reset & Restart',
+        body: 'Clear the saved conversation session, delete workspace files, and start fresh.',
+      },
+    ],
+    []
+  )
+
+  async function handleSubmit() {
+    setSubmitting(true)
+    setError(null)
+    try {
+      await restartAgent(agentName, mode)
+      await onRestarted()
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal-box">
+        <div className="modal-header">
+          <span className="modal-title">Restart {agentName}</span>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-choice-list">
+          {options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className={`modal-choice-card ${mode === option.id ? 'modal-choice-card-active' : ''}`}
+              onClick={() => setMode(option.id)}
+            >
+              <span className="modal-choice-title">{option.title}</span>
+              <span className="modal-choice-body">{option.body}</span>
+            </button>
+          ))}
+        </div>
+        {error && <div className="modal-error">{error}</div>}
+        <div className="modal-footer">
+          <button className="btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn-primary" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Restarting...' : 'Restart'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DeleteAgentModal({
+  agentName,
+  onClose,
+  onDeleted,
+}: {
+  agentName: string
+  onClose: () => void
+  onDeleted: () => Promise<void>
+}) {
+  const [mode, setMode] = useState<DeleteMode>('preserve_workspace')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    setSubmitting(true)
+    setError(null)
+    try {
+      await deleteAgent(agentName, mode)
+      await onDeleted()
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal-box">
+        <div className="modal-header">
+          <span className="modal-title">Delete {agentName}</span>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-choice-list">
+          <button
+            type="button"
+            className={`modal-choice-card ${mode === 'preserve_workspace' ? 'modal-choice-card-active' : ''}`}
+            onClick={() => setMode('preserve_workspace')}
+          >
+            <span className="modal-choice-title">Delete Agent Only</span>
+            <span className="modal-choice-body">Remove the Chorus record and keep workspace files on disk.</span>
+          </button>
+          <button
+            type="button"
+            className={`modal-choice-card ${mode === 'delete_workspace' ? 'modal-choice-card-active' : ''}`}
+            onClick={() => setMode('delete_workspace')}
+          >
+            <span className="modal-choice-title">Delete Agent + Workspace</span>
+            <span className="modal-choice-body">Remove the Chorus record and delete the workspace directory.</span>
+          </button>
+        </div>
+        {error && <div className="modal-error">{error}</div>}
+        <div className="modal-footer">
+          <button className="btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn-primary btn-danger" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Deleting...' : 'Delete'}
+          </button>
         </div>
       </div>
     </div>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -21,6 +21,16 @@ export interface AgentInfo {
   activity_detail?: string
 }
 
+export interface AgentEnvVar {
+  key: string
+  value: string
+}
+
+export interface AgentDetailResponse {
+  agent: AgentInfo
+  envVars: AgentEnvVar[]
+}
+
 export interface HumanInfo {
   name: string
 }
@@ -46,6 +56,7 @@ export interface HistoryMessage {
   content: string
   senderName: string
   senderType: 'human' | 'agent'
+  senderDeleted: boolean
   createdAt: string
   thread_parent_id?: string
   attachments?: AttachmentRef[]

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -14,6 +14,7 @@ export interface AgentInfo {
   status: 'active' | 'sleeping' | 'inactive'
   runtime?: string
   model?: string
+  reasoningEffort?: string
   description?: string
   session_id?: string
   /** Live activity state: online | thinking | working | offline */


### PR DESCRIPTION
## Summary
- add Codex reasoning effort to the shared create/edit agent config flow
- persist reasoning effort in the backend and surface it in agent/profile APIs
- pass Codex reasoning effort through to the CLI via model_reasoning_effort
- tighten AGT-002 and AGT-004 to cover the new runtime-specific reasoning behavior

## Verification
- cargo test test_agent_reasoning_effort_persists_in_agent_record --test store_tests -- --nocapture
- cargo test get_and_update_agent_via_api --test server_tests -- --nocapture
- cargo test codex_args_include_reasoning_effort_override_when_configured --lib -- --nocapture
- cargo test stale_output_reader_does_not_remove_restarted_agent -- --nocapture
- cargo test restart_agent --test server_tests -- --nocapture
- cargo test --test driver_tests -- --nocapture
- cd ui && npm run build
- targeted browser QA for AGT-002 and AGT-004 reasoning-effort assertions (report kept in qa/runs/2026-03-23T113807/)