### PR TITLE
feat(runtime): detect local install and auth status

### DIFF
--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -1,15 +1,16 @@
 use std::io::Write as _;
 use std::process::{Child, Command, Stdio};
 
-use super::{Driver, ParsedEvent, SpawnContext};
+use super::{command_exists, run_command, Driver, ParsedEvent, SpawnContext};
 use crate::agent::drivers::prompt::{build_base_system_prompt, PromptOptions};
-use crate::store::agents::AgentConfig;
+use crate::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus};
+use crate::store::agents::{AgentConfig, AgentRuntime};
 
 pub struct ClaudeDriver;
 
 impl Driver for ClaudeDriver {
-    fn id(&self) -> &str {
-        "claude"
+    fn runtime(&self) -> AgentRuntime {
+        AgentRuntime::Claude
     }
 
     fn supports_stdin_notification(&self) -> bool {
@@ -332,5 +333,36 @@ impl Driver for ClaudeDriver {
             "mcp__chat__upload_file" => str_field("file_path"),
             _ => String::new(),
         }
+    }
+
+    fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus> {
+        if !command_exists("claude") {
+            return Ok(RuntimeStatus {
+                runtime: self.id().to_string(),
+                installed: false,
+                auth_status: None,
+            });
+        }
+
+        let auth_status = run_command("claude", &["auth", "status"])
+            .ok()
+            .and_then(|result| {
+                if !result.success {
+                    return Some(RuntimeAuthStatus::Unauthed);
+                }
+                let payload: serde_json::Value = serde_json::from_str(&result.stdout).ok()?;
+                Some(if payload["loggedIn"].as_bool().unwrap_or(false) {
+                    RuntimeAuthStatus::Authed
+                } else {
+                    RuntimeAuthStatus::Unauthed
+                })
+            })
+            .unwrap_or(RuntimeAuthStatus::Unauthed);
+
+        Ok(RuntimeStatus {
+            runtime: self.id().to_string(),
+            installed: true,
+            auth_status: Some(auth_status),
+        })
     }
 }

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -1,8 +1,9 @@
 use std::process::{Child, Command, Stdio};
 
 use super::prompt::{build_base_system_prompt, PromptOptions};
-use super::{Driver, ParsedEvent, SpawnContext};
-use crate::store::agents::AgentConfig;
+use super::{command_exists, run_command, Driver, ParsedEvent, SpawnContext};
+use crate::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus};
+use crate::store::agents::{AgentConfig, AgentRuntime};
 
 pub struct CodexDriver;
 
@@ -58,8 +59,8 @@ fn build_codex_args(ctx: &SpawnContext) -> anyhow::Result<Vec<String>> {
 }
 
 impl Driver for CodexDriver {
-    fn id(&self) -> &str {
-        "codex"
+    fn runtime(&self) -> AgentRuntime {
+        AgentRuntime::Codex
     }
 
     fn supports_stdin_notification(&self) -> bool {
@@ -443,6 +444,36 @@ impl Driver for CodexDriver {
             _ => String::new(),
         }
     }
+
+    fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus> {
+        if !command_exists("codex") {
+            return Ok(RuntimeStatus {
+                runtime: self.id().to_string(),
+                installed: false,
+                auth_status: None,
+            });
+        }
+
+        let auth_status = run_command("codex", &["login", "status"])
+            .ok()
+            .map(|result| codex_auth_status_from_probe(&result))
+            .unwrap_or(RuntimeAuthStatus::Unauthed);
+
+        Ok(RuntimeStatus {
+            runtime: self.id().to_string(),
+            installed: true,
+            auth_status: Some(auth_status),
+        })
+    }
+}
+
+fn codex_auth_status_from_probe(result: &super::CommandProbeResult) -> RuntimeAuthStatus {
+    let combined = format!("{}\n{}", result.stdout, result.stderr).to_ascii_lowercase();
+    if result.success && combined.contains("logged in") {
+        RuntimeAuthStatus::Authed
+    } else {
+        RuntimeAuthStatus::Unauthed
+    }
 }
 
 #[cfg(test)]
@@ -473,5 +504,16 @@ mod tests {
 
         let args = build_codex_args(&ctx).unwrap();
         assert!(args.contains(&"model_reasoning_effort=\"low\"".to_string()));
+    }
+
+    #[test]
+    fn codex_runtime_status_treats_stderr_logged_in_message_as_authed() {
+        let status = codex_auth_status_from_probe(&super::super::CommandProbeResult {
+            success: true,
+            stdout: String::new(),
+            stderr: "WARNING: proceeding\nLogged in using ChatGPT\n".to_string(),
+        });
+
+        assert_eq!(status, RuntimeAuthStatus::Authed);
     }
 }

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -1,9 +1,11 @@
 use std::io::Write as _;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
