### PR TITLE
feat: disable unavailable runtimes in agent config form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file is the working contract for agents. Read it before making changes.
 | Rule                       | Example                                                              |
 | -------------------------- | -------------------------------------------------------------------- |
 | Names are documentation    | `isLoading` not `loading`; `hasPermission()` not `checkPermission()` |
+| Name for the reason, not the control | `isRuntimeAvailable` not `canSelectRuntime`              |
 | One word per concept       | Don't alternate fetch/get/retrieve/load                              |
 | Booleans read as questions | `isLoading`, `hasError`, `canSubmit`                                 |
 | No cryptic shortcuts       | `id`, `url`, `err` ok in narrow scopes only                          |

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -20,6 +20,10 @@ describe('runtimeOptionLabel', () => {
 })
 
 describe('isRuntimeAvailable', () => {
+  it('returns false when the runtime status is unavailable', () => {
+    expect(isRuntimeAvailable('claude', [])).toBe(false)
+  })
+
   it('returns false for runtimes that are not installed', () => {
     expect(
       isRuntimeAvailable('kimi', [

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
+import { isRuntimeAvailable, runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
 
 describe('runtimeOptionLabel', () => {
   it('shows not installed copy when the runtime is missing', () => {
@@ -16,6 +16,24 @@ describe('runtimeOptionLabel', () => {
         { runtime: 'claude', installed: true, authStatus: 'authed' },
       ])
     ).toContain('signed in')
+  })
+})
+
+describe('isRuntimeAvailable', () => {
+  it('returns false for runtimes that are not installed', () => {
+    expect(
+      isRuntimeAvailable('kimi', [
+        { runtime: 'kimi', installed: false },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true for installed runtimes', () => {
+    expect(
+      isRuntimeAvailable('codex', [
+        { runtime: 'codex', installed: true, authStatus: 'unauthed' },
+      ])
+    ).toBe(true)
   })
 })
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -54,7 +54,7 @@ export function isRuntimeAvailable(
   runtimeStatuses: RuntimeStatusInfo[] = [],
 ): boolean {
   const status = runtimeStatuses.find((entry) => entry.runtime === runtime)
-  return status?.installed !== false
+  return status?.installed === true
 }
 
 export function runtimeStatusSummary(

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -49,6 +49,14 @@ export function runtimeOptionLabel(
   return `${baseLabel} · not signed in`
 }
 
+export function isRuntimeAvailable(
+  runtime: string,
+  runtimeStatuses: RuntimeStatusInfo[] = [],
+): boolean {
+  const status = runtimeStatuses.find((entry) => entry.runtime === runtime)
+  return status?.installed !== false
+}
+
 export function runtimeStatusSummary(
   runtime: string,
   runtimeStatuses: RuntimeStatusInfo[] = [],
@@ -190,10 +198,18 @@ export function AgentConfigForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="claude">{runtimeOptionLabel('claude', runtimeStatuses)}</SelectItem>
-                <SelectItem value="codex">{runtimeOptionLabel('codex', runtimeStatuses)}</SelectItem>
-                <SelectItem value="kimi">{runtimeOptionLabel('kimi', runtimeStatuses)}</SelectItem>
-                <SelectItem value="opencode">{runtimeOptionLabel('opencode', runtimeStatuses)}</SelectItem>
+                <SelectItem value="claude" disabled={!isRuntimeAvailable('claude', runtimeStatuses)}>
+                  {runtimeOptionLabel('claude', runtimeStatuses)}
+                </SelectItem>
+                <SelectItem value="codex" disabled={!isRuntimeAvailable('codex', runtimeStatuses)}>
+                  {runtimeOptionLabel('codex', runtimeStatuses)}
+                </SelectItem>
+                <SelectItem value="kimi" disabled={!isRuntimeAvailable('kimi', runtimeStatuses)}>
+                  {runtimeOptionLabel('kimi', runtimeStatuses)}
+                </SelectItem>
+                <SelectItem value="opencode" disabled={!isRuntimeAvailable('opencode', runtimeStatuses)}>
+                  {runtimeOptionLabel('opencode', runtimeStatuses)}
+                </SelectItem>
               </SelectContent>
             </Select>
             <div className={`runtime-status-banner runtime-status-banner-${runtimeSummary.tone}`}>


### PR DESCRIPTION
## What changed
- disable agent runtime options in the shared create/edit agent form when the backend reports the runtime is not installed
- keep runtime status messaging in place and add a focused predicate test for runtime availability
- document the naming rule in `AGENTS.md` as "Name for the reason, not the control"

## Why
The app already probed local runtime availability, but the modal only labeled missing runtimes instead of preventing users from choosing them.

## Impact
Users can no longer configure agents with runtimes that are unavailable on the local machine from either the create or edit flow.

## Validation
- `cd ui && npm test`

## Verification gap
- Browser QA from `qa/README.md` was not run for the modal interaction itself.
