### PR TITLE
feat(agent): add OpenCode runtime driver

### DIFF
--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -366,4 +366,12 @@ impl Driver for ClaudeDriver {
             auth_status: Some(auth_status),
         })
     }
+
+    fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![
+            "sonnet".to_string(),
+            "opus".to_string(),
+            "haiku".to_string(),
+        ])
+    }
 }

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -466,6 +466,18 @@ impl Driver for CodexDriver {
             auth_status: Some(auth_status),
         })
     }
+
+    fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![
+            "gpt-5.4".to_string(),
+            "gpt-5.4-mini".to_string(),
+            "gpt-5.3-codex".to_string(),
+            "gpt-5.2-codex".to_string(),
+            "gpt-5.2".to_string(),
+            "gpt-5.1-codex-max".to_string(),
+            "gpt-5.1-codex-mini".to_string(),
+        ])
+    }
 }
 
 fn codex_auth_status_from_probe(result: &super::CommandProbeResult) -> RuntimeAuthStatus {

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -311,6 +311,10 @@ impl Driver for KimiDriver {
     fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus> {
         detect_kimi_runtime_status(self.id(), &home_dir())
     }
+
+    fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec!["kimi-code/kimi-for-coding".to_string()])
+    }
 }
 
 fn detect_kimi_runtime_status(runtime_id: &str, home: &Path) -> anyhow::Result<RuntimeStatus> {

--- a/src/agent/drivers/mod.rs
+++ b/src/agent/drivers/mod.rs
@@ -1,6 +1,7 @@
 pub mod claude;
 pub mod codex;
 pub mod kimi;
+pub mod opencode;
 pub mod prompt;
 
 use std::fs;
@@ -83,6 +84,7 @@ pub fn all_runtime_drivers() -> Vec<Arc<dyn Driver>> {
         Arc::new(claude::ClaudeDriver),
         Arc::new(codex::CodexDriver),
         Arc::new(kimi::KimiDriver),
+        Arc::new(opencode::OpencodeDriver),
     ]
 }
 

--- a/src/agent/drivers/mod.rs
+++ b/src/agent/drivers/mod.rs
@@ -77,6 +77,8 @@ pub trait Driver: Send + Sync {
     fn summarize_tool_input(&self, name: &str, input: &serde_json::Value) -> String;
     /// Detect whether the runtime is installed and authenticated on this machine.
     fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus>;
+    /// Return the runtime's currently supported model ids.
+    fn list_models(&self) -> anyhow::Result<Vec<String>>;
 }
 
 pub fn all_runtime_drivers() -> Vec<Arc<dyn Driver>> {

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -41,8 +41,7 @@ impl Driver for OpencodeDriver {
             }
         });
         // OpenCode reads opencode.json from the working directory automatically.
