### PR TITLE
fix(ui): polish select menu states

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -196,3 +196,28 @@ body {
   border-radius: 0;
 }
 ::-webkit-scrollbar-thumb:hover { background: rgba(35, 32, 26, 0.24); }
+
+.select-trigger-text,
+.select-trigger-loading {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.select-trigger-loading {
+  gap: 8px;
+  color: var(--color-muted-foreground);
+}
+
+.select-trigger-spinner {
+  flex: 0 0 auto;
+  animation: form-control-spin 0.9s linear infinite;
+}
+
+@keyframes form-control-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/ui/src/components/agents/AgentConfigForm.test.ts
+++ b/ui/src/components/agents/AgentConfigForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isRuntimeAvailable, runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
+import { isRuntimeAvailable, modelSelectDisplayLabel, runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
 
 describe('runtimeOptionLabel', () => {
   it('shows not installed copy when the runtime is missing', () => {
@@ -53,5 +53,23 @@ describe('runtimeStatusSummary', () => {
       detail:
         'The CLI is installed, but local authentication needs to be completed before agent startup will work reliably.',
     })
+  })
+})
+
+describe('modelSelectDisplayLabel', () => {
+  it('shows loading copy while models are being fetched', () => {
+    expect(modelSelectDisplayLabel({
+      selectedModel: 'openai/gpt-5.4',
+      runtimeModels: [],
+      isLoading: true,
+    })).toBe('Loading models…')
+  })
+
+  it('falls back to the first available model when the selection is empty', () => {
+    expect(modelSelectDisplayLabel({
+      selectedModel: '',
+      runtimeModels: ['openai/codex-mini-latest'],
+      isLoading: false,
+    })).toBe('openai/codex-mini-latest')
   })
 })

--- a/ui/src/components/agents/AgentConfigForm.tsx
+++ b/ui/src/components/agents/AgentConfigForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { LoaderCircle } from "lucide-react";
 import type { AgentEnvVar, RuntimeStatusInfo } from "./types";
 import { useRuntimeModels } from "../../hooks/useRuntimeModels";
 import {
@@ -120,6 +121,21 @@ function groupModelsByProvider(
     .map(([provider, models]) => ({ provider, models }));
 }
 
+export function modelSelectDisplayLabel({
+  selectedModel,
+  runtimeModels,
+  isLoading,
+}: {
+  selectedModel: string;
+  runtimeModels: string[];
+  isLoading: boolean;
+}): string {
+  if (isLoading) return "Loading models…";
+  if (selectedModel) return selectedModel;
+  if (runtimeModels.length > 0) return runtimeModels[0];
+  return "No models available";
+}
+
 export function AgentConfigForm({
   state,
   runtimeStatuses = [],
@@ -127,7 +143,7 @@ export function AgentConfigForm({
   editableName = false,
   onChange,
 }: Props) {
-  const { runtimeModels, runtimeModelsError } = useRuntimeModels(state.runtime);
+  const { runtimeModels, runtimeModelsError, isLoading } = useRuntimeModels(state.runtime);
 
   useEffect(() => {
     if (runtimeModels.length === 0 || runtimeModels.includes(state.model)) {
@@ -162,6 +178,11 @@ export function AgentConfigForm({
   }
 
   const runtimeSummary = runtimeStatusSummary(state.runtime, runtimeStatuses);
+  const modelLabel = modelSelectDisplayLabel({
+    selectedModel: state.model,
+    runtimeModels,
+    isLoading,
+  });
 
   return (
     <div className="agent-config-form">
@@ -290,9 +311,17 @@ export function AgentConfigForm({
             <Select
               value={state.model}
               onValueChange={(model) => onChange({ ...state, model })}
+              disabled={isLoading || runtimeModels.length === 0}
             >
               <SelectTrigger aria-label="Model">
-                <SelectValue />
+                {isLoading ? (
+                  <span className="select-trigger-loading">
+                    <LoaderCircle size={14} className="select-trigger-spinner" />
+                    <span>{modelLabel}</span>
+                  </span>
+                ) : (
+                  <span className="select-trigger-text">{modelLabel}</span>
+                )}
               </SelectTrigger>
               <SelectContent className="max-h-[320px] overflow-y-auto">
                 {groupModelsByProvider(runtimeModels).map(

--- a/ui/src/components/chat/ChatPanel.css
+++ b/ui/src/components/chat/ChatPanel.css
@@ -402,12 +402,14 @@
   border: 1px solid transparent;
   transition:
     background-color 0.15s ease,
-    border-color 0.15s ease;
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .mention-pill-clickable:hover {
   background: var(--color-primary);
-  border-color: var(--border-strong);
+  border-color: var(--color-primary);
+  color: #f8f6f1;
 }
 
 .message-attachments {

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -14,13 +14,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex w-full items-center justify-between",
+      "flex w-full items-center justify-between gap-3",
       "min-h-[46px] px-3 py-2",
       "border border-input rounded-none bg-muted",
       "font-mono text-[13px]",
       "transition-colors",
       "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
       "disabled:opacity-45 disabled:cursor-not-allowed",
+      "[&>span]:min-w-0 [&>span]:flex-1",
       className
     )}
     {...props}
@@ -53,7 +54,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          "p-0",
+          "max-h-80 p-1",
           position === "popper" && "w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
@@ -84,8 +85,9 @@ const SelectItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center",
-      "min-h-11 pl-6 pr-13 py-2",
-      "text-sm outline-none",
+      "min-h-[38px] pl-[14px] pr-10 py-2",
+      "border-b border-border text-[13px] leading-5 outline-none",
+      "transition-colors last:border-b-0",
       "data-[state=checked]:bg-secondary data-[state=checked]:text-foreground",
       "focus:bg-secondary focus:text-foreground",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -93,12 +95,14 @@ const SelectItem = React.forwardRef<
     )}
     {...props}
   >
-    <span className="absolute right-5 flex h-4 w-4 items-center justify-center">
+    <span className="absolute right-3 flex h-4 w-4 items-center justify-center text-muted-foreground">
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemText>
+      <span className="block truncate">{children}</span>
+    </SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName

--- a/ui/src/hooks/useRuntimeModels.ts
+++ b/ui/src/hooks/useRuntimeModels.ts
@@ -4,14 +4,17 @@ import { listRuntimeModels } from '../data'
 export function useRuntimeModels(runtime: string): {
   runtimeModels: string[]
   runtimeModelsError: string | null
+  isLoading: boolean
 } {
   const [runtimeModels, setRuntimeModels] = useState<string[]>([])
   const [runtimeModelsError, setRuntimeModelsError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     setRuntimeModels([])
     setRuntimeModelsError(null)
+    setIsLoading(true)
 
     async function refreshRuntimeModels() {
       try {
@@ -19,11 +22,13 @@ export function useRuntimeModels(runtime: string): {
         if (!cancelled) {
           setRuntimeModels(nextModels)
           setRuntimeModelsError(null)
+          setIsLoading(false)
         }
       } catch (err) {
         if (!cancelled) {
           setRuntimeModels([])
           setRuntimeModelsError(String(err))
+          setIsLoading(false)
         }
       }
     }
@@ -35,5 +40,5 @@ export function useRuntimeModels(runtime: string): {
     }
   }, [runtime])
 
-  return { runtimeModels, runtimeModelsError }
+  return { runtimeModels, runtimeModelsError, isLoading }
 }


### PR DESCRIPTION
## Summary
- tighten shared select menu styling so dropdown items match the modal form system
- show model loading state directly inside the select trigger while runtime models are fetched
- fix mention pill hover contrast so text remains readable

## Verification
- npm test -- AgentConfigForm.test.ts
- npm run build