-use super::{Driver, ParsedEvent, SpawnContext};
+use super::{command_exists, home_dir, read_file, Driver, ParsedEvent, SpawnContext};
 use crate::agent::drivers::prompt::{build_base_system_prompt, PromptOptions};
-use crate::store::agents::AgentConfig;
+use crate::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus};
+use crate::store::agents::{AgentConfig, AgentRuntime};
 
 pub struct KimiDriver;
 
@@ -27,8 +29,8 @@ fn normalize_kimi_tool_name(name: &str) -> String {
 }
 
 impl Driver for KimiDriver {
-    fn id(&self) -> &str {
-        "kimi"
+    fn runtime(&self) -> AgentRuntime {
+        AgentRuntime::Kimi
     }
 
     fn supports_stdin_notification(&self) -> bool {
@@ -304,11 +306,52 @@ impl Driver for KimiDriver {
             _ => String::new(),
         }
     }
+
+    fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus> {
+        detect_kimi_runtime_status(self.id(), &home_dir())
+    }
+}
+
+fn detect_kimi_runtime_status(runtime_id: &str, home: &Path) -> anyhow::Result<RuntimeStatus> {
+    if !command_exists("kimi") {
+        return Ok(RuntimeStatus {
+            runtime: runtime_id.to_string(),
+            installed: false,
+            auth_status: None,
+        });
+    }
+
+    let auth_status = read_file(&home.join(".kimi/credentials/kimi-code.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .map(|payload| {
+            let has_access = payload["access_token"]
+                .as_str()
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false);
+            let has_refresh = payload["refresh_token"]
+                .as_str()
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false);
+            if has_access || has_refresh {
+                RuntimeAuthStatus::Authed
+            } else {
+                RuntimeAuthStatus::Unauthed
+            }
+        })
+        .unwrap_or(RuntimeAuthStatus::Unauthed);
+
+    Ok(RuntimeStatus {
+        runtime: runtime_id.to_string(),
+        installed: true,
+        auth_status: Some(auth_status),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn kimi_parse_line_maps_documented_assistant_text_output() {
@@ -371,5 +414,26 @@ mod tests {
             driver.summarize_tool_input("read_history", &input),
             "#common-feature-squad"
         );
+    }
+
+    #[test]
+    fn kimi_runtime_status_reads_local_credentials() {
+        let dir = tempdir().unwrap();
+        let credentials_dir = dir.path().join(".kimi/credentials");
+        std::fs::create_dir_all(&credentials_dir).unwrap();
+        std::fs::write(
+            credentials_dir.join("kimi-code.json"),
+            r#"{"access_token":"token","refresh_token":""}"#,
+        )
+        .unwrap();
+
+        let status = detect_kimi_runtime_status("kimi", dir.path()).unwrap();
+
+        assert_eq!(status.runtime, "kimi");
+        if status.installed {
+            assert_eq!(status.auth_status, Some(RuntimeAuthStatus::Authed));
+        } else {
+            assert_eq!(status.auth_status, None);
+        }
     }
 }

--- a/src/agent/drivers/mod.rs
+++ b/src/agent/drivers/mod.rs
@@ -3,7 +3,17 @@ pub mod codex;
 pub mod kimi;
 pub mod prompt;
 
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::Child;
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::Context;
+
+use crate::agent::runtime_status::RuntimeStatus;
+use crate::store::agents::AgentRuntime;
 
 /// Events parsed from agent CLI stdout.
 #[derive(Debug, Clone)]
@@ -43,7 +53,10 @@ pub struct SpawnContext {
 /// Runtime driver for a specific CLI (Claude, Codex, etc.)
 pub trait Driver: Send + Sync {
     /// Return the stable runtime identifier persisted in agent records.
-    fn id(&self) -> &str;
+    fn runtime(&self) -> AgentRuntime;
+    fn id(&self) -> &str {
+        self.runtime().as_str()
+    }
     /// Report whether the runtime can be nudged via stdin after startup.
     fn supports_stdin_notification(&self) -> bool;
     /// Return the MCP tool namespace prefix emitted by this runtime.
@@ -64,4 +77,56 @@ pub trait Driver: Send + Sync {
     fn tool_display_name(&self, name: &str) -> String;
     /// Produce a compact summary of tool input for UI activity rows and tracing.
     fn summarize_tool_input(&self, name: &str, input: &serde_json::Value) -> String;
+    /// Detect whether the runtime is installed and authenticated on this machine.
+    fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus>;
+}
+
+pub fn all_runtime_drivers() -> Vec<Arc<dyn Driver>> {
+    vec![
+        Arc::new(claude::ClaudeDriver),
+        Arc::new(codex::CodexDriver),
+        Arc::new(kimi::KimiDriver),
+    ]
+}
+
+pub(crate) fn command_exists(command: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).collect::<Vec<_>>())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|dir| dir.join(command))
+        .any(|candidate| {
+            fs::metadata(&candidate)
+                .map(|metadata| metadata.is_file() && (metadata.permissions().mode() & 0o111) != 0)
+                .unwrap_or(false)
+        })
+}
+
+pub(crate) fn run_command(program: &str, args: &[&str]) -> anyhow::Result<CommandProbeResult> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run {program} {}", args.join(" ")))?;
+    Ok(CommandProbeResult {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+pub(crate) fn read_file(path: &Path) -> anyhow::Result<String> {
+    fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))
+}
+
+pub(crate) fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandProbeResult {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
 }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, info, warn};
 use crate::agent::activity_log::{self, ActivityEntry, ActivityLogMap, ActivityLogResponse};
 use crate::agent::drivers::{Driver, ParsedEvent, SpawnContext};
 use crate::agent::AgentLifecycle;