-        let config_path =
-            std::path::Path::new(&ctx.working_directory).join("opencode.json");
+        let config_path = std::path::Path::new(&ctx.working_directory).join("opencode.json");
         std::fs::write(&config_path, serde_json::to_string_pretty(&mcp_config)?)?;
 
         let mut args = vec![
@@ -367,7 +366,10 @@ mod tests {
     fn parse_opencode_models_skips_blank_lines() {
         assert_eq!(
             parse_opencode_models("\nopenai/gpt-5.4\n\nopenai/gpt-5.4-mini\n"),
-            vec!["openai/gpt-5.4".to_string(), "openai/gpt-5.4-mini".to_string()]
+            vec![
+                "openai/gpt-5.4".to_string(),
+                "openai/gpt-5.4-mini".to_string()
+            ]
         );
     }
 
@@ -450,9 +452,8 @@ mod tests {
     #[test]
     fn opencode_parse_line_step_start_emits_session_init() {
         let driver = OpencodeDriver;
-        let events = driver.parse_line(
-            r#"{"type":"step_start","timestamp":1711929600000,"sessionID":"sess-99"}"#,
-        );
+        let events = driver
+            .parse_line(r#"{"type":"step_start","timestamp":1711929600000,"sessionID":"sess-99"}"#);
 
         assert!(matches!(
             &events[0],

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -1,0 +1,432 @@
+use std::process::{Child, Command, Stdio};
+
+use super::prompt::{build_base_system_prompt, PromptOptions};
+use super::{command_exists, run_command, Driver, ParsedEvent, SpawnContext};
+use crate::agent::config::AgentConfig;
+use crate::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus};
+use crate::store::agents::AgentRuntime;
+
+pub struct OpencodeDriver;
+
+impl Driver for OpencodeDriver {
+    fn runtime(&self) -> AgentRuntime {
+        AgentRuntime::Opencode
+    }
+
+    fn supports_stdin_notification(&self) -> bool {
+        false
+    }
+
+    fn mcp_tool_prefix(&self) -> &str {
+        "mcp_chat_"
+    }
+
+    fn spawn(&self, ctx: &SpawnContext) -> anyhow::Result<Child> {
+        // Write opencode.json MCP config in the working directory.
+        let mcp_config = serde_json::json!({
+            "mcp": {
+                "chat": {
+                    "type": "local",
+                    "command": [&ctx.bridge_binary, "bridge", "--agent-id", &ctx.agent_id, "--server-url", &ctx.server_url]
+                }
+            }
+        });
+        // OpenCode reads opencode.json from the working directory automatically.
+        let config_path =
+            std::path::Path::new(&ctx.working_directory).join("opencode.json");
+        std::fs::write(&config_path, serde_json::to_string_pretty(&mcp_config)?)?;
+
+        let mut args = vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "--thinking".to_string(),
+        ];
+
+        if let Some(ref session_id) = ctx.config.session_id {
+            args.push("--session".to_string());
+            args.push(session_id.clone());
+        }
+
+        if !ctx.config.model.is_empty() {
+            args.push("--model".to_string());
+            args.push(ctx.config.model.clone());
+        }
+
+        if let Some(ref variant) = ctx.config.reasoning_effort {
+            args.push("--variant".to_string());
+            args.push(variant.clone());
+        }
+
+        // Positional prompt argument comes last.
+        args.push(ctx.prompt.clone());
+
+        let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        env_vars.insert("FORCE_COLOR".to_string(), "0".to_string());
+        env_vars.insert("NO_COLOR".to_string(), "1".to_string());
+        for extra in &ctx.config.env_vars {
+            env_vars.insert(extra.key.clone(), extra.value.clone());
+        }
+
+        let child = Command::new("opencode")
+            .args(&args)
+            .current_dir(&ctx.working_directory)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .envs(&env_vars)
+            .spawn()?;
+
+        Ok(child)
+    }
+
+    fn parse_line(&self, line: &str) -> Vec<ParsedEvent> {
+        let event: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return vec![],
+        };
+
+        let mut events = Vec::new();
+        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        match event_type {
+            "step_start" => {
+                if let Some(session_id) = event.get("sessionID").and_then(|v| v.as_str()) {
+                    events.push(ParsedEvent::SessionInit {
+                        session_id: session_id.to_string(),
+                    });
+                }
+                events.push(ParsedEvent::Thinking {
+                    text: String::new(),
+                });
+            }
+            "reasoning" => {
+                let text = event
+                    .get("part")
+                    .and_then(|p| p.get("text"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                events.push(ParsedEvent::Thinking {
+                    text: text.to_string(),
+                });
+            }
+            "text" => {
+                let text = event
+                    .get("part")
+                    .and_then(|p| p.get("text"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                events.push(ParsedEvent::Text {
+                    text: text.to_string(),
+                });
+            }
+            "tool_use" => {
+                if let Some(part) = event.get("part") {
+                    let state = part.get("state").and_then(|v| v.as_str()).unwrap_or("");
+                    // Emit tool calls on pending/running states (start of tool use).
+                    if state == "pending" || state == "running" {
+                        let tool = part
+                            .get("tool")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown_tool");
+                        let input = part
+                            .get("input")
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+
+                        // OpenCode names MCP tools as mcp_{server}_{tool}.
+                        // Tools from the "chat" server are already prefixed mcp_chat_.
+                        events.push(ParsedEvent::ToolCall {
+                            name: tool.to_string(),
+                            input,
+                        });
+                    }
+                }
+            }
+            "step_finish" => {
+                let session_id = event
+                    .get("sessionID")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                events.push(ParsedEvent::TurnEnd { session_id });
+            }
+            "error" => {
+                let message = event
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|v| v.as_str())
+                    .or_else(|| event.get("message").and_then(|v| v.as_str()))
+                    .unwrap_or("Unknown error");
+                events.push(ParsedEvent::Error {
+                    message: message.to_string(),
+                });
+            }
+            _ => {}
+        }
+
+        events
+    }
+
+    fn encode_stdin_message(&self, _text: &str, _session_id: &str) -> Option<String> {
+        None
+    }
+
+    fn build_system_prompt(&self, config: &AgentConfig, _agent_id: &str) -> String {
+        build_base_system_prompt(
+            config,
+            &PromptOptions {
+                tool_prefix: "mcp_chat_".to_string(),
+                extra_critical_rules: vec![
+                    "- Do NOT use shell commands to send or receive messages. The MCP tools handle everything.".to_string(),
+                    "- ALWAYS call `mcp_chat_wait_for_message()` after completing any task so you return to the idle loop.".to_string(),
+                ],
+                post_startup_notes: vec![
+                    "**IMPORTANT**: Your process may exit after an idle wait completes. The server will resume you when new work arrives.".to_string(),
+                ],
+                include_stdin_notification_section: false,
+                teams: config.teams.clone(),
+            },
+        )
+    }
+
+    fn tool_display_name(&self, name: &str) -> String {
+        match name {
+            "mcp_chat_send_message" => "Sending message\u{2026}".to_string(),
+            "mcp_chat_check_messages" => "Checking messages\u{2026}".to_string(),
+            "mcp_chat_wait_for_message" => "Waiting for messages\u{2026}".to_string(),
+            "mcp_chat_receive_message" => "Receiving messages\u{2026}".to_string(),
+            "mcp_chat_upload_file" => "Uploading file\u{2026}".to_string(),
+            "mcp_chat_view_file" => "Viewing file\u{2026}".to_string(),
+            "mcp_chat_list_tasks" => "Listing tasks\u{2026}".to_string(),
+            "mcp_chat_create_tasks" => "Creating tasks\u{2026}".to_string(),
+            "mcp_chat_claim_tasks" => "Claiming tasks\u{2026}".to_string(),
+            "mcp_chat_unclaim_task" => "Unclaiming task\u{2026}".to_string(),
+            "mcp_chat_update_task_status" => "Updating task status\u{2026}".to_string(),
+            "mcp_chat_list_server" => "Listing server\u{2026}".to_string(),
+            "mcp_chat_read_history" => "Reading history\u{2026}".to_string(),
+            n if n.starts_with("mcp_chat_") => {
+                let op = n.trim_start_matches("mcp_chat_").replace('_', " ");
+                format!("Using {op}\u{2026}")
+            }
+            other => {
+                let truncated: String = other.chars().take(20).collect();
+                format!("Using {truncated}\u{2026}")
+            }
+        }
+    }
+
+    fn summarize_tool_input(&self, name: &str, input: &serde_json::Value) -> String {
+        if !input.is_object() {
+            return String::new();
+        }
+
+        let str_field = |field: &str| -> String {
+            input
+                .get(field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+
+        match name {
+            "file_read" | "file_write" | "file_change" => {
+                let p = str_field("path");
+                if p.is_empty() {
+                    str_field("file_path")
+                } else {
+                    p
+                }
+            }
+            "shell" | "bash" | "command_execution" => {
+                let cmd = str_field("command");
+                if cmd.chars().count() > 100 {
+                    let truncated: String = cmd.chars().take(100).collect();
+                    format!("{truncated}\u{2026}")
+                } else {
+                    cmd
+                }
+            }
+            "web_search" => str_field("query"),
+            "mcp_chat_check_messages" | "mcp_chat_wait_for_message" => String::new(),
+            "mcp_chat_send_message" => {
+                let t = str_field("target");
+                if t.is_empty() {
+                    str_field("channel")
+                } else {
+                    t
+                }
+            }
+            "mcp_chat_read_history" => {
+                let t = str_field("target");
+                if t.is_empty() {
+                    str_field("channel")
+                } else {
+                    t
+                }
+            }
+            "mcp_chat_list_tasks" | "mcp_chat_create_tasks" => str_field("channel"),
+            "mcp_chat_claim_tasks" => {
+                let channel = str_field("channel");
+                if channel.is_empty() {
+                    return String::new();
+                }
+                let nums = input.get("task_numbers");
+                let nums_str = match nums {
+                    Some(serde_json::Value::Array(arr)) => arr
+                        .iter()
+                        .filter_map(|v| v.as_i64().or_else(|| v.as_u64().map(|u| u as i64)))
+                        .map(|n| format!("#t{n}"))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                    Some(v) => {
+                        if let Some(n) = v.as_i64() {
+                            format!("#t{n}")
+                        } else {
+                            format!("#t{v}")
+                        }
+                    }
+                    None => return channel,
+                };
+                format!("{channel} {nums_str}")
+            }
+            "mcp_chat_unclaim_task" | "mcp_chat_update_task_status" => {
+                let channel = str_field("channel");
+                if channel.is_empty() {
+                    return String::new();
+                }
+                let tn = input
+                    .get("task_number")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| format!("#t{n}"))
+                    .unwrap_or_default();
+                format!("{channel} {tn}")
+            }
+            "mcp_chat_upload_file" => str_field("file_path"),
+            _ => String::new(),
+        }
+    }
+
+    fn detect_runtime_status(&self) -> anyhow::Result<RuntimeStatus> {
+        if !command_exists("opencode") {
+            return Ok(RuntimeStatus {
+                runtime: self.id().to_string(),
+                installed: false,
+                auth_status: None,
+            });
+        }
+
+        // OpenCode is provider-agnostic; auth depends on the chosen provider's
+        // API keys being present in the environment.  A simple version probe
+        // confirms the binary works.
+        let auth_status = run_command("opencode", &["--version"])
+            .ok()
+            .map(|result| {
+                if result.success {
+                    RuntimeAuthStatus::Authed
+                } else {
+                    RuntimeAuthStatus::Unauthed
+                }
+            })
+            .unwrap_or(RuntimeAuthStatus::Unauthed);
+
+        Ok(RuntimeStatus {
+            runtime: self.id().to_string(),
+            installed: true,
+            auth_status: Some(auth_status),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_parse_line_maps_text_event() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"text","timestamp":1711929600000,"sessionID":"sess-1","part":{"type":"text","text":"Hello world"}}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::Text { text } if text == "Hello world"
+        ));
+    }
+
+    #[test]
+    fn opencode_parse_line_maps_tool_use_event() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r##"{"type":"tool_use","timestamp":1711929600000,"sessionID":"sess-1","part":{"tool":"mcp_chat_send_message","state":"running","input":{"target":"#all","content":"hi"}}}"##,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::ToolCall { name, input }
+                if name == "mcp_chat_send_message" && input["target"] == "#all"
+        ));
+    }
+
+    #[test]
+    fn opencode_parse_line_ignores_completed_tool_state() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"tool_use","timestamp":1711929600000,"sessionID":"sess-1","part":{"tool":"bash","state":"completed","input":{}}}"#,
+        );
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn opencode_parse_line_maps_step_finish_with_session_id() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"step_finish","timestamp":1711929600000,"sessionID":"sess-42"}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::TurnEnd { session_id } if session_id.as_deref() == Some("sess-42")
+        ));
+    }
+
+    #[test]
+    fn opencode_parse_line_maps_error_event() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"error","timestamp":1711929600000,"sessionID":"sess-1","error":{"message":"rate limited"}}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::Error { message } if message == "rate limited"
+        ));
+    }
+
+    #[test]
+    fn opencode_parse_line_maps_reasoning_event() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"reasoning","timestamp":1711929600000,"sessionID":"sess-1","part":{"type":"reasoning","text":"Let me think..."}}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::Thinking { text } if text == "Let me think..."
+        ));
+    }
+
+    #[test]
+    fn opencode_parse_line_step_start_emits_session_init() {
+        let driver = OpencodeDriver;
+        let events = driver.parse_line(
+            r#"{"type":"step_start","timestamp":1711929600000,"sessionID":"sess-99"}"#,
+        );
+
+        assert!(matches!(
+            &events[0],
+            ParsedEvent::SessionInit { session_id } if session_id == "sess-99"
+        ));
+    }
+}

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -8,6 +8,15 @@ use crate::store::agents::AgentRuntime;
 
 pub struct OpencodeDriver;
 
