### PR TITLE
fix: preserve agent thread wake replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/plans
 docs/handoffs
 .playwright-cli/
 node_modules
+.worktrees/

--- a/dev.sh
+++ b/dev.sh
@@ -11,19 +11,55 @@ RESET='\033[0m'
 
 echo -e "${CYAN}Chorus dev environment${RESET}"
 
+port_in_use() {
+  lsof -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+API_PORT=3001
+if port_in_use "$API_PORT"; then
+  echo -e "${YELLOW}⚠ Port :$API_PORT is already in use.${RESET}"
+  if [ ! -t 0 ]; then
+    echo "Run interactively to choose another API port."
+    exit 1
+  fi
+
+  while true; do
+    printf "Enter a different API port, or type 'q' to abort: "
+    read -r CHOSEN_PORT
+
+    if [ "$CHOSEN_PORT" = "q" ] || [ "$CHOSEN_PORT" = "Q" ]; then
+      echo "Aborted."
+      exit 1
+    fi
+
+    if ! [[ "$CHOSEN_PORT" =~ ^[0-9]+$ ]] || [ "$CHOSEN_PORT" -lt 1 ] || [ "$CHOSEN_PORT" -gt 65535 ]; then
+      echo "Port must be a number between 1 and 65535."
+      continue
+    fi
+
+    if port_in_use "$CHOSEN_PORT"; then
+      echo "Port :$CHOSEN_PORT is also in use."
+      continue
+    fi
+
+    API_PORT="$CHOSEN_PORT"
+    break
+  done
+fi
+
 # ── Build Rust binary if needed ──
 echo -e "${YELLOW}▶ Building chorus...${RESET}"
 cd "$ROOT"
 cargo build 2>&1 | grep -E "^error|Compiling chorus|Finished" || true
 
 # ── Start Rust server ──
-echo -e "${YELLOW}▶ Starting chorus server on :3001...${RESET}"
-"$ROOT/target/debug/chorus" serve --port 3001 &
+echo -e "${YELLOW}▶ Starting chorus server on :$API_PORT...${RESET}"
+"$ROOT/target/debug/chorus" serve --port "$API_PORT" &
 CHORUS_PID=$!
 
 # ── Wait for server to be ready ──
 for i in $(seq 1 20); do
-  if curl -sf http://localhost:3001/api/whoami > /dev/null 2>&1; then
+  if curl -sf "http://localhost:$API_PORT/api/whoami" > /dev/null 2>&1; then
     break
   fi
   sleep 0.2
@@ -39,13 +75,13 @@ fi
 # ── Start Vite dev server ──
 echo -e "${YELLOW}▶ Starting Vite dev server on :5173...${RESET}"
 cd "$ROOT/ui"
-npm run dev &
+CHORUS_API_PORT="$API_PORT" npm run dev &
 VITE_PID=$!
 
 echo ""
 echo -e "${GREEN}✓ Dev environment running${RESET}"
 echo -e "  UI  → ${CYAN}http://localhost:5173${RESET}"
-echo -e "  API → ${CYAN}http://localhost:3001${RESET}"
+echo -e "  API → ${CYAN}http://localhost:$API_PORT${RESET}"
 echo ""
 echo "Press Ctrl+C to stop all processes."
 

--- a/qa/QA_CASES.md
+++ b/qa/QA_CASES.md
@@ -75,7 +75,7 @@ Cases are split into focused modules under [`cases/`](./cases/):
 | [`cases/channels.md`](./cases/channels.md) | CHN-001, CHN-002, CHN-003, CHN-004 |
 | [`cases/messaging.md`](./cases/messaging.md) | MSG-001, MSG-002, MSG-003, MSG-004, HIS-001, ATT-001, ERR-001 |
 | [`cases/tasks.md`](./cases/tasks.md) | TSK-001, TSK-002 |
-| [`cases/teams.md`](./cases/teams.md) | TMT-001, TMT-002, TMT-003, TMT-004, TMT-005, TMT-006, TMT-007, TMT-008 |
+| [`cases/teams.md`](./cases/teams.md) | TMT-001, TMT-002, TMT-003, TMT-004, TMT-005, TMT-006, TMT-007, TMT-008, TMT-009 |
 | [`cases/shared_memory.md`](./cases/shared_memory.md) | MEM-001, MEM-002, MEM-003, MEM-004, MEM-005, MEM-006, MEM-007, MEM-008, MEM-009, MEM-010 |
 
 ## Maintenance Notes

--- a/qa/cases/playwright/TMT-009.spec.ts
+++ b/qa/cases/playwright/TMT-009.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test'
+import {
+  createTeamApi,
+  ensureMixedRuntimeTrio,
+  getWhoami,
+  historyForUser,
+  stopAgentApi,
+  teamExists,
+  waitForAgentStatus,
+} from './helpers/api'
+import { clickSidebarChannel, openThreadFromMessage, sendChatMessage, sendThreadMessage } from './helpers/ui'
+
+const skipLLM = process.env.CHORUS_E2E_LLM === '0'
+const runtimeMatrix = [
+  { agentName: 'bot-a', runtimeLabel: 'claude', channelName: 'qa-thread-wake-claude' },
+  { agentName: 'bot-c', runtimeLabel: 'codex', channelName: 'qa-thread-wake-codex' },
+]
+
+/**
+ * Catalog: `qa/cases/teams.md` — TMT-009 Agent Team Thread Wake And In-Thread Reply
+ *
+ * Preconditions:
+ * - mixed-runtime trio exists with at least one Claude agent and one Codex agent
+ * - per-runtime team channels exist with the selected agent as a member and the current human user as an observer
+ *
+ * Steps:
+ * 1. For each runtime agent, seed a unique parent message in its team channel.
+ * 2. Stop that agent.
+ * 3. Open the matching team channel.
+ * 4. Open a thread from that parent message.
+ * 5. Ask the stopped agent for an exact-token reply in the thread.
+ * 6. Wait for wake + reply.
+ * 7. Verify the reply stays in the thread.
+ * 8. Verify the top-level channel does not show the thread-only reply.
+ * 9. Verify the agent status is `active`.
+ */
+test.describe('TMT-009', () => {
+  test.beforeAll(async ({ request }) => {
+    await ensureMixedRuntimeTrio(request)
+    const { username } = await getWhoami(request)
+    for (const scenario of runtimeMatrix) {
+      if (await teamExists(request, scenario.channelName)) continue
+      await createTeamApi(request, {
+        name: scenario.channelName,
+        display_name: `QA Thread Wake ${scenario.runtimeLabel}`,
+        collaboration_model: 'leader_operators',
+        leader_agent_name: scenario.agentName,
+        members: [
+          {
+            member_name: scenario.agentName,
+            member_type: 'agent',
+            member_id: scenario.agentName,
+            role: 'leader',
+          },
+          { member_name: username, member_type: 'human', member_id: username, role: 'observer' },
+        ],
+      })
+    }
+  })
+
+  test('Agent Team Thread Wake And In-Thread Reply @case TMT-009', async ({ page, request }) => {
+    test.skip(skipLLM, 'CHORUS_E2E_LLM=0')
+    test.setTimeout(420_000)
+
+    const { username } = await getWhoami(request)
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    for (const scenario of runtimeMatrix) {
+      const parentToken = `tmt9-parent-${scenario.runtimeLabel}-${Date.now()}`
+      const replyToken = `tmt9-thread-${scenario.runtimeLabel}-${Date.now()}`
+
+      await test.step(
+        `Steps 1–5 (${scenario.runtimeLabel}): Seed ${scenario.agentName} parent, stop it, open team thread, and send thread prompt`,
+        async () => {
+          const seededParent = await request.post(`/internal/agent/${scenario.agentName}/send`, {
+            data: {
+              target: `#${scenario.channelName}`,
+              content: `Parent marker ${parentToken}`,
+            },
+          })
+          expect(seededParent.ok(), await seededParent.text()).toBeTruthy()
+
+          await stopAgentApi(request, scenario.agentName)
+          await clickSidebarChannel(page, scenario.channelName)
+          await openThreadFromMessage(page, parentToken)
+          await sendThreadMessage(
+            page,
+            `@${scenario.agentName} reply in this thread with exact token ${replyToken}`
+          )
+        }
+      )
+
+      await test.step(
+        `Steps 6–9 (${scenario.runtimeLabel}): Wake ${scenario.agentName}, verify reply remains in thread, and top-level stays clean`,
+        async () => {
+          await waitForAgentStatus(request, scenario.agentName, 'active', 120_000)
+
+          const deadline = Date.now() + 120_000
+          let parentId: string | undefined
+          let sawThreadReply = false
+
+          while (Date.now() < deadline) {
+            const topLevelHistory = await historyForUser(request, username, `#${scenario.channelName}`, 50)
+            const parentMessage = topLevelHistory.find((message) =>
+              (message.content ?? '').includes(parentToken)
+            )
+            parentId = parentMessage?.id
+
+            if (parentId) {
+              const threadHistory = await historyForUser(
+                request,
+                username,
+                `#${scenario.channelName}:${parentId.slice(0, 8)}`,
+                50
+              )
+              sawThreadReply = threadHistory.some(
+                (message) =>
+                  message.senderName === scenario.agentName &&
+                  (message.content ?? '').includes(replyToken)
+              )
+              if (sawThreadReply) {
+                expect(
+                  topLevelHistory.some((message) => (message.content ?? '').includes(replyToken))
+                ).toBe(false)
+                break
+              }
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 4000))
+          }
+
+          expect(parentId).toBeTruthy()
+          expect(sawThreadReply).toBe(true)
+          await expect(page.locator('.thread-panel')).toContainText(replyToken)
+        }
+      )
+    }
+  })
+})