-use crate::store::agents::{AgentConfig, AgentStatus};
+use crate::store::agents::{AgentConfig, AgentRuntime, AgentStatus};
 use crate::store::messages::ReceivedMessage;
 use crate::store::Store;
 
@@ -35,11 +35,11 @@ pub struct AgentManager {
 }
 
 fn get_driver(runtime: &str) -> anyhow::Result<Arc<dyn Driver>> {
-    match runtime {
-        "claude" => Ok(Arc::new(crate::agent::drivers::claude::ClaudeDriver)),
-        "codex" => Ok(Arc::new(crate::agent::drivers::codex::CodexDriver)),
-        "kimi" => Ok(Arc::new(crate::agent::drivers::kimi::KimiDriver)),
-        _ => anyhow::bail!("Unknown runtime: {runtime}"),
+    match AgentRuntime::parse(runtime) {
+        Some(AgentRuntime::Claude) => Ok(Arc::new(crate::agent::drivers::claude::ClaudeDriver)),
+        Some(AgentRuntime::Codex) => Ok(Arc::new(crate::agent::drivers::codex::CodexDriver)),
+        Some(AgentRuntime::Kimi) => Ok(Arc::new(crate::agent::drivers::kimi::KimiDriver)),
+        None => anyhow::bail!("Unknown runtime: {runtime}"),
     }
 }
 
@@ -81,15 +81,15 @@ impl AgentManager {
             .ok_or_else(|| anyhow::anyhow!("Agent not found: {agent_name}"))?;
 
         let driver = get_driver(&agent.runtime)?;
-        let resumable_session_id = match driver.id() {
-            "codex" => agent.session_id.clone(),
-            "kimi" => Some(
+        let resumable_session_id = match driver.runtime() {
+            AgentRuntime::Codex => agent.session_id.clone(),
+            AgentRuntime::Kimi => Some(
                 agent
                     .session_id
                     .clone()
                     .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
             ),
-            _ => None,
+            AgentRuntime::Claude => None,
         };
 
         let config = AgentConfig {
@@ -138,7 +138,7 @@ impl AgentManager {
         );
 
         let running_session_id = config.session_id.clone();
-        if driver.id() == "kimi" {
+        if driver.runtime() == AgentRuntime::Kimi {
             if let Some(ref session_id) = running_session_id {
                 self.store
                     .update_agent_session(agent_name, Some(session_id.as_str()))?;
@@ -322,7 +322,7 @@ impl AgentManager {
                     continue;
                 }
 
-                if driver.id() == "kimi" {
+                if driver.runtime() == AgentRuntime::Kimi {
                     debug!(agent = %name, raw_stdout = %line, "raw agent stdout");
                     activity_log::push_activity(
                         &activity_logs,
@@ -707,8 +707,8 @@ mod tests {
     struct FakeDriver;
 
     impl Driver for FakeDriver {
-        fn id(&self) -> &str {
-            "codex"
+        fn runtime(&self) -> AgentRuntime {
+            AgentRuntime::Codex
         }
 
         fn supports_stdin_notification(&self) -> bool {
@@ -741,6 +741,16 @@ mod tests {
 
         fn summarize_tool_input(&self, _name: &str, _input: &serde_json::Value) -> String {
             String::new()
+        }
+
+        fn detect_runtime_status(
+            &self,
+        ) -> anyhow::Result<crate::agent::runtime_status::RuntimeStatus> {
+            Ok(crate::agent::runtime_status::RuntimeStatus {
+                runtime: self.id().to_string(),
+                installed: true,
+                auth_status: Some(crate::agent::runtime_status::RuntimeAuthStatus::Authed),
+            })
         }
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod collaboration;
 pub mod drivers;
 pub mod lifecycle;
 pub mod manager;
+pub mod runtime_status;
 pub mod workspace;
 
 pub use lifecycle::AgentLifecycle;

--- a/src/agent/runtime_status.rs
+++ b/src/agent/runtime_status.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent::drivers::all_runtime_drivers;
+
+/// Authentication state for a locally installed agent runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAuthStatus {
+    Authed,
+    Unauthed,
+}
+
+/// Installation and authentication summary for one supported runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeStatus {
+    pub runtime: String,
+    pub installed: bool,
+    #[serde(rename = "authStatus", skip_serializing_if = "Option::is_none")]
+    pub auth_status: Option<RuntimeAuthStatus>,
+}
+
+/// Backend service used by HTTP handlers to query local runtime availability.
+pub trait RuntimeStatusProvider: Send + Sync {
+    fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatus>>;
+}
+
+/// Shared trait alias used by the server state.
+pub type SharedRuntimeStatusProvider = Arc<dyn RuntimeStatusProvider>;
+
+/// Production runtime status provider backed by per-driver probes.
+pub struct SystemRuntimeStatusProvider;
+
+impl RuntimeStatusProvider for SystemRuntimeStatusProvider {
+    fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatus>> {
+        all_runtime_drivers()
+            .into_iter()
+            .map(|driver| driver.detect_runtime_status())
+            .collect()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use chorus::agent::manager::AgentManager;
 use chorus::bridge;
 use chorus::server::build_router_with_lifecycle;
-use chorus::store::agents::AgentStatus;
+use chorus::store::agents::{AgentRuntime, AgentStatus};
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::SenderType;
 use chorus::store::Store;
@@ -103,9 +103,9 @@ fn default_data_dir() -> String {
 }
 
 fn default_model_for_runtime(runtime: &str) -> &str {
-    match runtime {
-        "codex" => "gpt-5.4",
-        "kimi" => "kimi-code/kimi-for-coding",
+    match AgentRuntime::parse(runtime) {
+        Some(AgentRuntime::Codex) => "gpt-5.4",
+        Some(AgentRuntime::Kimi) => "kimi-code/kimi-for-coding",
         _ => "sonnet",
     }
 }

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use super::{acquire_transition, api_err, internal_err, ApiResult, AppState};
 use crate::agent::activity_log::ActivityLogResponse;
 use crate::agent::workspace::AgentWorkspace;
-use crate::store::agents::{AgentEnvVar, AgentStatus};
+use crate::store::agents::{AgentEnvVar, AgentRuntime, AgentStatus};
 use crate::store::messages::SenderType;
 use crate::store::AgentRecordUpsert;
 
@@ -100,7 +100,7 @@ pub enum DeleteMode {
 }
 
 pub(super) fn default_runtime() -> String {
-    "claude".to_string()
+    AgentRuntime::Claude.as_str().to_string()
 }
 
 pub(super) fn default_model() -> String {
@@ -144,7 +144,7 @@ pub(super) fn normalize_reasoning_effort(
     runtime: &str,
     reasoning_effort: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, Json<super::ErrorResponse>)> {
-    if runtime != "codex" {
+    if AgentRuntime::parse(runtime) != Some(AgentRuntime::Codex) {
         return Ok(None);
     }
 

--- a/src/server/handlers/dto.rs
+++ b/src/server/handlers/dto.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::agent::runtime_status::RuntimeAuthStatus;
 use crate::store::agents::{Agent, Human};
 use crate::store::channels::{Channel, ChannelType};
 use crate::store::Store;
@@ -79,6 +80,18 @@ pub struct AgentInfo {
     /// Longer activity text for tooltips / panels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activity_detail: Option<String>,
+}
+
+/// Local machine status for a supported CLI runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeStatusInfo {
+    /// Driver key, e.g. `claude`, `codex`, `kimi`.
+    pub runtime: String,
+    /// Whether the executable is present on the local machine.
+    pub installed: bool,
+    /// Authentication state when the runtime is installed.
+    #[serde(rename = "authStatus", skip_serializing_if = "Option::is_none")]
+    pub auth_status: Option<RuntimeAuthStatus>,
 }
 
 /// Human user row for server info and shell.

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -26,6 +26,7 @@ use axum::http::StatusCode;
 use axum::Json;
 use tracing::debug;
 
+use crate::agent::runtime_status::SharedRuntimeStatusProvider;
 use crate::agent::AgentLifecycle;
 use crate::store::Store;
 
@@ -45,6 +46,7 @@ pub type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
 pub struct AppState {
     pub store: Arc<Store>,
     pub lifecycle: Arc<dyn AgentLifecycle>,
+    pub runtime_status_provider: SharedRuntimeStatusProvider,
     pub transitioning_agents: Arc<Mutex<HashSet<String>>>,
 }
 
@@ -125,4 +127,21 @@ pub async fn handle_ui_server_info(State(state): State<AppState>) -> ApiResult<s
     let info = server_info::build_ui_shell_info(state.store.as_ref())
         .map_err(|e| api_err(e.to_string()))?;
     Ok(Json(serde_json::to_value(info).unwrap()))
+}
+
+pub async fn handle_list_runtime_statuses(
+    State(state): State<AppState>,
+) -> ApiResult<Vec<dto::RuntimeStatusInfo>> {
+    let statuses = state
+        .runtime_status_provider
+        .list_statuses()
+        .map_err(|e| internal_err(e.to_string()))?
+        .into_iter()
+        .map(|status| dto::RuntimeStatusInfo {
+            runtime: status.runtime,
+            installed: status.installed,
+            auth_status: status.auth_status,
+        })
+        .collect();
+    Ok(Json(statuses))
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ use axum::Router;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 
+use crate::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
 use crate::agent::{AgentLifecycle, NoopAgentLifecycle};
 use crate::store::Store;
 
@@ -23,6 +24,18 @@ pub fn build_router_with_lifecycle(
     store: Arc<Store>,
     lifecycle: Arc<dyn AgentLifecycle>,
 ) -> Router {
+    build_router_with_services(
+        store,
+        lifecycle,
+        Arc::new(SystemRuntimeStatusProvider) as SharedRuntimeStatusProvider,
+    )
+}
+
+pub fn build_router_with_services(
+    store: Arc<Store>,
+    lifecycle: Arc<dyn AgentLifecycle>,
+    runtime_status_provider: SharedRuntimeStatusProvider,
+) -> Router {
     use handlers::*;
 
     let cors = CorsLayer::new()
@@ -33,6 +46,7 @@ pub fn build_router_with_lifecycle(
     let state = AppState {
         store,
         lifecycle,
+        runtime_status_provider,
         transitioning_agents: Arc::new(Mutex::new(HashSet::new())),
     };
 
@@ -79,6 +93,7 @@ pub fn build_router_with_lifecycle(
             "/api/agents",
             get(handle_list_agents).post(handle_create_agent),
         )
+        .route("/api/runtimes", get(handle_list_runtime_statuses))
         .route(
             "/api/teams",
             get(handle_list_teams).post(handle_create_team),

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -79,6 +79,34 @@ impl AgentStatus {
     }
 }
 
+/// Supported local agent runtimes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntime {
+    Claude,
+    Codex,
+    Kimi,
+}
+
+impl AgentRuntime {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Kimi => "kimi",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "kimi" => Some(Self::Kimi),
+            _ => None,
+        }
+    }
+}
+
 /// Snapshot passed to the bridge when spawning an agent (includes team context).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -1,11 +1,13 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use chorus::agent::activity_log::{ActivityEntry, ActivityLogResponse};
+use chorus::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus, RuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
 use chorus::server::dto::ChannelInfo;
 use chorus::server::dto::ServerInfo;
 use chorus::server::{
-    build_router, build_router_with_lifecycle, AgentDetailResponse, HistoryResponse,
+    build_router, build_router_with_lifecycle, build_router_with_services, AgentDetailResponse,
+    HistoryResponse,
 };
 use chorus::store::agents::AgentStatus;
 use chorus::store::channels::ChannelType;
@@ -72,6 +74,16 @@ struct MockLifecycle {
     stopped: Mutex<Vec<String>>,
     notified: Mutex<Vec<String>>,
     activity_logs: ActivityLogMap,
+}
+
+struct MockRuntimeStatusProvider {
+    statuses: Vec<RuntimeStatus>,
+}
+
+impl RuntimeStatusProvider for MockRuntimeStatusProvider {
+    fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatus>> {
+        Ok(self.statuses.clone())
+    }
 }
 
 impl MockLifecycle {
@@ -166,6 +178,30 @@ fn setup_with_lifecycle() -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
         .unwrap();
     let lifecycle = Arc::new(MockLifecycle::default());
     let router = build_router_with_lifecycle(store.clone(), lifecycle.clone());
+    (store, router, lifecycle)
+}
+
+fn setup_with_runtime_statuses(
+    statuses: Vec<RuntimeStatus>,
+) -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
+    let store = Arc::new(Store::open(":memory:").unwrap());
+    store
+        .create_channel("general", Some("General"), ChannelType::Channel)
+        .unwrap();
+    store.add_human("alice").unwrap();
+    store
+        .join_channel("general", "alice", SenderType::Human)
+        .unwrap();
+    store
+        .create_agent_record("bot1", "Bot 1", None, "claude", "sonnet", &[])
+        .unwrap();
+    store
+        .join_channel("general", "bot1", SenderType::Agent)
+        .unwrap();
+    let lifecycle = Arc::new(MockLifecycle::default());
+    let runtime_status_provider = Arc::new(MockRuntimeStatusProvider { statuses });
+    let router =
+        build_router_with_services(store.clone(), lifecycle.clone(), runtime_status_provider);
     (store, router, lifecycle)
 }
 
@@ -806,6 +842,55 @@ async fn test_whoami() {
         .unwrap();
     let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(val["username"].as_str().is_some(), "username field missing");
+}
+
+#[tokio::test]
+async fn test_list_runtime_statuses() {
+    let (_store, app, _lifecycle) = setup_with_runtime_statuses(vec![
+        RuntimeStatus {
+            runtime: "claude".to_string(),
+            installed: true,
+            auth_status: Some(RuntimeAuthStatus::Authed),
+        },
+        RuntimeStatus {
+            runtime: "codex".to_string(),
+            installed: true,
+            auth_status: Some(RuntimeAuthStatus::Unauthed),
+        },
+        RuntimeStatus {
+            runtime: "kimi".to_string(),
+            installed: false,
+            auth_status: None,
+        },
+    ]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/runtimes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1_000_000)
+        .await
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let runtimes = payload
+        .as_array()
+        .expect("runtimes payload should be an array");
+    assert_eq!(runtimes.len(), 3);
+    assert_eq!(runtimes[0]["runtime"], "claude");
+    assert_eq!(runtimes[0]["installed"], true);
+    assert_eq!(runtimes[0]["authStatus"], "authed");
+    assert_eq!(runtimes[1]["runtime"], "codex");
+    assert_eq!(runtimes[1]["authStatus"], "unauthed");
+    assert_eq!(runtimes[2]["runtime"], "kimi");
+    assert_eq!(runtimes[2]["installed"], false);
+    assert!(runtimes[2].get("authStatus").is_none());
 }
 
 #[tokio::test]

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -14,6 +14,7 @@ import type {
   WorkspaceFileResponse,
   AgentDetailResponse,
   AgentEnvVar,
+  RuntimeStatusInfo,
   ChannelMembersResponse,
   Team,
   TeamResponse,
@@ -56,6 +57,10 @@ export async function listChannels(params?: {
 
 export async function listAgents(): Promise<AgentInfo[]> {
   return json(await fetch(`${BASE}/api/agents`))
+}
+
+export async function listRuntimeStatuses(): Promise<RuntimeStatusInfo[]> {
+  return json(await fetch(`${BASE}/api/runtimes`))
 }
 
 export async function createChannel(payload: {

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
+
+describe('runtimeOptionLabel', () => {
+  it('shows not installed copy when the runtime is missing', () => {
+    expect(
+      runtimeOptionLabel('kimi', [
+        { runtime: 'kimi', installed: false },
+      ])
+    ).toContain('not installed')
+  })
+
+  it('shows signed in copy for authenticated runtimes', () => {
+    expect(
+      runtimeOptionLabel('claude', [
+        { runtime: 'claude', installed: true, authStatus: 'authed' },
+      ])
+    ).toContain('signed in')
+  })
+})
+
+describe('runtimeStatusSummary', () => {
+  it('warns when a runtime is installed but not signed in', () => {
+    expect(
+      runtimeStatusSummary('codex', [
+        { runtime: 'codex', installed: true, authStatus: 'unauthed' },
+      ])
+    ).toEqual({
+      tone: 'warn',
+      title: 'Not signed in',
+      detail:
+        'The CLI is installed, but local authentication needs to be completed before agent startup will work reliably.',
+    })
+  })
+})

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1,4 +1,4 @@
-import type { AgentEnvVar } from '../types'
+import type { AgentEnvVar, RuntimeStatusInfo } from '../types'
 
 export const MODELS: Record<string, { value: string; label: string }[]> = {
   claude: [
@@ -42,11 +42,65 @@ export interface AgentConfigState {
 
 interface Props {
   state: AgentConfigState
+  runtimeStatuses?: RuntimeStatusInfo[]
+  runtimeStatusError?: string | null
   editableName?: boolean
   onChange: (next: AgentConfigState) => void
 }
 
-export function AgentConfigForm({ state, editableName = false, onChange }: Props) {
+export function runtimeOptionLabel(
+  runtime: string,
+  runtimeStatuses: RuntimeStatusInfo[] = [],
+): string {
+  const baseLabel =
+    runtime === 'claude' ? 'Claude Code' : runtime === 'codex' ? 'Codex CLI' : 'Kimi CLI'
+  const status = runtimeStatuses.find((entry) => entry.runtime === runtime)
+  if (!status) return `${baseLabel} · status unavailable`
+  if (!status.installed) return `${baseLabel} · not installed`
+  if (status.authStatus === 'authed') return `${baseLabel} · signed in`
+  return `${baseLabel} · not signed in`
+}
+
+export function runtimeStatusSummary(
+  runtime: string,
+  runtimeStatuses: RuntimeStatusInfo[] = [],
+): { tone: 'ok' | 'warn' | 'muted'; title: string; detail: string } {
+  const status = runtimeStatuses.find((entry) => entry.runtime === runtime)
+  if (!status) {
+    return {
+      tone: 'muted',
+      title: 'Status unavailable',
+      detail: 'The local runtime probe did not return a status for this CLI.',
+    }
+  }
+  if (!status.installed) {
+    return {
+      tone: 'warn',
+      title: 'Not installed',
+      detail: 'This runtime is not available on the local machine yet.',
+    }
+  }
+  if (status.authStatus === 'authed') {
+    return {
+      tone: 'ok',
+      title: 'Signed in',
+      detail: 'This runtime is installed locally and has an active login.',
+    }
+  }
+  return {
+    tone: 'warn',
+    title: 'Not signed in',
+    detail: 'The CLI is installed, but local authentication needs to be completed before agent startup will work reliably.',
+  }
+}
+
+export function AgentConfigForm({
+  state,
+  runtimeStatuses = [],
+  runtimeStatusError = null,
+  editableName = false,
+  onChange,
+}: Props) {
   function updateEnvVar(index: number, key: keyof AgentEnvVar, value: string) {
     const envVars = state.envVars.map((envVar, envIndex) =>
       envIndex === index ? { ...envVar, [key]: value } : envVar
@@ -67,6 +121,8 @@ export function AgentConfigForm({ state, editableName = false, onChange }: Props
       envVars: state.envVars.filter((_, envIndex) => envIndex !== index),
     })
   }
+
+  const runtimeSummary = runtimeStatusSummary(state.runtime, runtimeStatuses)
 
   return (
     <div className="agent-config-form">
@@ -131,10 +187,17 @@ export function AgentConfigForm({ state, editableName = false, onChange }: Props
                 })
               }}
             >
-              <option value="claude">Claude Code</option>
-              <option value="codex">Codex CLI</option>
-              <option value="kimi">Kimi CLI</option>
+              <option value="claude">{runtimeOptionLabel('claude', runtimeStatuses)}</option>
+              <option value="codex">{runtimeOptionLabel('codex', runtimeStatuses)}</option>
+              <option value="kimi">{runtimeOptionLabel('kimi', runtimeStatuses)}</option>
             </select>
+            <div className={`runtime-status-banner runtime-status-banner-${runtimeSummary.tone}`}>
+              <strong>{runtimeSummary.title}</strong>
+              <span>{runtimeSummary.detail}</span>
+            </div>
+            {runtimeStatusError && (
+              <div className="modal-field-hint">{runtimeStatusError}</div>
+            )}
           </div>
 
           <div className="modal-field">

--- a/ui/src/components/CreateAgentModal.tsx
+++ b/ui/src/components/CreateAgentModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useRuntimeStatuses } from '../hooks/useRuntimeStatuses'
 import './ProfilePanel.css'  // reuses modal styles
 import { AgentConfigForm, type AgentConfigState } from './AgentConfigForm'
 
@@ -19,6 +20,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
   })
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { runtimeStatuses, runtimeStatusError } = useRuntimeStatuses()
 
   async function handleCreate() {
     if (!config.name.trim()) {
@@ -71,7 +73,13 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           </select>
         </div>
 
-        <AgentConfigForm state={config} editableName onChange={setConfig} />
+        <AgentConfigForm
+          state={config}
+          runtimeStatuses={runtimeStatuses}
+          runtimeStatusError={runtimeStatusError}
+          editableName
+          onChange={setConfig}
+        />
 
         {error && <div className="modal-error">{error}</div>}
 

--- a/ui/src/components/ProfilePanel.css
+++ b/ui/src/components/ProfilePanel.css
@@ -244,6 +244,42 @@
   gap: 0 12px;
 }
 
+.runtime-status-banner {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.runtime-status-banner strong {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.runtime-status-banner-ok {
+  background: rgba(144, 198, 149, 0.14);
+  border-color: rgba(79, 125, 87, 0.35);
+  color: #23492f;
+}
+
+.runtime-status-banner-warn {
+  background: rgba(214, 165, 73, 0.14);
+  border-color: rgba(162, 115, 34, 0.35);
+  color: #7b4f0f;
+}
+
+.runtime-status-banner-muted {
+  background: rgba(80, 87, 99, 0.08);
+  border-color: rgba(80, 87, 99, 0.2);
+  color: var(--text-secondary);
+}
+
 .modal-accordion-trigger {
   font-size: 13px;
   font-weight: 600;

--- a/ui/src/components/ProfilePanel.tsx
+++ b/ui/src/components/ProfilePanel.tsx
@@ -1,8 +1,20 @@
 import { useEffect, useMemo, useState } from 'react'
-import { deleteAgent, getAgentDetail, restartAgent, startAgent, stopAgent, updateAgent } from '../api'
-import type { AgentDetailResponse } from '../types'
+import {
+  deleteAgent,
+  getAgentDetail,
+  restartAgent,
+  startAgent,
+  stopAgent,
+  updateAgent,
+} from '../api'
+import type { AgentDetailResponse, RuntimeStatusInfo } from '../types'
+import { useRuntimeStatuses } from '../hooks/useRuntimeStatuses'
 import { useApp } from '../store'
-import { AgentConfigForm, type AgentConfigState } from './AgentConfigForm'
+import {
+  AgentConfigForm,
+  runtimeStatusSummary,
+  type AgentConfigState,
+} from './AgentConfigForm'
 import './ProfilePanel.css'
 
 function agentColor(name: string): string {
@@ -39,6 +51,7 @@ export function ProfilePanel() {
   const [error, setError] = useState<string | null>(null)
   const [detail, setDetail] = useState<AgentDetailResponse | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
+  const { runtimeStatuses, runtimeStatusError } = useRuntimeStatuses()
   const [showEdit, setShowEdit] = useState(false)
   const [showRestart, setShowRestart] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
@@ -69,6 +82,7 @@ export function ProfilePanel() {
   const isActive = agent.status === 'active'
   const envVars = detail?.envVars ?? []
   const reasoningEffort = agent.reasoningEffort ?? detail?.agent.reasoningEffort ?? null
+  const runtimeSummary = runtimeStatusSummary(agent.runtime ?? 'claude', runtimeStatuses)
 
   async function handleStartStop() {
     setBusy(true)
@@ -154,6 +168,13 @@ export function ProfilePanel() {
             {agent.status}
           </span>
         </div>
+        <div className={`runtime-status-banner runtime-status-banner-${runtimeSummary.tone}`}>
+          <strong>{runtimeSummary.title}</strong>
+          <span>{runtimeSummary.detail}</span>
+        </div>
+        {runtimeStatusError && (
+          <div className="profile-role-text">{runtimeStatusError}</div>
+        )}
       </div>
 
       <div className="profile-section">
@@ -187,6 +208,8 @@ export function ProfilePanel() {
                 : null,
             envVars: detail.envVars,
           }}
+          runtimeStatuses={runtimeStatuses}
+          runtimeStatusError={runtimeStatusError}
           onClose={() => setShowEdit(false)}
           onSaved={async () => {
             setShowEdit(false)
@@ -224,11 +247,15 @@ export function ProfilePanel() {
 function EditAgentModal({
   agentName,
   initialState,
+  runtimeStatuses,
+  runtimeStatusError,
   onClose,
   onSaved,
 }: {
   agentName: string
   initialState: AgentConfigState
+  runtimeStatuses: RuntimeStatusInfo[]
+  runtimeStatusError: string | null
   onClose: () => void
   onSaved: () => Promise<void>
 }) {
@@ -266,7 +293,7 @@ function EditAgentModal({
           </div>
           <button className="modal-close" onClick={onClose}>×</button>
         </div>
-        <AgentConfigForm state={state} onChange={setState} />
+        <AgentConfigForm state={state} runtimeStatuses={runtimeStatuses} runtimeStatusError={runtimeStatusError} onChange={setState} />
         {error && <div className="modal-error">{error}</div>}
         <div className="modal-footer">
           <button className="btn-secondary" onClick={onClose}>Cancel</button>

--- a/ui/src/hooks/useRuntimeStatuses.ts
+++ b/ui/src/hooks/useRuntimeStatuses.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { listRuntimeStatuses } from '../api'
+import type { RuntimeStatusInfo } from '../types'
+
+export function useRuntimeStatuses(pollMs = 10000): {
+  runtimeStatuses: RuntimeStatusInfo[]
+  runtimeStatusError: string | null
+} {
+  const [runtimeStatuses, setRuntimeStatuses] = useState<RuntimeStatusInfo[]>([])
+  const [runtimeStatusError, setRuntimeStatusError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function refreshRuntimeStatuses() {
+      try {
+        const nextStatuses = await listRuntimeStatuses()
+        if (!cancelled) {
+          setRuntimeStatuses(nextStatuses)
+          setRuntimeStatusError(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setRuntimeStatusError(String(err))
+        }
+      }
+    }
+
+    void refreshRuntimeStatuses()
+    const intervalId = window.setInterval(() => {
+      void refreshRuntimeStatuses()
+    }, pollMs)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+    }
+  }, [pollMs])
+
+  return { runtimeStatuses, runtimeStatusError }
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -29,6 +29,14 @@ export interface AgentEnvVar {
   value: string
 }
 
+export type RuntimeAuthStatus = 'authed' | 'unauthed'
+
+export interface RuntimeStatusInfo {
+  runtime: 'claude' | 'codex' | 'kimi' | string
+  installed: boolean
+  authStatus?: RuntimeAuthStatus
+}
+
 export interface AgentDetailResponse {
   agent: AgentInfo
   envVars: AgentEnvVar[]


### PR DESCRIPTION
## Summary
- add backend runtime install/auth detection for Claude, Codex, and Kimi via the /api/runtimes endpoint
- move runtime detection ownership into the driver trait and replace core runtime string branching with a shared enum
- surface runtime auth/install state in the create/edit flow and profile panel, with periodic refresh to avoid stale UI state

## Test Plan
- [x] cargo test codex_runtime_status_treats_stderr_logged_in_message_as_authed --lib
- [x] cargo test test_list_runtime_statuses --test server_tests
- [x] cargo test --test driver_tests
- [x] cd ui && npm test -- AgentConfigForm.test.ts
- [x] cd ui && npm run build
- [ ] Browser QA not run
