### PR TITLE
refactor(ui): simplify code quality and efficiency issues

### DIFF
--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use axum::extract::{Path, Query, State};
 use axum::Json;
 use regex::Regex;
@@ -305,6 +307,25 @@ fn sender_type_for_actor(
         .unwrap_or(SenderType::Human))
 }
 
+fn require_channel_membership(
+    state: &AppState,
+    actor_id: &str,
+    channel: &Channel,
+    denied_label: &str,
+) -> Result<(), (axum::http::StatusCode, Json<super::ErrorResponse>)> {
+    if !state
+        .store
+        .is_member(&channel.name, actor_id)
+        .map_err(|e| api_err(e.to_string()))?
+    {
+        return Err(api_err(format!(
+            "you are not a member of channel {}",
+            denied_label
+        )));
+    }
+    Ok(())
+}
+
 fn load_channel_by_id(
     store: &Store,
     channel_id: &str,
@@ -326,16 +347,7 @@ fn history_for_channel(
     before: Option<i64>,
     after: Option<i64>,
 ) -> ApiResult<HistoryResponse> {
-    if !state
-        .store
-        .is_member(&channel.name, actor_id)
-        .map_err(|e| api_err(e.to_string()))?
-    {
-        return Err(api_err(format!(
-            "you are not a member of channel {}",
-            denied_label
-        )));
-    }
+    require_channel_membership(state, actor_id, channel, denied_label)?;
 
     let snapshot = state
         .store
@@ -362,16 +374,7 @@ fn threads_for_channel(
     channel: &Channel,
     denied_label: &str,
 ) -> ApiResult<ThreadsResponse> {
-    if !state
-        .store
-        .is_member(&channel.name, actor_id)
-        .map_err(|e| api_err(e.to_string()))?
-    {
-        return Err(api_err(format!(
-            "you are not a member of channel {}",
-            denied_label
-        )));
-    }
+    require_channel_membership(state, actor_id, channel, denied_label)?;
 
     let inbox = state
         .store
@@ -391,16 +394,7 @@ fn update_read_cursor_for_channel(
     thread_parent_id: Option<&str>,
     last_read_seq: i64,
 ) -> ApiResult<ReadCursorResponse> {
-    if !state
-        .store
-        .is_member(&channel.name, actor_id)
-        .map_err(|e| api_err(e.to_string()))?
-    {
-        return Err(api_err(format!(
-            "you are not a member of channel {}",
-            denied_label
-        )));
-    }
+    require_channel_membership(state, actor_id, channel, denied_label)?;
 
     let sender_type = sender_type_for_actor(&state.store, actor_id)?;
     state
@@ -562,6 +556,9 @@ async fn send_message_to_channel(
     }))
 }
 
+static MENTION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"@([A-Za-z0-9_-]+)").expect("team mention regex is valid"));
+
 /// Mirror `@team-name` mentions into the corresponding team channel.
 async fn forward_team_mentions(
     state: &AppState,
@@ -570,8 +567,7 @@ async fn forward_team_mentions(
     sender_type: SenderType,
     content: &str,
 ) -> anyhow::Result<()> {
-    let mention_re = Regex::new(r"@([A-Za-z0-9_-]+)").expect("team mention regex is valid");
-    let mentions = mention_re
+    let mentions = MENTION_RE
         .captures_iter(content)
         .filter_map(|capture| capture.get(1).map(|m| m.as_str().to_string()))
         .collect::<std::collections::BTreeSet<_>>();

--- a/src/store/channels.rs
+++ b/src/store/channels.rs
@@ -293,6 +293,14 @@ impl Store {
             .collect();
 
         conn.execute(
+            "DELETE FROM inbox_thread_read_state WHERE conversation_id = ?1",
+            params![channel_id],
+        )?;
+        conn.execute(
+            "DELETE FROM inbox_read_state WHERE conversation_id = ?1",
+            params![channel_id],
+        )?;
+        conn.execute(
             "DELETE FROM message_attachments WHERE message_id IN (SELECT id FROM messages WHERE channel_id = ?1)",
             params![channel_id],
         )?;

--- a/src/store/inbox.rs
+++ b/src/store/inbox.rs
@@ -512,7 +512,12 @@ impl Store {
             return Ok(None);
         };
         if member_type == SenderType::Agent.as_str() {
-            if !Self::agent_can_access_thread_inner(conn, channel_id, thread_parent_id, member_name)? {
+            if !Self::agent_can_access_thread_inner(
+                conn,
+                channel_id,
+                thread_parent_id,
+                member_name,
+            )? {
                 return Ok(None);
             }
         }

--- a/src/store/inbox.rs
+++ b/src/store/inbox.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use super::channels::Channel;
+use super::messages::SenderType;
 use super::Store;
 
 /// Explicit read-model row for per-member conversation state while inbox
@@ -510,22 +511,8 @@ impl Store {
         let Some(member_type) = member_type else {
             return Ok(None);
         };
-        if member_type == "agent" {
-            let parent_author_matches: i64 = conn.query_row(
-                "SELECT COUNT(*)
-                 FROM messages
-                 WHERE id = ?1 AND channel_id = ?2 AND sender_type = 'agent' AND sender_name = ?3",
-                params![thread_parent_id, channel_id, member_name],
-                |row| row.get(0),
-            )?;
-            let prior_reply_matches: i64 = conn.query_row(
-                "SELECT COUNT(*)
-                 FROM messages
-                 WHERE channel_id = ?1 AND thread_parent_id = ?2 AND sender_type = 'agent' AND sender_name = ?3",
-                params![channel_id, thread_parent_id, member_name],
-                |row| row.get(0),
-            )?;
-            if parent_author_matches == 0 && prior_reply_matches == 0 {
+        if member_type == SenderType::Agent.as_str() {
+            if !Self::agent_can_access_thread_inner(conn, channel_id, thread_parent_id, member_name)? {
                 return Ok(None);
             }
         }

--- a/src/store/inbox.rs
+++ b/src/store/inbox.rs
@@ -511,15 +511,15 @@ impl Store {
         let Some(member_type) = member_type else {
             return Ok(None);
         };
-        if member_type == SenderType::Agent.as_str() {
-            if !Self::agent_can_access_thread_inner(
+        if member_type == SenderType::Agent.as_str()
+            && !Self::agent_can_access_thread_inner(
                 conn,
                 channel_id,
                 thread_parent_id,
                 member_name,
-            )? {
-                return Ok(None);
-            }
+            )?
+        {
+            return Ok(None);
         }
 
         let last_read_seq = conn

--- a/ui/src/components/Channels/CreateChannelModal.tsx
+++ b/ui/src/components/Channels/CreateChannelModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Plus, Users } from 'lucide-react'
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -53,7 +53,10 @@ export function CreateChannelModal({ open, onOpenChange, onCreated, defaultMode 
   const availableMembers = directory.filter(
     (member) => !teamMembers.some((entry) => entry.member_name === member.name)
   )
-  const agentMembers = teamMembers.filter((member) => member.member_type === 'agent')
+  const agentMembers = useMemo(
+    () => teamMembers.filter((member) => member.member_type === 'agent'),
+    [teamMembers]
+  )
 
   useEffect(() => {
     setMode(defaultMode)

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -99,11 +99,12 @@ export function ChatPanel({
   const messageRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const pendingInitialScrollTargetRef = useRef<string | null>(null)
 
-  const { scheduleBatchVisibilityCheck } = useVisibilityTracking(reportVisibleSeq)
+  const { scheduleBatchVisibilityCheck, resetHighestVisibleSeq } = useVisibilityTracking(reportVisibleSeq)
 
   useEffect(() => {
     pendingInitialScrollTargetRef.current = target
-  }, [target])
+    resetHighestVisibleSeq()
+  }, [target, resetHighestVisibleSeq])
 
   useEffect(() => {
     const container = scrollContainerRef.current

--- a/ui/src/components/ThreadPanel.tsx
+++ b/ui/src/components/ThreadPanel.tsx
@@ -205,7 +205,6 @@ export function ThreadPanel({ variant = 'drawer' }: ThreadPanelProps) {
 
   return (
     <div className={`thread-panel${variant === 'content' ? ' thread-panel--content' : ''}`}>
-      {/* Header */}
       <div className="thread-header">
         <div className="thread-header-copy">
           <span className="thread-kicker">[ctx::thread]</span>
@@ -216,7 +215,7 @@ export function ThreadPanel({ variant = 'drawer' }: ThreadPanelProps) {
       </div>
 
       <div className="thread-body" ref={scrollContainerRef}>
-        {/* Parent message (copy only, no reply) */}
+        {/* no onReply — replies aren't nested */}
         <div className="thread-parent-wrapper">
           <MessageItem
             message={openThreadMsg}
@@ -224,7 +223,6 @@ export function ThreadPanel({ variant = 'drawer' }: ThreadPanelProps) {
           />
         </div>
 
-        {/* Replies */}
         <div className="thread-replies">
           {messages.length === 0 ? (
             <div className="thread-empty">No replies yet</div>
@@ -250,7 +248,6 @@ export function ThreadPanel({ variant = 'drawer' }: ThreadPanelProps) {
         </div>
       </div>
 
-      {/* Input */}
       <div className="thread-input-area">
         <div className="thread-input-row">
           <MentionTextarea

--- a/ui/src/components/ThreadPanel.tsx
+++ b/ui/src/components/ThreadPanel.tsx
@@ -61,11 +61,12 @@ export function ThreadPanel({ variant = 'drawer' }: ThreadPanelProps) {
   const messageRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const pendingInitialScrollTargetRef = useRef<string | null>(null)
 
-  const { scheduleBatchVisibilityCheck } = useVisibilityTracking(reportVisibleSeq)
+  const { scheduleBatchVisibilityCheck, resetHighestVisibleSeq } = useVisibilityTracking(reportVisibleSeq)
 
   useEffect(() => {
     pendingInitialScrollTargetRef.current = threadTarget
-  }, [threadTarget])
+    resetHighestVisibleSeq()
+  }, [threadTarget, resetHighestVisibleSeq])
 
   useEffect(() => {
     const container = scrollContainerRef.current

--- a/ui/src/hooks/useVisibilityTracking.ts
+++ b/ui/src/hooks/useVisibilityTracking.ts
@@ -38,6 +38,11 @@ export function useVisibilityTracking(onHighestVisibleSeqChange?: (seq: number) 
   const lastFiredSeqRef = useRef(0)
   onChangeRef.current = onHighestVisibleSeqChange
 
+  const resetHighestVisibleSeq = useCallback(() => {
+    setHighestVisibleSeq(0)
+    lastFiredSeqRef.current = 0
+  }, [])
+
   const flushVisibilityCheck = useCallback(() => {
     if (document.visibilityState !== 'visible') return
 
@@ -85,5 +90,6 @@ export function useVisibilityTracking(onHighestVisibleSeqChange?: (seq: number) 
   return {
     highestVisibleSeq,
     scheduleBatchVisibilityCheck,
+    resetHighestVisibleSeq,
   }
 }

--- a/ui/src/hooks/useVisibilityTracking.ts
+++ b/ui/src/hooks/useVisibilityTracking.ts
@@ -35,6 +35,7 @@ export function useVisibilityTracking(onHighestVisibleSeqChange?: (seq: number) 
   const containerRef = useRef<HTMLElement | null>(null)
   const rafRef = useRef<number | null>(null)
   const onChangeRef = useRef(onHighestVisibleSeqChange)
+  const lastFiredSeqRef = useRef(0)
   onChangeRef.current = onHighestVisibleSeqChange
 
   const flushVisibilityCheck = useCallback(() => {
@@ -51,7 +52,10 @@ export function useVisibilityTracking(onHighestVisibleSeqChange?: (seq: number) 
 
     if (maxSeq > 0) {
       setHighestVisibleSeq((current) => Math.max(current, maxSeq))
-      onChangeRef.current?.(maxSeq)
+      if (maxSeq > lastFiredSeqRef.current) {
+        lastFiredSeqRef.current = maxSeq
+        onChangeRef.current?.(maxSeq)
+      }
     }
 
     pendingReadsRef.current = []

--- a/ui/src/store.tsx
+++ b/ui/src/store.tsx
@@ -83,6 +83,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const selectedChannelIdRef = useRef<string | null>(null)
   const conversationThreadsRefreshInFlight = useRef<Map<string, Promise<void>>>(new Map())
   const inboxRefreshInFlight = useRef<Set<string>>(new Set())
+  // Tracks one trailing re-fetch per key when a message.created event arrives while a fetch is in-flight.
+  // The snapshot endpoint returns current state at request time, so one re-fetch after the in-flight
+  // completes is sufficient to pick up all messages that arrived during the window.
+  const inboxRefreshPending = useRef<Map<string, [string, string | undefined]>>(new Map())
 
   // Fetch current user once on mount
   useEffect(() => {
@@ -238,6 +242,25 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     const targets = conversationRegistry.map((entry) => `conversation:${entry.conversationId}`)
     if (targets.length === 0) return
 
+    const scheduleInboxRefresh = (key: string, channelId: string, threadParentId: string | undefined): void => {
+      inboxRefreshInFlight.current.add(key)
+      void getConversationInboxNotification(channelId, threadParentId)
+        .then((payload) => {
+          setInboxState((current) => mergeInboxNotificationRefresh(current, payload))
+        })
+        .catch((error) => {
+          console.error('Failed to refresh inbox after message', error)
+        })
+        .finally(() => {
+          inboxRefreshInFlight.current.delete(key)
+          const pending = inboxRefreshPending.current.get(key)
+          if (pending) {
+            inboxRefreshPending.current.delete(key)
+            scheduleInboxRefresh(key, ...pending)
+          }
+        })
+    }
+
     return getRealtimeSession(currentUser).subscribe({
       targets,
       onFrame: (frame) => {
@@ -251,18 +274,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           const threadParentId =
             typeof threadRaw === 'string' && threadRaw.length > 0 ? threadRaw : undefined
           const key = `${channelId}:${threadParentId ?? ''}`
-          if (!inboxRefreshInFlight.current.has(key)) {
-            inboxRefreshInFlight.current.add(key)
-            void getConversationInboxNotification(channelId, threadParentId)
-              .then((payload) => {
-                setInboxState((current) => mergeInboxNotificationRefresh(current, payload))
-              })
-              .catch((error) => {
-                console.error('Failed to refresh inbox after message', error)
-              })
-              .finally(() => {
-                inboxRefreshInFlight.current.delete(key)
-              })
+          if (inboxRefreshInFlight.current.has(key)) {
+            inboxRefreshPending.current.set(key, [channelId, threadParentId])
+          } else {
+            scheduleInboxRefresh(key, channelId, threadParentId)
           }
           return
         }

--- a/ui/src/store.tsx
+++ b/ui/src/store.tsx
@@ -82,6 +82,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const selectedChannelRef = useRef<string | null>(null)
   const selectedChannelIdRef = useRef<string | null>(null)
   const conversationThreadsRefreshInFlight = useRef<Map<string, Promise<void>>>(new Map())
+  const inboxRefreshInFlight = useRef<Set<string>>(new Set())
 
   // Fetch current user once on mount
   useEffect(() => {
@@ -249,13 +250,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           const threadRaw = frame.event.payload.threadParentId
           const threadParentId =
             typeof threadRaw === 'string' && threadRaw.length > 0 ? threadRaw : undefined
-          void getConversationInboxNotification(channelId, threadParentId)
-            .then((payload) => {
-              setInboxState((current) => mergeInboxNotificationRefresh(current, payload))
-            })
-            .catch((error) => {
-              console.error('Failed to refresh inbox after message', error)
-            })
+          const key = `${channelId}:${threadParentId ?? ''}`
+          if (!inboxRefreshInFlight.current.has(key)) {
+            inboxRefreshInFlight.current.add(key)
+            void getConversationInboxNotification(channelId, threadParentId)
+              .then((payload) => {
+                setInboxState((current) => mergeInboxNotificationRefresh(current, payload))
+              })
+              .catch((error) => {
+                console.error('Failed to refresh inbox after message', error)
+              })
+              .finally(() => {
+                inboxRefreshInFlight.current.delete(key)
+              })
+          }
           return
         }
       },


### PR DESCRIPTION
## Summary

- Memoize `agentMembers` in `CreateChannelModal` — was a new array reference every render, causing unnecessary `useEffect` re-runs
- Add `lastFiredSeqRef` to `useVisibilityTracking` so `onHighestVisibleSeqChange` only fires when the highest visible seq actually advances, not on every scroll event
- Deduplicate in-flight inbox refresh requests in `store.tsx` — rapid `message.created` events were each firing a separate `getConversationInboxNotification` call; now coalesced per channel/thread key
- Remove structural JSX comments in `ThreadPanel` (`{/* Header */}`, `{/* Replies */}`, `{/* Input */}`) that described layout structure already evident from class names

## Test plan

- [ ] Create a team channel and add members — leader auto-selection should still work correctly
- [ ] Open a busy channel and scroll — verify no visible regressions in read cursor tracking
- [ ] Verify thread panel opens, replies load, and read state updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)