--- a/qa/cases/playwright/helpers/ui.ts
+++ b/qa/cases/playwright/helpers/ui.ts
@@ -104,6 +104,8 @@ export async function closeMembersPanel(page: Page): Promise<void> {
 export async function openThreadFromMessage(page: Page, contentSnippet: string): Promise<void> {
   const msg = page.locator('.message-item').filter({ hasText: contentSnippet }).first()
   await expect(msg).toBeVisible()
+  await msg.hover()
+  await expect(msg.locator('.message-action-btn[title="Reply in thread"]')).toBeVisible()
   await msg.locator('.message-action-btn[title="Reply in thread"]').click()
   await expect(page.locator('.thread-panel')).toBeVisible()
 }

--- a/qa/cases/teams.md
+++ b/qa/cases/teams.md
@@ -270,3 +270,40 @@
   - `bot-a` posts `READY:` in `#qa-eng` (Swarm bleed-over)
   - `bot-a` tries to delegate in `#qa-algo` instead of deliberating
   - agent says it belongs to only one team despite being in two
+
+---
+
+### TMT-009 Agent Team Thread Wake And In-Thread Reply
+
+- Tier: 0
+- Release-sensitive: yes when touching agent lifecycle, restart prompts, bridge formatting, thread routing, or team-channel messaging
+- Execution mode: hybrid
+- Goal:
+  - verify a stopped agent can wake and reply in a team thread it already belongs to
+  - verify the reply remains in the thread and does not flatten into the top-level team timeline
+- Script:
+  - [`playwright/TMT-009.spec.ts`](./playwright/TMT-009.spec.ts) (runtime matrix across supported agents; hybrid setup for agent-authored parent; browser thread flow; hybrid API polling for exact thread history and agent status)
+- Preconditions:
+  - mixed-runtime trio exists with at least one Claude agent and one Codex agent
+  - per-runtime team channels exist with the selected agent as a member and the current human user as an observer
+- Steps:
+  1. For each supported runtime under test, seed a unique top-level parent message from that agent in its team channel.
+  2. Stop that agent so the next thread message must wake it.
+  3. Open the team channel.
+  4. Open a thread from the agent-authored parent message.
+  5. In the thread, send a message asking the stopped agent to reply with an exact token.
+  6. Wait for the agent to wake and reply.
+  7. Verify the exact-token reply appears in the thread.
+  8. Verify the top-level team timeline does not show the thread-only reply as a normal channel message.
+  9. Open the agent profile or poll agent state and verify the wake path returned it to `active`.
+- Expected:
+  - stopped agents across supported runtimes wake from a thread where they are already the parent author
+  - reply appears under the same thread target
+  - top-level team timeline still contains only the parent message
+  - lifecycle status and visible thread history agree
+- Common failure signals:
+  - one runtime wakes correctly while another does not
+  - stopped agent never wakes on a thread it owns
+  - agent wakes but posts in `#qa-codex-thread` top-level instead of the thread
+  - agent replies in the wrong target or drops the exact token request
+  - profile shows active but thread history never updates

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -610,7 +610,8 @@ fn build_wake_message_prompt(
 }
 
 /// Convert the stored message shape into the human-facing target label used in
-/// prompts, matching channel, DM, and thread semantics.
+/// prompts. For threads we preserve the exact reply target so restarted
+/// runtimes can respond in-place without reconstructing the short id.
 fn format_message_target(message: &ReceivedMessage) -> String {
     match message.channel_type.as_str() {
         "dm" => format!("dm:@{}", message.channel_name),
@@ -619,9 +620,13 @@ fn format_message_target(message: &ReceivedMessage) -> String {
                 .parent_channel_name
                 .as_deref()
                 .unwrap_or(&message.channel_name);
+            let short_id = message
+                .channel_name
+                .strip_prefix("thread-")
+                .unwrap_or(&message.channel_name);
             match message.parent_channel_type.as_deref() {
-                Some("dm") => format!("dm:@{parent_name} thread"),
-                _ => format!("#{parent_name} thread"),
+                Some("dm") => format!("dm:@{parent_name}:{short_id}"),
+                _ => format!("#{parent_name}:{short_id}"),
             }
         }
         _ => format!("#{}", message.channel_name),
@@ -715,6 +720,21 @@ mod tests {
         .expect("wake message fixture should deserialize")
     }
 
+    fn sample_thread_wake_message() -> ReceivedMessage {
+        serde_json::from_value(json!({
+            "message_id": "reply-1",
+            "channel_name": "thread-a1b2c3d4",
+            "channel_type": "thread",
+            "parent_channel_name": "eng-team",
+            "parent_channel_type": "channel",
+            "sender_name": "alice",
+            "sender_type": "human",
+            "content": "Please reply in the team thread.",
+            "timestamp": "2026-03-22T12:00:00Z"
+        }))
+        .expect("thread wake message fixture should deserialize")
+    }
+
     #[test]
     fn wake_prompt_for_resumed_agent_mentions_check_and_wait_tools() {
         let config = sample_config(Some("thread-123"));
@@ -752,6 +772,25 @@ mod tests {
         assert!(prompt.contains("BASE PROMPT"));
         assert!(prompt.contains("Treat this preview as wake-up context only."));
         assert!(prompt.contains("Target: #general"));
+    }
+
+    #[test]
+    fn wake_prompt_for_thread_message_uses_exact_reply_target() {
+        let config = sample_config(Some("thread-123"));
+        let driver = FakeDriver;
+        let prompt = build_start_prompt(
+            &config,
+            &driver,
+            true,
+            &std::collections::HashMap::new(),
+            Some(&sample_thread_wake_message()),
+        );
+
+        assert!(prompt.contains("Target: #eng-team:a1b2c3d4"));
+        assert!(
+            !prompt.contains("Target: #eng-team thread"),
+            "wake prompts must preserve the exact thread target so resumed agents can reply in place"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -421,3 +421,113 @@ async fn test_multi_agent_channel_communication() {
         .unwrap();
     assert_eq!(resp["messages"].as_array().unwrap().len(), 1);
 }
+
+/// Test 7: Team thread targets round-trip correctly for Codex agents
+#[tokio::test]
+async fn test_team_thread_target_round_trip_for_codex_agent() {
+    let (url, store) = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    let team_id = store
+        .create_team("qa-eng", "QA Engineering", "leader_operators", Some("bot1"))
+        .unwrap();
+    store
+        .create_channel("qa-eng", Some("QA Engineering"), ChannelType::Team)
+        .unwrap();
+    store
+        .create_agent_record("bot1", "Bot 1", None, "codex", "gpt-5.4-mini", &[])
+        .unwrap();
+    store
+        .add_team_member(&team_id, "bot1", "agent", "bot1", "leader")
+        .unwrap();
+    store
+        .add_team_member(&team_id, "testuser", "human", "testuser", "observer")
+        .unwrap();
+    store
+        .join_channel("qa-eng", "bot1", SenderType::Agent)
+        .unwrap();
+    store
+        .join_channel("qa-eng", "testuser", SenderType::Human)
+        .unwrap();
+
+    let parent_resp: serde_json::Value = client
+        .post(format!("{url}/internal/agent/bot1/send"))
+        .json(&serde_json::json!({
+            "target": "#qa-eng",
+            "content": "bot1 team parent"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let parent_id = parent_resp["messageId"].as_str().unwrap();
+    let short_id = &parent_id[..8];
+    let thread_target = format!("#qa-eng:{short_id}");
+
+    let send_resp = client
+        .post(format!("{url}/internal/agent/testuser/send"))
+        .json(&serde_json::json!({
+            "target": thread_target,
+            "content": "please stay in the team thread"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(send_resp.status().is_success());
+
+    let thread_history: serde_json::Value = client
+        .get(format!(
+            "{url}/internal/agent/testuser/history?channel={}&limit=10",
+            urlencoding::encode(&format!("#qa-eng:{short_id}"))
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let thread_messages = thread_history["messages"].as_array().unwrap();
+    assert_eq!(thread_messages.len(), 1);
+    assert_eq!(
+        thread_messages[0]["content"].as_str().unwrap(),
+        "please stay in the team thread"
+    );
+    assert_eq!(
+        thread_messages[0]["senderName"].as_str().unwrap(),
+        "testuser"
+    );
+
+    let top_level_history: serde_json::Value = client
+        .get(format!(
+            "{url}/internal/agent/testuser/history?channel=%23qa-eng&limit=10"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let top_level_messages = top_level_history["messages"].as_array().unwrap();
+    assert_eq!(top_level_messages.len(), 1);
+    assert_eq!(
+        top_level_messages[0]["content"].as_str().unwrap(),
+        "bot1 team parent"
+    );
+
+    let receive_resp: serde_json::Value = client
+        .get(format!("{url}/internal/agent/bot1/receive?block=false"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let received_messages = receive_resp["messages"].as_array().unwrap();
+    assert!(received_messages.iter().any(|message| {
+        message["channel_type"].as_str() == Some("thread")
+            && message["parent_channel_name"].as_str() == Some("qa-eng")
+            && message["content"].as_str() == Some("please stay in the team thread")
+    }));
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const apiPort = process.env.CHORUS_API_PORT ?? '3001'
+
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/internal': 'http://localhost:3001',
-      '/api': 'http://localhost:3001',
+      '/internal': `http://localhost:${apiPort}`,
+      '/api': `http://localhost:${apiPort}`,
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- preserve exact thread targets in agent wake prompts so resumed runtimes reply in-thread
- add and generalize TMT-009 to cover team-thread wake/reply behavior across runtimes
- prompt for an alternate API port in dev.sh when :3001 is already in use

## Verification
- cargo test test_team_thread_target_round_trip_for_codex_agent
- cd ui && npm run build
- CHORUS_BASE_URL=http://127.0.0.1:3101 npx playwright test TMT-009.spec.ts --reporter=list