+fn parse_opencode_models(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 impl Driver for OpencodeDriver {
     fn runtime(&self) -> AgentRuntime {
         AgentRuntime::Opencode
@@ -335,11 +344,32 @@ impl Driver for OpencodeDriver {
             auth_status: Some(auth_status),
         })
     }
+
+    fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        if !command_exists("opencode") {
+            return Ok(Vec::new());
+        }
+
+        let result = run_command("opencode", &["models"])?;
+        if !result.success {
+            anyhow::bail!("failed to list opencode models: {}", result.stderr.trim());
+        }
+
+        Ok(parse_opencode_models(&result.stdout))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_opencode_models_skips_blank_lines() {
+        assert_eq!(
+            parse_opencode_models("\nopenai/gpt-5.4\n\nopenai/gpt-5.4-mini\n"),
+            vec!["openai/gpt-5.4".to_string(), "openai/gpt-5.4-mini".to_string()]
+        );
+    }
 
     #[test]
     fn opencode_parse_line_maps_text_event() {

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -18,7 +18,7 @@ impl Driver for OpencodeDriver {
     }
 
     fn mcp_tool_prefix(&self) -> &str {
-        "mcp_chat_"
+        "chat_"
     }
 
     fn spawn(&self, ctx: &SpawnContext) -> anyhow::Result<Child> {
@@ -134,8 +134,8 @@ impl Driver for OpencodeDriver {
                             .cloned()
                             .unwrap_or(serde_json::Value::Null);
 
-                        // OpenCode names MCP tools as mcp_{server}_{tool}.
-                        // Tools from the "chat" server are already prefixed mcp_chat_.
+                        // OpenCode names MCP tools as {server}_{tool}.
+                        // Tools from the "chat" server are prefixed chat_.
                         events.push(ParsedEvent::ToolCall {
                             name: tool.to_string(),
                             input,
@@ -175,10 +175,10 @@ impl Driver for OpencodeDriver {
         build_base_system_prompt(
             config,
             &PromptOptions {
-                tool_prefix: "mcp_chat_".to_string(),
+                tool_prefix: "chat_".to_string(),
                 extra_critical_rules: vec![
                     "- Do NOT use shell commands to send or receive messages. The MCP tools handle everything.".to_string(),
-                    "- ALWAYS call `mcp_chat_wait_for_message()` after completing any task so you return to the idle loop.".to_string(),
+                    "- ALWAYS call `chat_wait_for_message()` after completing any task so you return to the idle loop.".to_string(),
                 ],
                 post_startup_notes: vec![
                     "**IMPORTANT**: Your process may exit after an idle wait completes. The server will resume you when new work arrives.".to_string(),
@@ -191,21 +191,21 @@ impl Driver for OpencodeDriver {
 
     fn tool_display_name(&self, name: &str) -> String {
         match name {
-            "mcp_chat_send_message" => "Sending message\u{2026}".to_string(),
-            "mcp_chat_check_messages" => "Checking messages\u{2026}".to_string(),
-            "mcp_chat_wait_for_message" => "Waiting for messages\u{2026}".to_string(),
-            "mcp_chat_receive_message" => "Receiving messages\u{2026}".to_string(),
-            "mcp_chat_upload_file" => "Uploading file\u{2026}".to_string(),
-            "mcp_chat_view_file" => "Viewing file\u{2026}".to_string(),
-            "mcp_chat_list_tasks" => "Listing tasks\u{2026}".to_string(),
-            "mcp_chat_create_tasks" => "Creating tasks\u{2026}".to_string(),
-            "mcp_chat_claim_tasks" => "Claiming tasks\u{2026}".to_string(),
-            "mcp_chat_unclaim_task" => "Unclaiming task\u{2026}".to_string(),
-            "mcp_chat_update_task_status" => "Updating task status\u{2026}".to_string(),
-            "mcp_chat_list_server" => "Listing server\u{2026}".to_string(),
-            "mcp_chat_read_history" => "Reading history\u{2026}".to_string(),
-            n if n.starts_with("mcp_chat_") => {
-                let op = n.trim_start_matches("mcp_chat_").replace('_', " ");
+            "chat_send_message" => "Sending message\u{2026}".to_string(),
+            "chat_check_messages" => "Checking messages\u{2026}".to_string(),
+            "chat_wait_for_message" => "Waiting for messages\u{2026}".to_string(),
+            "chat_receive_message" => "Receiving messages\u{2026}".to_string(),
+            "chat_upload_file" => "Uploading file\u{2026}".to_string(),
+            "chat_view_file" => "Viewing file\u{2026}".to_string(),
+            "chat_list_tasks" => "Listing tasks\u{2026}".to_string(),
+            "chat_create_tasks" => "Creating tasks\u{2026}".to_string(),
+            "chat_claim_tasks" => "Claiming tasks\u{2026}".to_string(),
+            "chat_unclaim_task" => "Unclaiming task\u{2026}".to_string(),
+            "chat_update_task_status" => "Updating task status\u{2026}".to_string(),
+            "chat_list_server" => "Listing server\u{2026}".to_string(),
+            "chat_read_history" => "Reading history\u{2026}".to_string(),
+            n if n.starts_with("chat_") => {
+                let op = n.trim_start_matches("chat_").replace('_', " ");
                 format!("Using {op}\u{2026}")
             }
             other => {
@@ -247,8 +247,8 @@ impl Driver for OpencodeDriver {
                 }
             }
             "web_search" => str_field("query"),
-            "mcp_chat_check_messages" | "mcp_chat_wait_for_message" => String::new(),
-            "mcp_chat_send_message" => {
+            "chat_check_messages" | "chat_wait_for_message" => String::new(),
+            "chat_send_message" => {
                 let t = str_field("target");
                 if t.is_empty() {
                     str_field("channel")
@@ -256,7 +256,7 @@ impl Driver for OpencodeDriver {
                     t
                 }
             }
-            "mcp_chat_read_history" => {
+            "chat_read_history" => {
                 let t = str_field("target");
                 if t.is_empty() {
                     str_field("channel")
@@ -264,8 +264,8 @@ impl Driver for OpencodeDriver {
                     t
                 }
             }
-            "mcp_chat_list_tasks" | "mcp_chat_create_tasks" => str_field("channel"),
-            "mcp_chat_claim_tasks" => {
+            "chat_list_tasks" | "chat_create_tasks" => str_field("channel"),
+            "chat_claim_tasks" => {
                 let channel = str_field("channel");
                 if channel.is_empty() {
                     return String::new();
@@ -289,7 +289,7 @@ impl Driver for OpencodeDriver {
                 };
                 format!("{channel} {nums_str}")
             }
-            "mcp_chat_unclaim_task" | "mcp_chat_update_task_status" => {
+            "chat_unclaim_task" | "chat_update_task_status" => {
                 let channel = str_field("channel");
                 if channel.is_empty() {
                     return String::new();
@@ -301,7 +301,7 @@ impl Driver for OpencodeDriver {
                     .unwrap_or_default();
                 format!("{channel} {tn}")
             }
-            "mcp_chat_upload_file" => str_field("file_path"),
+            "chat_upload_file" => str_field("file_path"),
             _ => String::new(),
         }
     }
@@ -358,13 +358,13 @@ mod tests {
     fn opencode_parse_line_maps_tool_use_event() {
         let driver = OpencodeDriver;
         let events = driver.parse_line(
-            r##"{"type":"tool_use","timestamp":1711929600000,"sessionID":"sess-1","part":{"tool":"mcp_chat_send_message","state":"running","input":{"target":"#all","content":"hi"}}}"##,
+            r##"{"type":"tool_use","timestamp":1711929600000,"sessionID":"sess-1","part":{"tool":"chat_send_message","state":"running","input":{"target":"#all","content":"hi"}}}"##,
         );
 
         assert!(matches!(
             &events[0],
             ParsedEvent::ToolCall { name, input }
-                if name == "mcp_chat_send_message" && input["target"] == "#all"
+                if name == "chat_send_message" && input["target"] == "#all"
         ));
     }
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -40,6 +40,9 @@ fn get_driver(runtime: &str) -> anyhow::Result<Arc<dyn Driver>> {
         Some(AgentRuntime::Claude) => Ok(Arc::new(crate::agent::drivers::claude::ClaudeDriver)),
         Some(AgentRuntime::Codex) => Ok(Arc::new(crate::agent::drivers::codex::CodexDriver)),
         Some(AgentRuntime::Kimi) => Ok(Arc::new(crate::agent::drivers::kimi::KimiDriver)),
+        Some(AgentRuntime::Opencode) => {
+            Ok(Arc::new(crate::agent::drivers::opencode::OpencodeDriver))
+        }
         None => anyhow::bail!("Unknown runtime: {runtime}"),
     }
 }
@@ -83,7 +86,7 @@ impl AgentManager {
 
         let driver = get_driver(&agent.runtime)?;
         let resumable_session_id = match driver.runtime() {
-            AgentRuntime::Codex => agent.session_id.clone(),
+            AgentRuntime::Codex | AgentRuntime::Opencode => agent.session_id.clone(),
             AgentRuntime::Kimi => Some(
                 agent
                     .session_id

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -756,6 +756,10 @@ mod tests {
                 auth_status: Some(crate::agent::runtime_status::RuntimeAuthStatus::Authed),
             })
         }
+
+        fn list_models(&self) -> anyhow::Result<Vec<String>> {
+            Ok(vec!["gpt-5.4-mini".to_string()])
+        }
     }
 
     fn sample_config(session_id: Option<&str>) -> AgentConfig {

--- a/src/agent/runtime_status.rs
+++ b/src/agent/runtime_status.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::drivers::all_runtime_drivers;
@@ -24,6 +25,7 @@ pub struct RuntimeStatus {
 /// Backend service used by HTTP handlers to query local runtime availability.
 pub trait RuntimeStatusProvider: Send + Sync {
     fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatus>>;
+    fn list_models(&self, runtime: &str) -> anyhow::Result<Vec<String>>;
 }
 
 /// Shared trait alias used by the server state.
@@ -38,5 +40,13 @@ impl RuntimeStatusProvider for SystemRuntimeStatusProvider {
             .into_iter()
             .map(|driver| driver.detect_runtime_status())
             .collect()
+    }
+
+    fn list_models(&self, runtime: &str) -> anyhow::Result<Vec<String>> {
+        let driver = all_runtime_drivers()
+            .into_iter()
+            .find(|driver| driver.id() == runtime)
+            .with_context(|| format!("unknown runtime: {runtime}"))?;
+        driver.list_models()
     }
 }

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -144,7 +144,8 @@ pub(super) fn normalize_reasoning_effort(
     runtime: &str,
     reasoning_effort: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, Json<super::ErrorResponse>)> {
-    if AgentRuntime::parse(runtime) != Some(AgentRuntime::Codex) {
+    let parsed = AgentRuntime::parse(runtime);
+    if parsed != Some(AgentRuntime::Codex) && parsed != Some(AgentRuntime::Opencode) {
         return Ok(None);
     }
 
@@ -156,11 +157,11 @@ pub(super) fn normalize_reasoning_effort(
     }
 
     match reasoning_effort {
-        "none" | "minimal" | "low" | "medium" | "high" | "xhigh" => {
+        "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" => {
             Ok(Some(reasoning_effort.to_string()))
         }
         _ => Err(api_err(format!(
-            "unsupported Codex reasoning effort: {reasoning_effort}"
+            "unsupported reasoning effort: {reasoning_effort}"
         ))),
     }
 }

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -187,6 +187,17 @@ pub async fn handle_list_runtime_statuses(
     Ok(Json(statuses))
 }
 
+pub async fn handle_list_runtime_models(
+    State(state): State<AppState>,
+    Path(runtime): Path<String>,
+) -> ApiResult<Vec<String>> {
+    let models = state
+        .runtime_status_provider
+        .list_models(&runtime)
+        .map_err(|e| api_err(e.to_string()))?;
+    Ok(Json(models))
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -123,7 +123,10 @@ pub fn build_router_with_services(
         )
         .route("/agents", get(handle_list_agents).post(handle_create_agent))
         .route("/runtimes", get(handle_list_runtime_statuses))
-        .route("/runtimes/{runtime}/models", get(handle_list_runtime_models))
+        .route(
+            "/runtimes/{runtime}/models",
+            get(handle_list_runtime_models),
+        )
         .route("/teams", get(handle_list_teams).post(handle_create_team))
         .route(
             "/teams/{name}",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -123,6 +123,7 @@ pub fn build_router_with_services(
         )
         .route("/agents", get(handle_list_agents).post(handle_create_agent))
         .route("/runtimes", get(handle_list_runtime_statuses))
+        .route("/runtimes/{runtime}/models", get(handle_list_runtime_models))
         .route("/teams", get(handle_list_teams).post(handle_create_team))
         .route(
             "/teams/{name}",

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -85,6 +85,7 @@ pub enum AgentRuntime {
     Claude,
     Codex,
     Kimi,
+    Opencode,
 }
 
 impl AgentRuntime {
@@ -93,6 +94,7 @@ impl AgentRuntime {
             Self::Claude => "claude",
             Self::Codex => "codex",
             Self::Kimi => "kimi",
+            Self::Opencode => "opencode",
         }
     }
 
@@ -101,6 +103,7 @@ impl AgentRuntime {
             "claude" => Some(Self::Claude),
             "codex" => Some(Self::Codex),
             "kimi" => Some(Self::Kimi),
+            "opencode" => Some(Self::Opencode),
             _ => None,
         }
     }

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -2,6 +2,7 @@ use chorus::agent::config::AgentConfig;
 use chorus::agent::drivers::claude::ClaudeDriver;
 use chorus::agent::drivers::codex::CodexDriver;
 use chorus::agent::drivers::kimi::KimiDriver;
+use chorus::agent::drivers::opencode::OpencodeDriver;
 use chorus::agent::drivers::Driver;
 
 #[test]
@@ -122,5 +123,48 @@ fn test_kimi_prompt_uses_split_message_tools() {
     assert!(
         prompt.contains("Any reply meant for humans must be delivered with `send_message()`"),
         "Kimi prompts should explicitly forbid treating raw stdout text as a valid human reply"
+    );
+}
+
+#[test]
+fn test_opencode_prompt_uses_split_message_tools() {
+    let driver = OpencodeDriver;
+    let config = AgentConfig {
+        name: "opencode-bot".to_string(),
+        display_name: "OpenCode Bot".to_string(),
+        description: Some("Replies in Chorus".to_string()),
+        runtime: "opencode".to_string(),
+        model: "anthropic/claude-sonnet-4-20250514".to_string(),
+        session_id: None,
+        reasoning_effort: None,
+        env_vars: Vec::new(),
+        teams: vec![],
+    };
+
+    let prompt = driver.build_system_prompt(&config, "agent-id");
+
+    assert!(
+        prompt.contains("mcp_chat_wait_for_message"),
+        "OpenCode prompts must reference the blocking idle tool"
+    );
+    assert!(
+        prompt.contains("mcp_chat_check_messages"),
+        "OpenCode prompts must reference the non-blocking check tool"
+    );
+    assert!(
+        prompt.contains("mcp_chat_send_message"),
+        "OpenCode prompts must reference the actual MCP send tool"
+    );
+    assert!(
+        !prompt.contains("mcp_chat_receive_message"),
+        "OpenCode prompts should not rely on the legacy combined receive tool"
+    );
+    assert!(
+        prompt.contains("mcp_chat_view_file"),
+        "OpenCode prompts should teach attachment inspection explicitly"
+    );
+    assert!(
+        prompt.contains("Chorus"),
+        "OpenCode prompts should use the current product name"
     );
 }

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -144,23 +144,23 @@ fn test_opencode_prompt_uses_split_message_tools() {
     let prompt = driver.build_system_prompt(&config, "agent-id");
 
     assert!(
-        prompt.contains("mcp_chat_wait_for_message"),
+        prompt.contains("chat_wait_for_message"),
         "OpenCode prompts must reference the blocking idle tool"
     );
     assert!(
-        prompt.contains("mcp_chat_check_messages"),
+        prompt.contains("chat_check_messages"),
         "OpenCode prompts must reference the non-blocking check tool"
     );
     assert!(
-        prompt.contains("mcp_chat_send_message"),
+        prompt.contains("chat_send_message"),
         "OpenCode prompts must reference the actual MCP send tool"
     );
     assert!(
-        !prompt.contains("mcp_chat_receive_message"),
+        !prompt.contains("chat_receive_message"),
         "OpenCode prompts should not rely on the legacy combined receive tool"
     );
     assert!(
-        prompt.contains("mcp_chat_view_file"),
+        prompt.contains("chat_view_file"),
         "OpenCode prompts should teach attachment inspection explicitly"
     );
     assert!(

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -1215,23 +1215,26 @@ async fn test_whoami() {
 
 #[tokio::test]
 async fn test_list_runtime_statuses() {
-    let (_store, app, _lifecycle) = setup_with_runtime_statuses(vec![
-        RuntimeStatus {
-            runtime: "claude".to_string(),
-            installed: true,
-            auth_status: Some(RuntimeAuthStatus::Authed),
-        },
-        RuntimeStatus {
-            runtime: "codex".to_string(),
-            installed: true,
-            auth_status: Some(RuntimeAuthStatus::Unauthed),
-        },
-        RuntimeStatus {
-            runtime: "kimi".to_string(),
-            installed: false,
-            auth_status: None,
-        },
-    ], vec![]);
+    let (_store, app, _lifecycle) = setup_with_runtime_statuses(
+        vec![
+            RuntimeStatus {
+                runtime: "claude".to_string(),
+                installed: true,
+                auth_status: Some(RuntimeAuthStatus::Authed),
+            },
+            RuntimeStatus {
+                runtime: "codex".to_string(),
+                installed: true,
+                auth_status: Some(RuntimeAuthStatus::Unauthed),
+            },
+            RuntimeStatus {
+                runtime: "kimi".to_string(),
+                installed: false,
+                auth_status: None,
+            },
+        ],
+        vec![],
+    );
 
     let resp = app
         .oneshot(
@@ -1271,10 +1274,7 @@ async fn test_list_runtime_models() {
                 "codex".to_string(),
                 vec!["gpt-5.4".to_string(), "gpt-5.4-mini".to_string()],
             ),
-            (
-                "opencode".to_string(),
-                vec!["openai/gpt-5.4".to_string()],
-            ),
+            ("opencode".to_string(), vec!["openai/gpt-5.4".to_string()]),
         ],
     );
 

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -78,6 +78,7 @@ struct MockLifecycle {
 
 struct MockRuntimeStatusProvider {
     statuses: Vec<RuntimeStatus>,
+    models_by_runtime: Vec<(String, Vec<String>)>,
 }
 
 struct FailStartLifecycle;
@@ -85,6 +86,15 @@ struct FailStartLifecycle;
 impl RuntimeStatusProvider for MockRuntimeStatusProvider {
     fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatus>> {
         Ok(self.statuses.clone())
+    }
+
+    fn list_models(&self, runtime: &str) -> anyhow::Result<Vec<String>> {
+        Ok(self
+            .models_by_runtime
+            .iter()
+            .find(|(name, _)| name == runtime)
+            .map(|(_, models)| models.clone())
+            .unwrap_or_default())
     }
 }
 
@@ -227,6 +237,7 @@ fn setup_with_lifecycle() -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
 
 fn setup_with_runtime_statuses(
     statuses: Vec<RuntimeStatus>,
+    models_by_runtime: Vec<(String, Vec<String>)>,
 ) -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     store
@@ -243,7 +254,10 @@ fn setup_with_runtime_statuses(
         .join_channel("general", "bot1", SenderType::Agent)
         .unwrap();
     let lifecycle = Arc::new(MockLifecycle::default());
-    let runtime_status_provider = Arc::new(MockRuntimeStatusProvider { statuses });
+    let runtime_status_provider = Arc::new(MockRuntimeStatusProvider {
+        statuses,
+        models_by_runtime,
+    });
     let router =
         build_router_with_services(store.clone(), lifecycle.clone(), runtime_status_provider);
     (store, router, lifecycle)
@@ -1217,7 +1231,7 @@ async fn test_list_runtime_statuses() {
             installed: false,
             auth_status: None,
         },
-    ]);
+    ], vec![]);
 
     let resp = app
         .oneshot(
@@ -1246,6 +1260,40 @@ async fn test_list_runtime_statuses() {
     assert_eq!(runtimes[2]["runtime"], "kimi");
     assert_eq!(runtimes[2]["installed"], false);
     assert!(runtimes[2].get("authStatus").is_none());
+}
+
+#[tokio::test]
+async fn test_list_runtime_models() {
+    let (_store, app, _lifecycle) = setup_with_runtime_statuses(
+        vec![],
+        vec![
+            (
+                "codex".to_string(),
+                vec!["gpt-5.4".to_string(), "gpt-5.4-mini".to_string()],
+            ),
+            (
+                "opencode".to_string(),
+                vec!["openai/gpt-5.4".to_string()],
+            ),
+        ],
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/runtimes/opencode/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1_000_000)
+        .await
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload, serde_json::json!(["openai/gpt-5.4"]));
 }
 
 #[tokio::test]

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -85,6 +85,10 @@ export async function listRuntimeStatuses(): Promise<RuntimeStatusInfo[]> {
   return json(await fetch(`${BASE}/api/runtimes`))
 }
 
+export async function listRuntimeModels(runtime: string): Promise<string[]> {
+  return json(await fetch(`${BASE}/api/runtimes/${encodeURIComponent(runtime)}/models`))
+}
+
 export async function createChannel(payload: {
   name: string
   description: string

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -19,6 +19,13 @@ export const MODELS: Record<string, { value: string; label: string }[]> = {
   kimi: [
     { value: 'kimi-code/kimi-for-coding', label: 'kimi-for-coding' },
   ],
+  opencode: [
+    { value: 'anthropic/claude-sonnet-4-20250514', label: 'claude-sonnet-4 (Anthropic)' },
+    { value: 'anthropic/claude-opus-4-20250514', label: 'claude-opus-4 (Anthropic)' },
+    { value: 'openai/gpt-4.1', label: 'gpt-4.1 (OpenAI)' },
+    { value: 'openai/o3', label: 'o3 (OpenAI)' },
+    { value: 'google/gemini-2.5-pro', label: 'gemini-2.5-pro (Google)' },
+  ],
 }
 
 export const REASONING_EFFORTS = [
@@ -54,7 +61,7 @@ export function runtimeOptionLabel(
   runtimeStatuses: RuntimeStatusInfo[] = [],
 ): string {
   const baseLabel =
-    runtime === 'claude' ? 'Claude Code' : runtime === 'codex' ? 'Codex CLI' : 'Kimi CLI'
+    runtime === 'claude' ? 'Claude Code' : runtime === 'codex' ? 'Codex CLI' : runtime === 'opencode' ? 'OpenCode' : 'Kimi CLI'
   const status = runtimeStatuses.find((entry) => entry.runtime === runtime)
   if (!status) return `${baseLabel} · status unavailable`
   if (!status.installed) return `${baseLabel} · not installed`
@@ -186,7 +193,7 @@ export function AgentConfigForm({
                   ...state,
                   runtime,
                   model,
-                  reasoningEffort: runtime === 'codex' ? state.reasoningEffort ?? 'default' : null,
+                  reasoningEffort: runtime === 'codex' || runtime === 'opencode' ? state.reasoningEffort ?? 'default' : null,
                 })
               }}
             >
@@ -197,6 +204,7 @@ export function AgentConfigForm({
                 <SelectItem value="claude">{runtimeOptionLabel('claude', runtimeStatuses)}</SelectItem>
                 <SelectItem value="codex">{runtimeOptionLabel('codex', runtimeStatuses)}</SelectItem>
                 <SelectItem value="kimi">{runtimeOptionLabel('kimi', runtimeStatuses)}</SelectItem>
+                <SelectItem value="opencode">{runtimeOptionLabel('opencode', runtimeStatuses)}</SelectItem>
               </SelectContent>
             </Select>
             <div className={`runtime-status-banner runtime-status-banner-${runtimeSummary.tone}`}>
@@ -227,7 +235,7 @@ export function AgentConfigForm({
             </Select>
           </div>
 
-          {state.runtime === 'codex' && (
+          {(state.runtime === 'codex' || state.runtime === 'opencode') && (
             <div className="modal-field">
               <label className="form-label">Reasoning</label>
               <Select

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1,32 +1,7 @@
+import { useEffect } from 'react'
 import type { AgentEnvVar, RuntimeStatusInfo } from '../types'
+import { useRuntimeModels } from '../hooks/useRuntimeModels'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-
-export const MODELS: Record<string, { value: string; label: string }[]> = {
-  claude: [
-    { value: 'sonnet', label: 'claude-sonnet-4-6' },
-    { value: 'opus', label: 'claude-opus-4-6' },
-    { value: 'haiku', label: 'claude-haiku-4-5' },
-  ],
-  codex: [
-    { value: 'gpt-5.4', label: 'gpt-5.4' },
-    { value: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
-    { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
-    { value: 'gpt-5.2-codex', label: 'gpt-5.2-codex' },
-    { value: 'gpt-5.2', label: 'gpt-5.2' },
-    { value: 'gpt-5.1-codex-max', label: 'gpt-5.1-codex-max' },
-    { value: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini' },
-  ],
-  kimi: [
-    { value: 'kimi-code/kimi-for-coding', label: 'kimi-for-coding' },
-  ],
-  opencode: [
-    { value: 'anthropic/claude-sonnet-4-20250514', label: 'claude-sonnet-4 (Anthropic)' },
-    { value: 'anthropic/claude-opus-4-20250514', label: 'claude-opus-4 (Anthropic)' },
-    { value: 'openai/gpt-4.1', label: 'gpt-4.1 (OpenAI)' },
-    { value: 'openai/o3', label: 'o3 (OpenAI)' },
-    { value: 'google/gemini-2.5-pro', label: 'gemini-2.5-pro (Google)' },
-  ],
-}
 
 export const REASONING_EFFORTS = [
   { value: 'default', label: 'Default' },
@@ -109,6 +84,19 @@ export function AgentConfigForm({
   editableName = false,
   onChange,
 }: Props) {
+  const { runtimeModels, runtimeModelsError } = useRuntimeModels(state.runtime)
+
+  useEffect(() => {
+    if (runtimeModels.length === 0 || runtimeModels.includes(state.model)) {
+      return
+    }
+
+    onChange({
+      ...state,
+      model: runtimeModels[0],
+    })
+  }, [onChange, runtimeModels, state])
+
   function updateEnvVar(index: number, key: keyof AgentEnvVar, value: string) {
     const envVars = state.envVars.map((envVar, envIndex) =>
       envIndex === index ? { ...envVar, [key]: value } : envVar
@@ -188,11 +176,10 @@ export function AgentConfigForm({
             <Select
               value={state.runtime}
               onValueChange={(runtime) => {
-                const model = MODELS[runtime]?.[0]?.value ?? ''
                 onChange({
                   ...state,
                   runtime,
-                  model,
+                  model: '',
                   reasoningEffort: runtime === 'codex' || runtime === 'opencode' ? state.reasoningEffort ?? 'default' : null,
                 })
               }}
@@ -226,13 +213,16 @@ export function AgentConfigForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(MODELS[state.runtime] ?? []).map((model) => (
-                  <SelectItem key={model.value} value={model.value}>
-                    {model.label}
+                {runtimeModels.map((model) => (
+                  <SelectItem key={model} value={model}>
+                    {model}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            {runtimeModelsError && (
+              <div className="modal-field-hint">{runtimeModelsError}</div>
+            )}
           </div>
 
           {(state.runtime === 'codex' || state.runtime === 'opencode') && (

--- a/ui/src/components/CreateAgentModal.tsx
+++ b/ui/src/components/CreateAgentModal.tsx
@@ -40,7 +40,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           description: config.description,
           runtime: config.runtime,
           model: config.model,
-          reasoningEffort: config.runtime === 'codex' ? config.reasoningEffort : null,
+          reasoningEffort: config.runtime === 'codex' || config.runtime === 'opencode' ? config.reasoningEffort : null,
           envVars: config.envVars,
         }),
       })

--- a/ui/src/components/CreateAgentModal.tsx
+++ b/ui/src/components/CreateAgentModal.tsx
@@ -15,7 +15,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
     display_name: '',
     description: '',
     runtime: 'claude',
-    model: 'sonnet',
+    model: '',
     reasoningEffort: null,
     envVars: [],
   })
@@ -31,6 +31,9 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
     setCreating(true)
     setError(null)
     try {
+      if (!config.model.trim()) {
+        throw new Error('Model is required')
+      }
       const res = await fetch('/api/agents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -94,7 +97,7 @@ export function CreateAgentModal({ onClose, onCreated }: Props) {
           <button
             className="btn-brutal btn-cyan"
             onClick={handleCreate}
-            disabled={creating || !config.name.trim()}
+            disabled={creating || !config.name.trim() || !config.model.trim()}
           >
             {creating ? 'Creating...' : 'Create Agent'}
           </button>

--- a/ui/src/components/ProfilePanel.tsx
+++ b/ui/src/components/ProfilePanel.tsx
@@ -267,12 +267,15 @@ function EditAgentModal({
     setSaving(true)
     setError(null)
     try {
+      if (!state.model.trim()) {
+        throw new Error('Model is required')
+      }
       await updateAgent(agentName, {
         display_name: state.display_name,
         description: state.description,
         runtime: state.runtime,
         model: state.model,
-        reasoningEffort: state.runtime === 'codex' ? state.reasoningEffort : null,
+        reasoningEffort: state.runtime === 'codex' || state.runtime === 'opencode' ? state.reasoningEffort : null,
         envVars: state.envVars.filter((envVar) => envVar.key.trim() || envVar.value),
       })
       await onSaved()
@@ -297,7 +300,7 @@ function EditAgentModal({
         {error && <div className="error-banner">{error}</div>}
         <div className="modal-footer">
           <button className="btn-brutal" onClick={onClose}>Cancel</button>
-          <button className="btn-brutal btn-cyan" onClick={handleSave} disabled={saving}>
+          <button className="btn-brutal btn-cyan" onClick={handleSave} disabled={saving || !state.model.trim()}>
             {saving ? 'Saving...' : 'Save'}
           </button>
         </div>

--- a/ui/src/hooks/useRuntimeModels.ts
+++ b/ui/src/hooks/useRuntimeModels.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { listRuntimeModels } from '../api'
+
+export function useRuntimeModels(runtime: string): {
+  runtimeModels: string[]
+  runtimeModelsError: string | null
+} {
+  const [runtimeModels, setRuntimeModels] = useState<string[]>([])
+  const [runtimeModelsError, setRuntimeModelsError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setRuntimeModels([])
+    setRuntimeModelsError(null)
+
+    async function refreshRuntimeModels() {
+      try {
+        const nextModels = await listRuntimeModels(runtime)
+        if (!cancelled) {
+          setRuntimeModels(nextModels)
+          setRuntimeModelsError(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setRuntimeModels([])
+          setRuntimeModelsError(String(err))
+        }
+      }
+    }
+
+    void refreshRuntimeModels()
+
+    return () => {
+      cancelled = true
+    }
+  }, [runtime])
+
+  return { runtimeModels, runtimeModelsError }
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -32,7 +32,7 @@ export interface AgentEnvVar {
 export type RuntimeAuthStatus = 'authed' | 'unauthed'
 
 export interface RuntimeStatusInfo {
-  runtime: 'claude' | 'codex' | 'kimi' | string
+  runtime: 'claude' | 'codex' | 'kimi' | 'opencode' | string
   installed: boolean
   authStatus?: RuntimeAuthStatus
 }


### PR DESCRIPTION
Add support for anomalyco/opencode as a new agent runtime. OpenCode is
a provider-agnostic AI coding CLI that supports streaming JSON events,
MCP tools, and session resume.

Driver characteristics:
- Spawns `opencode run --format json` with MCP config in opencode.json
- Parses JSONL events: text, tool_use, reasoning, step_start/finish, error
- MCP tool prefix: mcp_chat_ (matching OpenCode's mcp_{server}_{tool} convention)
- Session resume via --session flag (like Codex)
- No stdin notification (process exits after idle, restarts on new work)
- Reasoning effort passed as --variant flag
- Supports multi-provider models (anthropic/*, openai/*, google/*)

https://claude.ai/code/session_01GAmZE6sfaiEtHrYLFF9b15