### PR TITLE
feat(agent): add kimi runtime driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/plans
 docs/handoffs
 .playwright-cli/
 node_modules
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ ui/ (React + Vite)  <->  src/ (Rust/Axum)  <->  ~/.chorus/
                               |
                     +---------+---------+
                     |                   |
-              agent processes      bridge processes
-              (claude/codex CLI)   (chorus bridge --agent-id)
+                    agent processes      bridge processes
+                 (claude/codex/kimi CLI) (chorus bridge --agent-id)
 ```
 
 ### Message Flow
@@ -31,7 +31,7 @@ Data flow for an agent receiving a message:
 Each agent runs as a single process across all channels and DMs. One session equals one process and retains full conversation history in the agent memory.
 
 - Session ID is persisted to SQLite on `SessionInit` and `TurnEnd`
-- On server restart, active agents are auto-restarted with `--resume <session_id>` (Claude) or `codex exec resume <thread_id>` (Codex)
+- On server restart, active agents are auto-restarted with `--resume <session_id>` (Claude), `codex exec resume <thread_id>` (Codex), or `kimi --session <session_id>` (Kimi)
 - Context isolation between channels is provided through `MEMORY.md` in the agent workspace, not through separate processes
 
 ## Code Organization
@@ -178,6 +178,7 @@ The authoritative QA execution workflow lives in `qa/README.md`, with the case c
 2. Implement the `Driver` trait with all required methods:
 3. Register the driver in `src/agent/drivers/mod.rs`
 4. Add it to the driver selection match in `src/agent/manager.rs`
+5. Follow [`docs/DRIVER_GUIDE.md`](./docs/DRIVER_GUIDE.md) for protocol discovery, live-runtime debugging, and required verification
 
 ## Completion Checklist
 

--- a/docs/DRIVER_GUIDE.md
+++ b/docs/DRIVER_GUIDE.md
@@ -1,0 +1,316 @@
+# Adding A New Driver
+
+This guide is the practical checklist for adding a new agent runtime to Chorus and verifying that it actually works in the live product.
+
+The goal is not just "the process starts." The goal is:
+
+- the runtime can be spawned reliably
+- the runtime can call the Chorus MCP bridge tools
+- the runtime receives messages correctly
+- the runtime replies through `send_message`, not raw stdout text
+- the runtime does not regress the user-visible DM and activity flows
+
+## Where Driver Support Lives
+
+New driver work usually touches these files:
+
+- `src/agent/drivers/<runtime>.rs`
+  - runtime-specific spawn, prompt, parsing, tool naming, and activity labels
+- `src/agent/drivers/mod.rs`
+  - module registration
+- `src/agent/manager.rs`
+  - driver selection, session handling, and subprocess lifecycle
+- `src/main.rs`
+  - CLI defaults or runtime-specific model choices when needed
+- `src/server/handlers/dto.rs`
+  - API runtime enum validation when needed
+- `src/store/agents.rs`
+  - persisted runtime/model support when needed
+- `ui/src/components/AgentConfigForm.tsx`
+  - runtime exposed in the create/edit UI
+- `ui/src/components/ProfilePanel.tsx`
+  - runtime/model rendering if the profile badges or labels need updates
+- `tests/driver_tests.rs`
+  - prompt and parser regression tests
+- `tests/server_tests.rs`
+  - runtime create/update API coverage when needed
+- `qa/cases/playwright/AGT-002.spec.ts`
+  - create/start matrix coverage
+- `qa/cases/playwright/<RUNTIME-CASE>.spec.ts`
+  - runtime-specific DM reply verification
+
+## Phase 1: Discover The Runtime Protocol First
+
+Do not start by copying Claude or Codex behavior and hoping it matches.
+
+Before writing much code, answer these questions from the real runtime:
+
+1. What stdin shape does the runtime expect in print/non-interactive mode?
+2. What stdout shape does it emit for:
+   - assistant text
+   - tool calls
+   - tool results
+   - errors
+3. What MCP tool names does it expose?
+   - namespaced like `mcp__chat__send_message`
+   - bare like `send_message`
+   - something else
+4. How does it represent tool-call arguments?
+   - embedded JSON object
+   - JSON string inside another object
+   - content array blocks
+5. How is session resume expressed?
+
+### Recommended Probe
+
+Use a tiny one-off probe before integrating fully:
+
+1. Create a temporary MCP config that points at:
+   - `chorus bridge --agent-id <test-agent> --server-url <local-server>`
+2. Run the runtime directly in its print/JSON mode
+3. Send one minimal prompt that asks it to call `send_message`
+4. Capture raw stdout and stderr
+
+You want at least one saved raw sample for:
+
+- a successful tool call
+- a tool result
+- a plain text assistant response
+
+That sample becomes the source of truth for the parser tests.
+
+## Phase 2: Implement The Driver
+
+Create `src/agent/drivers/<runtime>.rs` and implement the `Driver` trait.
+
+The key pieces are:
+
+- `spawn()`
+  - construct the real subprocess command
+  - pass the bridge MCP config
+  - enable piped stdin/stdout/stderr
+- `parse_line()`
+  - convert raw runtime output into Chorus `ParsedEvent`s
+- `encode_stdin_message()`
+  - format stdin notifications in the runtime's actual expected shape
+- `build_system_prompt()`
+  - teach the runtime the Chorus tool contract using the runtime's real tool names
+- `tool_display_name()` and `summarize_tool_input()`
+  - make activity log output readable
+
+### Prompt Rules That Matter
+
+The prompt must be explicit about these points:
+
+- all human-visible replies must go through `send_message`
+- raw assistant text is not a valid user-visible reply
+- after `wait_for_message()` or `check_messages()` returns a real user message, the agent must either:
+  - reply, or
+  - deliberately explain why no reply is needed
+- when idle, the agent must return to `wait_for_message()`
+
+### Tool Naming Rule
+
+Use the runtime's actual MCP-exposed names in the prompt and wake-up instructions.
+
+Do not assume they match another runtime.
+
+If the runtime emits bare names like `send_message`, the prompt should teach bare names. If the parser wants to normalize internally, do that in `parse_line()`, not in the prompt text.
+
+## Phase 3: Register It End To End
+
+Wire the runtime through the full product surface:
+
+1. Add the module in `src/agent/drivers/mod.rs`
+2. Add the runtime selection branch in `src/agent/manager.rs`
+3. Add API/runtime validation updates where needed
+4. Expose the runtime in the UI create/edit form
+5. Make sure runtime/model labels render correctly in the profile UI
+
+If the runtime needs session resume support, ensure the persisted session ID format is correct and that restart logic reuses it.
+
+## Phase 4: Add The Right Tests
+
+### Unit / Parser Tests
+
+In `tests/driver_tests.rs` and the driver's own unit tests, cover:
+
+- prompt contains the runtime's real tool names
+- prompt forbids raw stdout replies
+- parser handles:
+  - assistant text
+  - tool-call blocks
+  - top-level `tool_calls`
+  - runtime-specific argument encoding
+- stdin notifications use the runtime's actual JSON shape
+
+### Store / Lifecycle Tests
+
+Add focused regressions for any runtime-specific delivery behavior that shows up during debugging.
+
+Example from Kimi:
+
+- sender read position must advance on send
+- an agent must not receive its own outbound message back as unread
+
+### API / Server Tests
+
+Cover:
+
+- runtime accepted by `POST /api/agents`
+- runtime shows up in list/detail responses when needed
+- restart/session persistence if the runtime is resumable
+
+## Phase 5: Verify The Live Runtime, Not Just The Parser
+
+This is the most important phase.
+
+Start a fresh local server with:
+
+- a fresh temp data dir
+- `RUST_LOG=chorus=debug`
+- the current branch build
+
+Then reproduce one real DM flow against the live app.
+
+### Required Live Checks
+
+Verify all of these:
+
+1. Agent creates successfully
+2. Agent starts successfully
+3. Agent receives the DM
+4. Agent replies in the DM
+5. Activity log shows `Sending message…`
+6. Raw subprocess output shows a real `send_message` tool call
+7. The agent does not only emit raw assistant text
+8. The agent does not consume the message silently
+9. The agent does not receive its own outbound reply back as unread
+
+### Raw Logging Recommendation
+
+When bringing up a new driver, temporarily log:
+
+- raw stdout lines from that runtime
+- raw stderr lines from that runtime
+
+This makes it possible to distinguish:
+
+- tool injection failure
+- parser mismatch
+- prompt/tool-choice failure
+- lifecycle/read-position bugs
+
+Without raw logs, new-driver debugging is mostly guesswork.
+
+## Phase 6: Browser QA
+
+Every new runtime should have two Playwright checks:
+
+### 1. Runtime-Specific DM Reply Case
+
+Create a case like `qa/cases/playwright/<RUNTIME-001>.spec.ts` that proves:
+
+- a direct DM to the runtime gets a reply
+- the reply contains an exact token
+- the reply is visible in chat
+- the activity log contains a real `Sending message` tool event
+- success is not granted if only raw text output exists
+
+### 2. Create/Start Matrix Case
+
+Update `qa/cases/playwright/AGT-002.spec.ts` so the runtime is covered in the creation matrix.
+
+This catches:
+
+- runtime enum mismatches
+- model default issues
+- UI/runtime wiring regressions
+
+## Common Failure Modes
+
+These are the mistakes most likely to waste time:
+
+### 1. Wrong stdin protocol
+
+Symptom:
+
+- runtime starts but never behaves correctly
+- no useful stdout
+
+Cause:
+
+- sending another runtime's JSON envelope instead of the runtime's real input shape
+
+### 2. Wrong tool names in the prompt
+
+Symptom:
+
+- runtime can call one tool sometimes but ignores the reply contract
+
+Cause:
+
+- prompt teaches namespaced tools but runtime sees bare names, or vice versa
+
+### 3. Parser only handles one tool-call shape
+
+Symptom:
+
+- runtime logs raw JSON with tool calls, but Chorus only records text output
+
+Cause:
+
+- parser handles content-array tool blocks but not top-level `tool_calls`, or the reverse
+
+### 4. Runtime emits plain text after reading a message
+
+Symptom:
+
+- logs show the runtime understood the user message
+- chat never receives a reply
+- activity only shows `text output`
+
+Cause:
+
+- prompt contract is too weak, or the tool result needs a stronger local reply instruction
+
+### 5. Sender self-echo
+
+Symptom:
+
+- after replying, the agent receives its own outbound DM back through `wait_for_message()`
+
+Cause:
+
+- sender `last_read_seq` is not advanced on send
+
+## Completion Checklist
+
+Do not call a new driver "done" until all items below are true:
+
+- runtime protocol was confirmed from real raw samples
+- prompt uses the runtime's actual tool names
+- parser covers the runtime's actual output shapes
+- create/start works through the API and UI
+- live DM reply path uses `send_message`
+- activity log proves the tool path
+- no self-echo/unread loop remains
+- focused Rust tests pass
+- browser QA passes for:
+  - runtime-specific DM case
+  - `AGT-002`
+- `AGENTS.md` or related docs were updated
+
+## Recommended Fast Path Next Time
+
+If you want the shortest reliable path for the next runtime, do this in order:
+
+1. capture one raw runtime probe
+2. write parser tests from the raw sample
+3. implement spawn + parser + prompt
+4. verify one live DM with raw stdout/stderr logging
+5. add the runtime-specific Playwright case
+6. add the runtime to `AGT-002`
+7. only then polish UI and defaults
+
+That order avoids spending time debugging UI or API layers when the real bug is still at the runtime wire-protocol level.

--- a/qa/QA_PRESETS.md
+++ b/qa/QA_PRESETS.md
@@ -88,6 +88,8 @@ Current UI matrix:
   - `gpt-5.2`
   - `gpt-5.1-codex-max`
   - `gpt-5.1-codex-mini`
+- Kimi:
+  - `kimi-code/kimi-for-coding`
 
 Notes:
 - Use stable names such as `matrix-claude-sonnet` and `matrix-codex-gpt-5-4-mini`.

--- a/qa/cases/agents.md
+++ b/qa/cases/agents.md
@@ -78,10 +78,12 @@
     - `gpt-5.2`
     - `gpt-5.1-codex-max`
     - `gpt-5.1-codex-mini`
+  - Kimi:
+    - `kimi-for-coding`
 - Steps:
   1. Open the create-agent modal and record the runtime and model options actually shown in the build under test.
-  2. Switch between Claude and Codex in the create-agent modal.
-  3. Verify the reasoning-effort control is hidden for Claude and visible for Codex.
+  2. Switch between Claude, Codex, and Kimi in the create-agent modal.
+  3. Verify the reasoning-effort control is hidden for Claude and Kimi, and visible for Codex.
   4. For at least one Codex model, choose a non-default reasoning effort and create the agent.
   5. Create one disposable agent for every runtime/model pair using a stable naming scheme such as `matrix-<runtime>-<model>`.
   6. After each creation, verify the new agent appears in the sidebar.
@@ -95,14 +97,14 @@
   - every visible runtime/model pair is creatable
   - stored runtime and model match the selected values exactly
   - Codex shows a reasoning-effort control and persists the chosen value exactly
-  - Claude does not show a meaningless reasoning-effort control
+  - Claude and Kimi do not show a meaningless reasoning-effort control
   - duplicate names are rejected regardless of runtime or model
   - failures are attributable to a specific pair, not hidden behind a generic fallback
 - Common failure signals:
   - one runtime/model pair cannot be created
   - created agent shows a different model than requested
   - reasoning-effort control is missing for Codex
-  - reasoning-effort control appears for Claude
+  - reasoning-effort control appears for Claude or Kimi
   - created Codex agent ignores the selected reasoning effort
   - runtime picker and stored runtime disagree
   - duplicate name is accepted

--- a/qa/cases/playwright/AGT-002.spec.ts
+++ b/qa/cases/playwright/AGT-002.spec.ts
@@ -13,6 +13,7 @@ const MODELS: Record<string, string[]> = {
     'gpt-5.1-codex-max',
     'gpt-5.1-codex-mini',
   ],
+  kimi: ['kimi-code/kimi-for-coding'],
 }
 
 /**

--- a/qa/cases/playwright/KIMI-001.spec.ts
+++ b/qa/cases/playwright/KIMI-001.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test'
+import {
+  createAgentApi,
+  getAgentActivityLogApi,
+  getWhoami,
+  historyForUser,
+  waitForAgentActive,
+} from './helpers/api'
+import { openAgentChat, openAgentTab, sendChatMessage } from './helpers/ui'
+
+const skipLLM = process.env.CHORUS_E2E_LLM === '0'
+
+/**
+ * Runtime verification: direct DM to a Kimi-backed agent with an exact-token assertion.
+ */
+test.describe('KIMI-001', () => {
+  test.beforeAll(async ({ request }) => {
+    try {
+      await createAgentApi(request, { name: 'bot-k', runtime: 'kimi', model: 'kimi-code/kimi-for-coding' })
+    } catch (e) {
+      // Ignore if already exists
+    }
+  })
+
+  test('Kimi Agent Direct Reply', async ({ page, request }) => {
+    test.skip(skipLLM, 'CHORUS_E2E_LLM=0')
+    test.setTimeout(300_000)
+
+    const { username } = await getWhoami(request)
+    const mark = `kimi1-${Date.now()}`
+    const token = `OK-KIMI-${Date.now()}`
+
+    await waitForAgentActive(request, 'bot-k')
+
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    await test.step('Step 1: Send direct message to bot-k asking for an exact token', async () => {
+      await openAgentChat(page, 'bot-k')
+      await sendChatMessage(page, `MSG-KIMI ${mark}: reply with exact token ${token}`)
+    })
+
+    await test.step('Step 2: Wait and verify the Kimi reply appears in the same DM', async () => {
+      const deadline = Date.now() + 240_000
+      let msgs: Awaited<ReturnType<typeof historyForUser>> = []
+      while (Date.now() < deadline) {
+        msgs = await historyForUser(request, username, 'dm:@bot-k', 120)
+        const agents = msgs.filter(
+          (m) =>
+            m.senderType === 'agent' &&
+            m.senderName === 'bot-k' &&
+            (m.content ?? '').includes(token)
+        )
+        if (agents.length >= 1) break
+        await new Promise((r) => setTimeout(r, 5000))
+      }
+
+      const agents = msgs.filter(
+        (m) =>
+          m.senderType === 'agent' &&
+          m.senderName === 'bot-k' &&
+          (m.content ?? '').includes(token)
+      )
+      expect(agents.length).toBeGreaterThanOrEqual(1)
+      const bodies = agents.map((a) => a.content ?? '').join(' ')
+      expect(bodies).toContain(token)
+      console.log('Kimi reply:', bodies)
+      await expect(page.locator('.message-item').filter({ hasText: token }).first()).toBeVisible()
+    })
+
+    await test.step('Step 3: Verify activity shows a real send_message path, not only raw text output', async () => {
+      await openAgentTab(page, 'bot-k', 'Activity')
+      const deadline = Date.now() + 30_000
+      let activity = await getAgentActivityLogApi(request, 'bot-k')
+      while (
+        Date.now() < deadline &&
+        !activity.entries.some(
+          (item) =>
+            item.entry.kind === 'tool_start' &&
+            (item.entry.tool_name ?? '').includes('Sending message')
+        )
+      ) {
+        await new Promise((r) => setTimeout(r, 2000))
+        activity = await getAgentActivityLogApi(request, 'bot-k')
+      }
+
+      const sentTool = activity.entries.some(
+        (item) =>
+          item.entry.kind === 'tool_start' &&
+          (item.entry.tool_name ?? '').includes('Sending message')
+      )
+      expect(sentTool).toBe(true)
+
+      const rawTextOnlyReply = activity.entries.some(
+        (item) => item.entry.kind === 'text' && (item.entry.text ?? '').includes(token)
+      )
+      expect(rawTextOnlyReply).toBe(false)
+    })
+  })
+})

--- a/qa/cases/playwright/helpers/api.ts
+++ b/qa/cases/playwright/helpers/api.ts
@@ -211,6 +211,27 @@ export interface HistoryMessage {
   replyCount?: number
 }
 
+export interface ActivityLogEntry {
+  seq: number
+  timestamp_ms: number
+  entry: {
+    kind: string
+    text?: string
+    content?: string
+    tool_name?: string
+    tool_input?: string
+    target?: string
+    activity?: string
+    detail?: string
+  }
+}
+
+export interface AgentActivityLogResponse {
+  entries: ActivityLogEntry[]
+  agent_activity: string
+  agent_detail: string
+}
+
 export async function historyForUser(
   request: APIRequestContext,
   username: string,
@@ -224,6 +245,15 @@ export async function historyForUser(
   expect(res.ok(), await res.text()).toBeTruthy()
   const j = await res.json()
   return j.messages ?? []
+}
+
+export async function getAgentActivityLogApi(
+  request: APIRequestContext,
+  name: string
+): Promise<AgentActivityLogResponse> {
+  const res = await request.get(`/api/agents/${encodeURIComponent(name)}/activity-log`)
+  expect(res.ok(), await res.text()).toBeTruthy()
+  return res.json()
 }
 
 export async function listChannelsApi(

--- a/src/agent/activity_log.rs
+++ b/src/agent/activity_log.rs
@@ -18,6 +18,9 @@ pub enum ActivityEntry {
     Text {
         text: String,
     },
+    RawOutput {
+        text: String,
+    },
     MessageReceived {
         channel_label: String,
         sender_name: String,

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -138,9 +138,9 @@ impl Driver for KimiDriver {
                                     has_tool_calls = true;
                                     let name = normalize_kimi_tool_name(
                                         block
-                                        .get("name")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("unknown_tool")
+                                            .get("name")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("unknown_tool"),
                                     );
                                     let input = block
                                         .get("input")
@@ -313,9 +313,8 @@ mod tests {
     #[test]
     fn kimi_parse_line_maps_documented_assistant_text_output() {
         let driver = KimiDriver;
-        let events = driver.parse_line(
-            r#"{"role":"assistant","content":"Hello! How can I help you?"}"#,
-        );
+        let events =
+            driver.parse_line(r#"{"role":"assistant","content":"Hello! How can I help you?"}"#);
 
         assert!(matches!(
             &events[0],

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -1,0 +1,376 @@
+use std::io::Write as _;
+use std::process::{Child, Command, Stdio};
+
+use super::{Driver, ParsedEvent, SpawnContext};
+use crate::agent::drivers::prompt::{build_base_system_prompt, PromptOptions};
+use crate::store::agents::AgentConfig;
+
+pub struct KimiDriver;
+
+fn normalize_kimi_tool_name(name: &str) -> String {
+    match name {
+        "mcp__chat__send_message" => "send_message".to_string(),
+        "mcp__chat__check_messages" => "check_messages".to_string(),
+        "mcp__chat__wait_for_message" => "wait_for_message".to_string(),
+        "mcp__chat__receive_message" => "receive_message".to_string(),
+        "mcp__chat__upload_file" => "upload_file".to_string(),
+        "mcp__chat__view_file" => "view_file".to_string(),
+        "mcp__chat__list_tasks" => "list_tasks".to_string(),
+        "mcp__chat__create_tasks" => "create_tasks".to_string(),
+        "mcp__chat__claim_tasks" => "claim_tasks".to_string(),
+        "mcp__chat__unclaim_task" => "unclaim_task".to_string(),
+        "mcp__chat__update_task_status" => "update_task_status".to_string(),
+        "mcp__chat__list_server" => "list_server".to_string(),
+        "mcp__chat__read_history" => "read_history".to_string(),
+        other => other.to_string(),
+    }
+}
+
+impl Driver for KimiDriver {
+    fn id(&self) -> &str {
+        "kimi"
+    }
+
+    fn supports_stdin_notification(&self) -> bool {
+        true
+    }
+
+    fn mcp_tool_prefix(&self) -> &str {
+        ""
+    }
+
+    fn spawn(&self, ctx: &SpawnContext) -> anyhow::Result<Child> {
+        let mcp_config = serde_json::json!({
+            "mcpServers": {
+                "chat": {
+                    "command": ctx.bridge_binary,
+                    "args": ["bridge", "--agent-id", &ctx.agent_id, "--server-url", &ctx.server_url]
+                }
+            }
+        });
+        let mcp_config_path =
+            std::path::Path::new(&ctx.working_directory).join(".chorus-kimi-mcp.json");
+        std::fs::write(&mcp_config_path, serde_json::to_string(&mcp_config)?)?;
+
+        let session_id = ctx
+            .config
+            .session_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("Kimi requires a prepared session id"))?;
+
+        let mut args = vec![
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--input-format".to_string(),
+            "stream-json".to_string(),
+            "--work-dir".to_string(),
+            ctx.working_directory.clone(),
+            "--session".to_string(),
+            session_id.to_string(),
+            "--mcp-config-file".to_string(),
+            mcp_config_path.to_string_lossy().into_owned(),
+        ];
+
+        if !ctx.config.model.is_empty() {
+            args.push("--model".to_string());
+            args.push(ctx.config.model.clone());
+        }
+
+        let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        env_vars.insert("FORCE_COLOR".to_string(), "0".to_string());
+        env_vars.insert("NO_COLOR".to_string(), "1".to_string());
+        for extra in &ctx.config.env_vars {
+            env_vars.insert(extra.key.clone(), extra.value.clone());
+        }
+
+        let mut child = Command::new("kimi")
+            .args(&args)
+            .current_dir(&ctx.working_directory)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .envs(&env_vars)
+            .spawn()?;
+
+        let stdin_msg = serde_json::json!({
+            "role": "user",
+            "content": &ctx.prompt,
+        });
+
+        if let Some(ref mut stdin) = child.stdin {
+            let mut line = serde_json::to_string(&stdin_msg)?;
+            line.push('\n');
+            stdin.write_all(line.as_bytes())?;
+        }
+
+        Ok(child)
+    }
+
+    fn parse_line(&self, line: &str) -> Vec<ParsedEvent> {
+        let event: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return vec![],
+        };
+
+        let mut events = Vec::new();
+        match event.get("role").and_then(|v| v.as_str()) {
+            Some("assistant") => {
+                let mut has_tool_calls = false;
+
+                match event.get("content") {
+                    Some(serde_json::Value::String(text)) => {
+                        events.push(ParsedEvent::Text {
+                            text: text.to_string(),
+                        });
+                    }
+                    Some(serde_json::Value::Array(content)) => {
+                        for block in content {
+                            match block.get("type").and_then(|v| v.as_str()) {
+                                Some("text") => {
+                                    if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                        events.push(ParsedEvent::Text {
+                                            text: text.to_string(),
+                                        });
+                                    }
+                                }
+                                Some("tool_use") => {
+                                    has_tool_calls = true;
+                                    let name = normalize_kimi_tool_name(
+                                        block
+                                        .get("name")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("unknown_tool")
+                                    );
+                                    let input = block
+                                        .get("input")
+                                        .cloned()
+                                        .unwrap_or(serde_json::Value::Null);
+                                    events.push(ParsedEvent::ToolCall { name, input });
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                if let Some(tool_calls) = event.get("tool_calls").and_then(|v| v.as_array()) {
+                    for tool_call in tool_calls {
+                        has_tool_calls = true;
+                        let name = normalize_kimi_tool_name(
+                            tool_call
+                                .get("function")
+                                .and_then(|function| function.get("name"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown_tool"),
+                        );
+                        let input = tool_call
+                            .get("function")
+                            .and_then(|function| function.get("arguments"))
+                            .and_then(|v| v.as_str())
+                            .and_then(|value| serde_json::from_str(value).ok())
+                            .unwrap_or(serde_json::Value::Null);
+                        events.push(ParsedEvent::ToolCall { name, input });
+                    }
+                }
+
+                if !has_tool_calls {
+                    events.push(ParsedEvent::TurnEnd { session_id: None });
+                }
+            }
+            Some("tool") => {}
+            Some("error") => {
+                let message = event
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Unknown Kimi error");
+                events.push(ParsedEvent::Error {
+                    message: message.to_string(),
+                });
+            }
+            _ => {}
+        }
+
+        events
+    }
+
+    fn encode_stdin_message(&self, text: &str, _session_id: &str) -> Option<String> {
+        let msg = serde_json::json!({
+            "role": "user",
+            "content": text,
+        });
+        Some(serde_json::to_string(&msg).unwrap_or_default())
+    }
+
+    fn build_system_prompt(&self, config: &AgentConfig, _agent_id: &str) -> String {
+        build_base_system_prompt(
+            config,
+            &PromptOptions {
+                tool_prefix: "".to_string(),
+                extra_critical_rules: vec![
+                    "- Do NOT use bash/curl/sqlite to send or receive messages. The MCP tools handle everything.".to_string(),
+                    "- Call `wait_for_message()` when you are idle so the agent stays in the receive loop.".to_string(),
+                    "- After `wait_for_message()` or `check_messages()` returns a real user message, you must either send a reply or deliberately explain why no reply is needed before going idle again.".to_string(),
+                    "- Direct messages and explicit @mentions are addressed to you. Do not silently consume them and return to waiting.".to_string(),
+                    "- Never treat raw assistant stdout as a user-visible reply. Any reply meant for humans must be delivered with `send_message()`.".to_string(),
+                ],
+                post_startup_notes: vec![],
+                include_stdin_notification_section: true,
+                teams: config.teams.clone(),
+            },
+        )
+    }
+
+    fn tool_display_name(&self, name: &str) -> String {
+        match name {
+            "send_message" => "Sending message…".to_string(),
+            "check_messages" => "Checking messages…".to_string(),
+            "wait_for_message" => "Waiting for messages…".to_string(),
+            "receive_message" => "Receiving messages…".to_string(),
+            "upload_file" => "Uploading file…".to_string(),
+            "view_file" => "Viewing file…".to_string(),
+            "list_tasks" => "Listing tasks…".to_string(),
+            "create_tasks" => "Creating tasks…".to_string(),
+            "claim_tasks" => "Claiming tasks…".to_string(),
+            "unclaim_task" => "Unclaiming task…".to_string(),
+            "update_task_status" => "Updating task status…".to_string(),
+            "list_server" => "Listing server…".to_string(),
+            "read_history" => "Reading history…".to_string(),
+            n if n.starts_with("mcp__chat__") => {
+                let op = normalize_kimi_tool_name(n).replace('_', " ");
+                format!("Using {op}…")
+            }
+            other => {
+                let truncated: String = other.chars().take(20).collect();
+                format!("Using {truncated}…")
+            }
+        }
+    }
+
+    fn summarize_tool_input(&self, name: &str, input: &serde_json::Value) -> String {
+        if !input.is_object() {
+            return String::new();
+        }
+
+        let str_field = |field: &str| -> String {
+            input
+                .get(field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+
+        match name {
+            "Read" | "read_file" | "Write" | "write_file" | "Edit" | "edit_file" => {
+                let p = str_field("file_path");
+                if p.is_empty() {
+                    str_field("path")
+                } else {
+                    p
+                }
+            }
+            "Bash" | "bash" => {
+                let cmd = str_field("command");
+                if cmd.chars().count() > 100 {
+                    let truncated: String = cmd.chars().take(100).collect();
+                    format!("{truncated}…")
+                } else {
+                    cmd
+                }
+            }
+            "Glob" | "glob" | "Grep" | "grep" => str_field("pattern"),
+            "WebFetch" | "web_fetch" => str_field("url"),
+            "send_message" | "mcp__chat__send_message" => {
+                let target = str_field("target");
+                let text = {
+                    let content = str_field("content");
+                    if content.is_empty() {
+                        str_field("text")
+                    } else {
+                        content
+                    }
+                };
+                if target.is_empty() {
+                    text
+                } else if text.is_empty() {
+                    target
+                } else {
+                    format!("{target}: {text}")
+                }
+            }
+            "read_history" | "mcp__chat__read_history" => str_field("channel"),
+            "view_file" | "mcp__chat__view_file" => str_field("path"),
+            _ => String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kimi_parse_line_maps_documented_assistant_text_output() {
+        let driver = KimiDriver;
+        let events = driver.parse_line(
+            r#"{"role":"assistant","content":"Hello! How can I help you?"}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::Text { text } if text == "Hello! How can I help you?"
+        ));
+        assert!(matches!(events[1], ParsedEvent::TurnEnd { .. }));
+    }
+
+    #[test]
+    fn kimi_parse_line_maps_documented_tool_sequence() {
+        let driver = KimiDriver;
+        let events = driver.parse_line(
+            r#"{"role":"assistant","content":[{"type":"tool_use","name":"check_messages","input":{"limit":5}}]}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::ToolCall { name, .. } if name == "check_messages"
+        ));
+    }
+
+    #[test]
+    fn kimi_parse_line_maps_top_level_tool_calls() {
+        let driver = KimiDriver;
+        let events = driver.parse_line(
+            r#"{"role":"assistant","content":[{"type":"think","think":"..." }],"tool_calls":[{"type":"function","id":"tool_1","function":{"name":"send_message","arguments":"{\"target\":\"dm:@bytedance\",\"content\":\"TRACE-KIMI-123\"}"}}]}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::ToolCall { name, input }
+                if name == "send_message" && input["target"] == "dm:@bytedance"
+        ));
+    }
+
+    #[test]
+    fn kimi_encode_stdin_message_uses_documented_message_shape() {
+        let driver = KimiDriver;
+        let encoded = driver
+            .encode_stdin_message("Hello", "ignored")
+            .expect("Kimi driver should support stdin messages");
+        let json: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(json["role"], "user");
+        assert_eq!(json["content"], "Hello");
+    }
+
+    #[test]
+    fn kimi_summarize_tool_input_includes_read_history_channel() {
+        let driver = KimiDriver;
+        let input = serde_json::json!({ "channel": "#common-feature-squad", "limit": 20 });
+
+        assert_eq!(
+            driver.summarize_tool_input("read_history", &input),
+            "#common-feature-squad"
+        );
+    }
+}

--- a/src/agent/drivers/mod.rs
+++ b/src/agent/drivers/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod codex;
+pub mod kimi;
 pub mod prompt;
 
 use std::process::Child;

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -38,6 +38,7 @@ fn get_driver(runtime: &str) -> anyhow::Result<Arc<dyn Driver>> {
     match runtime {
         "claude" => Ok(Arc::new(crate::agent::drivers::claude::ClaudeDriver)),
         "codex" => Ok(Arc::new(crate::agent::drivers::codex::CodexDriver)),
+        "kimi" => Ok(Arc::new(crate::agent::drivers::kimi::KimiDriver)),
         _ => anyhow::bail!("Unknown runtime: {runtime}"),
     }
 }
@@ -80,10 +81,15 @@ impl AgentManager {
             .ok_or_else(|| anyhow::anyhow!("Agent not found: {agent_name}"))?;
 
         let driver = get_driver(&agent.runtime)?;
-        let resumable_session_id = if driver.id() == "codex" {
-            agent.session_id.clone()
-        } else {
-            None
+        let resumable_session_id = match driver.id() {
+            "codex" => agent.session_id.clone(),
+            "kimi" => Some(
+                agent
+                    .session_id
+                    .clone()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+            ),
+            _ => None,
         };
 
         let config = AgentConfig {
@@ -132,6 +138,12 @@ impl AgentManager {
         );
 
         let running_session_id = config.session_id.clone();
+        if driver.id() == "kimi" {
+            if let Some(ref session_id) = running_session_id {
+                self.store
+                    .update_agent_session(agent_name, Some(session_id.as_str()))?;
+            }
+        }
 
         let ctx = SpawnContext {
             agent_id: agent.name.clone(),
@@ -148,6 +160,7 @@ impl AgentManager {
             .stdout
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
+        let stderr = child.stderr.take();
 
         let instance_id = self.next_instance_id.fetch_add(1, Ordering::Relaxed);
 
@@ -171,6 +184,9 @@ impl AgentManager {
         activity_log::set_activity_state(&self.activity_logs, agent_name, "working", "Starting…");
 
         self.spawn_output_reader(agent_name.to_string(), stdout, driver, instance_id);
+        if let Some(stderr) = stderr {
+            self.spawn_stderr_reader(agent_name.to_string(), stderr, instance_id);
+        }
         Ok(())
     }
 
@@ -306,6 +322,15 @@ impl AgentManager {
                     continue;
                 }
 
+                if driver.id() == "kimi" {
+                    debug!(agent = %name, raw_stdout = %line, "raw agent stdout");
+                    activity_log::push_activity(
+                        &activity_logs,
+                        &name,
+                        ActivityEntry::RawOutput { text: line.clone() },
+                    );
+                }
+
                 for event in driver.parse_line(&line) {
                     let rt = tokio::runtime::Handle::current();
                     rt.block_on(async {
@@ -349,6 +374,32 @@ impl AgentManager {
                     }
                 }
             });
+        });
+    }
+
+    fn spawn_stderr_reader(
+        &self,
+        agent_name: String,
+        stderr: std::process::ChildStderr,
+        instance_id: u64,
+    ) {
+        tokio::task::spawn_blocking(move || {
+            use std::io::BufRead;
+            let reader = std::io::BufReader::new(stderr);
+
+            for line in reader.lines() {
+                let line = match line {
+                    Ok(l) => l,
+                    Err(e) => {
+                        error!(agent = %agent_name, err = %e, "stderr read error");
+                        break;
+                    }
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                warn!(agent = %agent_name, instance_id, raw_stderr = %line, "agent stderr");
+            }
         });
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -103,7 +103,10 @@ impl ChatBridge {
             })
             .collect();
 
-        Ok(formatted.join("\n"))
+        Ok(format!(
+            "{}\n\nReply instructions:\n- For any human-visible reply, call send_message(target=\"<exact target from the header above>\", content=\"...\").\n- Reuse the exact target value from the header when you reply.\n- Do not output the reply as plain assistant text.",
+            formatted.join("\n")
+        ))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ enum AgentCommands {
         name: String,
         #[arg(long, default_value = "claude")]
         runtime: String,
-        #[arg(long, default_value = "sonnet")]
+        #[arg(long, default_value = "")]
         model: String,
         #[arg(long)]
         description: Option<String>,
@@ -100,6 +100,14 @@ enum AgentCommands {
 fn default_data_dir() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
     format!("{home}/.chorus")
+}
+
+fn default_model_for_runtime(runtime: &str) -> &str {
+    match runtime {
+        "codex" => "gpt-5.4",
+        "kimi" => "kimi-code/kimi-for-coding",
+        _ => "sonnet",
+    }
 }
 
 #[tokio::main]
@@ -248,6 +256,11 @@ async fn main() -> anyhow::Result<()> {
                     description,
                     data_dir,
                 } => {
+                    let model = if model.is_empty() {
+                        default_model_for_runtime(&runtime).to_string()
+                    } else {
+                        model
+                    };
                     let data_dir = data_dir.unwrap_or_else(default_data_dir);
                     let db_path = format!("{data_dir}/chorus.db");
                     let store = Store::open(&db_path)?;

--- a/src/server/handlers/dto.rs
+++ b/src/server/handlers/dto.rs
@@ -61,7 +61,7 @@ pub struct AgentInfo {
     /// Optional longer blurb.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Driver key, e.g. `claude`, `codex`.
+    /// Driver key, e.g. `claude`, `codex`, `kimi`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
     /// Model id passed to the driver.

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -370,11 +370,10 @@ pub async fn handle_history(
         .is_member(&channel_name, &agent_id)
         .map_err(|e| api_err(e.to_string()))?
     {
-        return Ok(Json(HistoryResponse {
-            messages: vec![],
-            has_more: false,
-            last_read_seq: 0,
-        }));
+        return Err(api_err(format!(
+            "you are not a member of channel {}",
+            channel_target
+        )));
     }
 
     let limit = params.limit.unwrap_or(50);

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -20,7 +20,7 @@ pub struct Agent {
     pub display_name: String,
     /// Optional longer description.
     pub description: Option<String>,
-    /// Which subprocess driver to spawn (`claude`, `codex`, …).
+    /// Which subprocess driver to spawn (`claude`, `codex`, `kimi`, …).
     pub runtime: String,
     /// Model identifier for the driver.
     pub model: String,

--- a/src/store/messages.rs
+++ b/src/store/messages.rs
@@ -259,6 +259,12 @@ impl Store {
                 params![msg_id, att_id],
             )?;
         }
+        // Treat the sender's own newly-created message as already read so it
+        // does not come back later through get_messages_for_agent() as unread.
+        conn.execute(
+            "UPDATE channel_members SET last_read_seq = MAX(last_read_seq, ?1) WHERE channel_id = ?2 AND member_name = ?3",
+            params![seq, channel.id, sender_name],
+        )?;
         let _ = self.msg_tx.send((channel.id.clone(), msg_id.clone()));
         Ok(msg_id)
     }

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -1,5 +1,6 @@
 use chorus::agent::drivers::claude::ClaudeDriver;
 use chorus::agent::drivers::codex::CodexDriver;
+use chorus::agent::drivers::kimi::KimiDriver;
 use chorus::agent::drivers::Driver;
 use chorus::store::agents::AgentConfig;
 
@@ -74,5 +75,52 @@ fn test_codex_prompt_uses_split_message_tools() {
     assert!(
         prompt.contains("Chorus"),
         "Codex prompts should use the current product name"
+    );
+}
+
+#[test]
+fn test_kimi_prompt_uses_split_message_tools() {
+    let driver = KimiDriver;
+    let config = AgentConfig {
+        name: "kimi-bot".to_string(),
+        display_name: "Kimi Bot".to_string(),
+        description: Some("Replies in Chorus".to_string()),
+        runtime: "kimi".to_string(),
+        model: "kimi-code/kimi-for-coding".to_string(),
+        session_id: None,
+        reasoning_effort: None,
+        env_vars: Vec::new(),
+        teams: vec![],
+    };
+
+    let prompt = driver.build_system_prompt(&config, "agent-id");
+
+    assert!(
+        prompt.contains("wait_for_message"),
+        "Kimi prompts must teach the blocking idle tool explicitly with the Kimi-native tool name"
+    );
+    assert!(
+        prompt.contains("check_messages"),
+        "Kimi prompts must teach the non-blocking message check explicitly with the Kimi-native tool name"
+    );
+    assert!(
+        !prompt.contains("receive_message"),
+        "Kimi prompts should not rely on the legacy combined receive tool"
+    );
+    assert!(
+        prompt.contains("view_file"),
+        "Kimi prompts should teach attachment inspection explicitly"
+    );
+    assert!(
+        prompt.contains("Chorus"),
+        "Kimi prompts should use the current product name"
+    );
+    assert!(
+        prompt.contains("must either send a reply or deliberately explain why no reply is needed"),
+        "Kimi prompts should explicitly forbid consuming a message and silently returning to idle"
+    );
+    assert!(
+        prompt.contains("Any reply meant for humans must be delivered with `send_message()`"),
+        "Kimi prompts should explicitly forbid treating raw stdout text as a valid human reply"
     );
 }

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -1560,6 +1560,7 @@ async fn test_activity_log_includes_message_send_and_receive_events() {
             ActivityEntry::Thinking { .. } => "thinking",
             ActivityEntry::ToolStart { .. } => "tool_start",
             ActivityEntry::Text { .. } => "text",
+            ActivityEntry::RawOutput { .. } => "raw_output",
         })
         .collect();
 

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -10,6 +10,7 @@ use chorus::server::{
 use chorus::store::agents::AgentStatus;
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::{ReceivedMessage, SenderType};
+use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
 use std::future::Future;
 use std::pin::Pin;
@@ -628,7 +629,7 @@ async fn test_all_channel_member_count_matches_agents_plus_humans() {
 }
 
 #[tokio::test]
-async fn test_history_returns_empty_for_non_member_agent() {
+async fn test_history_rejects_non_member_agent() {
     let (store, app) = setup();
     store
         .create_agent_record("bot2", "Bot 2", None, "codex", "gpt-5.4", &[])
@@ -653,14 +654,15 @@ async fn test_history_returns_empty_for_non_member_agent() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = axum::body::to_bytes(resp.into_body(), 1_000_000)
         .await
         .unwrap();
-    let history: HistoryResponse = serde_json::from_slice(&body).unwrap();
-    assert!(history.messages.is_empty());
-    assert!(!history.has_more);
-    assert_eq!(history.last_read_seq, 0);
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"].as_str(),
+        Some("you are not a member of channel #general")
+    );
 }
 
 #[tokio::test]
@@ -948,6 +950,41 @@ async fn test_create_agent_via_api() {
 }
 
 #[tokio::test]
+async fn test_create_kimi_agent_via_api() {
+    let (store, app, lifecycle) = setup_with_lifecycle();
+    store.ensure_builtin_channels("alice").unwrap();
+
+    let req = serde_json::json!({
+        "name": "kimi-bot",
+        "description": "A Kimi test agent",
+        "runtime": "kimi",
+        "model": "kimi-code/kimi-for-coding"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/agents")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let agent = store
+        .get_agent("kimi-bot")
+        .unwrap()
+        .expect("agent should exist");
+    assert_eq!(agent.runtime, "kimi");
+    assert_eq!(agent.model, "kimi-code/kimi-for-coding");
+    assert_eq!(agent.reasoning_effort, None);
+    assert_eq!(lifecycle.started_names(), vec!["kimi-bot".to_string()]);
+}
+
+#[tokio::test]
 async fn test_get_and_update_agent_via_api() {
     let (store, app, lifecycle) = setup_with_lifecycle();
     store
@@ -998,6 +1035,57 @@ async fn test_get_and_update_agent_via_api() {
     assert_eq!(agent.runtime, "codex");
     assert_eq!(agent.model, "gpt-5.4");
     assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
+    assert_eq!(agent.env_vars.len(), 1);
+    assert_eq!(agent.env_vars[0].key, "DEBUG");
+    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
+    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+}
+
+#[tokio::test]
+async fn test_update_agent_to_kimi_clears_reasoning_effort() {
+    let (store, app, lifecycle) = setup_with_lifecycle();
+    store
+        .update_agent_status("bot1", AgentStatus::Active)
+        .unwrap();
+    store
+        .update_agent_record_with_reasoning(&AgentRecordUpsert {
+            name: "bot1",
+            display_name: "Bot 1",
+            description: Some("Replies in Chorus"),
+            runtime: "codex",
+            model: "gpt-5.4-mini",
+            reasoning_effort: Some("high"),
+            env_vars: &[],
+        })
+        .unwrap();
+
+    let update_req = serde_json::json!({
+        "display_name": "Kimi Bot",
+        "description": "Updated role",
+        "runtime": "kimi",
+        "model": "kimi-code/kimi-for-coding",
+        "reasoningEffort": "high",
+        "envVars": [{"key": "DEBUG", "value": "1"}]
+    });
+    let update_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/agents/bot1")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&update_req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(update_resp.status(), StatusCode::OK);
+
+    let agent = store.get_agent("bot1").unwrap().unwrap();
+    assert_eq!(agent.display_name, "Kimi Bot");
+    assert_eq!(agent.runtime, "kimi");
+    assert_eq!(agent.model, "kimi-code/kimi-for-coding");
+    assert_eq!(agent.reasoning_effort, None);
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
     assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -146,6 +146,37 @@ fn test_send_and_receive_messages() {
 }
 
 #[test]
+fn test_agent_does_not_receive_its_own_sent_message() {
+    let (store, _dir) = make_store();
+    store
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
+        .unwrap();
+    store.add_human("alice").unwrap();
+    let (dm_channel_id, _) = store.resolve_target("dm:@alice", "bot1").unwrap();
+    let dm_channel = store.find_channel_by_id(&dm_channel_id).unwrap().unwrap();
+
+    store
+        .send_message(
+            &dm_channel.name,
+            None,
+            "bot1",
+            SenderType::Agent,
+            "hello alice",
+            &[],
+        )
+        .unwrap();
+
+    let unread = store.get_messages_for_agent("bot1", false).unwrap();
+    assert!(
+        unread.is_empty(),
+        "an agent should not get its own outbound message back as unread"
+    );
+
+    let last_read = store.get_last_read_seq(&dm_channel.name, "bot1").unwrap();
+    assert_eq!(last_read, 1, "sender read position should advance on send");
+}
+
+#[test]
 fn test_message_history_pagination() {
     let (store, _dir) = make_store();
     store

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -493,8 +493,8 @@ fn test_unrelated_agents_do_not_receive_thread_messages() {
     assert!(
         bot1_messages
             .iter()
-            .any(|message| message.content == "bot1 thread reply"),
-        "the replying agent should still see its own thread activity"
+            .all(|message| message.content != "bot1 thread reply"),
+        "the replying agent should not get its own thread reply back as unread"
     );
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -178,6 +178,7 @@ select:focus-visible {
 .badge-bot,
 .badge-claude,
 .badge-codex,
+.badge-kimi,
 .badge-you {
   color: var(--text-primary);
 }

--- a/ui/src/components/ActivityPanel.css
+++ b/ui/src/components/ActivityPanel.css
@@ -217,9 +217,18 @@
   background: rgba(255, 255, 255, 0.78);
 }
 
+.activity-item-raw-output {
+  background: rgba(246, 244, 240, 0.96);
+}
+
 .activity-icon-text {
   color: #355d8a;
   background: color-mix(in srgb, #355d8a 14%, transparent);
+}
+
+.activity-icon-raw-output {
+  color: #6d5f48;
+  background: color-mix(in srgb, #6d5f48 12%, transparent);
 }
 
 .activity-item-message-received {

--- a/ui/src/components/ActivityPanel.tsx
+++ b/ui/src/components/ActivityPanel.tsx
@@ -247,6 +247,26 @@ function TextRow({ item }: { item: ActivityLogEntry }) {
   )
 }
 
+function RawOutputRow({ item }: { item: ActivityLogEntry }) {
+  const { entry, timestamp_ms } = item
+  return (
+    <div className="activity-item activity-item-raw-output">
+      <span className="activity-item-icon activity-icon-raw-output">
+        <Terminal size={13} />
+      </span>
+      <div className="activity-item-main">
+        <div className="activity-item-heading">
+          <span className="activity-item-label">Raw output</span>
+        </div>
+        <div className="activity-item-body">
+          <ExpandableText text={entry.text ?? ''} maxLines={4} />
+        </div>
+      </div>
+      <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
+    </div>
+  )
+}
+
 function MessageReceivedRow({ item }: { item: ActivityLogEntry }) {
   const { entry, timestamp_ms } = item
   return (
@@ -296,6 +316,7 @@ function ActivityRow({ item }: { item: ActivityLogEntry }) {
     case 'thinking': return <ThinkingRow item={item} />
     case 'tool_start': return <ToolRow item={item} />
     case 'text': return <TextRow item={item} />
+    case 'raw_output': return <RawOutputRow item={item} />
     case 'message_received': return <MessageReceivedRow item={item} />
     case 'message_sent': return <MessageSentRow item={item} />
     default: return null

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -15,6 +15,9 @@ export const MODELS: Record<string, { value: string; label: string }[]> = {
     { value: 'gpt-5.1-codex-max', label: 'gpt-5.1-codex-max' },
     { value: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini' },
   ],
+  kimi: [
+    { value: 'kimi-code/kimi-for-coding', label: 'kimi-for-coding' },
+  ],
 }
 
 export const REASONING_EFFORTS = [
@@ -130,6 +133,7 @@ export function AgentConfigForm({ state, editableName = false, onChange }: Props
             >
               <option value="claude">Claude Code</option>
               <option value="codex">Codex CLI</option>
+              <option value="kimi">Kimi CLI</option>
             </select>
           </div>
 

--- a/ui/src/components/ProfilePanel.tsx
+++ b/ui/src/components/ProfilePanel.tsx
@@ -140,7 +140,7 @@ export function ProfilePanel() {
         <div className="profile-section-label">[config::runtime]</div>
         <div className="profile-config-grid">
           <span className="profile-config-key">Runtime</span>
-          <span className="badge badge-claude">{agent.runtime ?? 'claude'}</span>
+          <span className={`badge badge-${agent.runtime ?? 'claude'}`}>{agent.runtime ?? 'claude'}</span>
           <span className="profile-config-key">Model</span>
           <span className="badge">{agent.model ?? 'sonnet'}</span>
           {agent.runtime === 'codex' && (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -142,6 +142,7 @@ export type ActivityEntryKind =
   | 'thinking'
   | 'tool_start'
   | 'text'
+  | 'raw_output'
   | 'message_received'
   | 'message_sent'
   | 'status'


### PR DESCRIPTION
## Summary
- add Kimi as a supported agent runtime across backend, UI, and stored agent config
- harden the Kimi driver around its actual MCP tool protocol, activity logging, and DM reply behavior
- add a driver integration guide and Playwright coverage for Kimi create/start/reply flows

## Details
- implement `src/agent/drivers/kimi.rs` and register it in driver selection
- expose Kimi in the agent config UI and profile/runtime badges
- make Kimi use its actual tool names (`send_message`, `wait_for_message`, `check_messages`)
- strengthen bridge reply instructions so Kimi replies through `send_message` instead of raw stdout text
- return an explicit non-member error for `read_history` instead of silently returning empty history
- advance sender read position on send so an agent does not receive its own outbound DM back as unread
- add raw Kimi stdout rows to the Activity panel for debugging and improve tool-input summaries such as `read_history`
- document the full new-driver workflow in `docs/DRIVER_GUIDE.md`

## Verification
- `cargo test --test driver_tests test_kimi_prompt_uses_split_message_tools`
- `cargo test kimi_parse_line_maps_top_level_tool_calls --lib`
- `cargo test --test store_tests test_agent_does_not_receive_its_own_sent_message`
- `cargo test --test server_tests test_history_rejects_non_member_agent`
- `cargo test kimi_summarize_tool_input_includes_read_history_channel --lib`
- `cargo build`
- `npm run build`
- `CHORUS_BASE_URL=http://localhost:3307 npx playwright test KIMI-001.spec.ts --reporter=list`
- `CHORUS_BASE_URL=http://localhost:3307 npx playwright test AGT-002.spec.ts --reporter=list`

## Notes
- live verification included inspecting raw Kimi stdout from the real subprocess session to confirm actual MCP tool calls were being made
