### PR TITLE
feat(agents): activity log improvements — start entry, tool_name on results, full session id, ActivityEntryKind enum

### DIFF
--- a/src/agent/activity_log.rs
+++ b/src/agent/activity_log.rs
@@ -8,31 +8,22 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ActivityEntry {
+    Start {
+        is_resume: bool,
+    },
     Thinking {
         text: String,
     },
-    ToolStart {
+    ToolCall {
         tool_name: String,
         tool_input: String,
     },
+    ToolResult {
+        tool_name: String,
+        content: String,
+    },
     Text {
         text: String,
-    },
-    RawOutput {
-        text: String,
-    },
-    MessageReceived {
-        channel_label: String,
-        sender_name: String,
-        content: String,
-    },
-    MessageSent {
-        target: String,
-        content: String,
-    },
-    Status {
-        activity: String,
-        detail: String,
     },
 }
 
@@ -80,15 +71,8 @@ impl AgentActivityLog {
     }
 
     pub fn set_state(&mut self, activity: &str, detail: &str) {
-        if self.activity == activity && self.detail == detail {
-            return;
-        }
         self.activity = activity.to_string();
         self.detail = detail.to_string();
-        self.push(ActivityEntry::Status {
-            activity: activity.to_string(),
-            detail: detail.to_string(),
-        });
     }
 
     pub fn entries_since(&self, after_seq: u64) -> Vec<ActivityLogEntry> {
@@ -166,7 +150,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_set_activity_state_skips_duplicate_entries() {
+    fn test_set_activity_state_does_not_emit_log_entries() {
         let logs = ActivityLogMap::default();
 
         set_activity_state(&logs, "bot1", "online", "Idle");
@@ -175,8 +159,10 @@ mod tests {
         let resp = get_activity_log(&logs, "bot1", None);
         assert_eq!(
             resp.entries.len(),
-            1,
-            "duplicate state transitions should not create duplicate log rows"
+            0,
+            "set_activity_state should not create log entries — only updates activity state fields"
         );
+        assert_eq!(resp.agent_activity, "online");
+        assert_eq!(resp.agent_detail, "Idle");
     }
 }

--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -77,13 +77,18 @@ impl Driver for ClaudeDriver {
             .spawn()?;
 
         // Send initial user message via stdin
-        let stdin_msg = serde_json::json!({
+        let mut stdin_msg = serde_json::json!({
             "type": "user",
             "message": {
                 "role": "user",
                 "content": [{"type": "text", "text": &ctx.prompt}]
             }
         });
+        if let Some(ref sid) = ctx.config.session_id {
+            if !sid.is_empty() {
+                stdin_msg["session_id"] = serde_json::Value::String(sid.clone());
+            }
+        }
 
         if let Some(ref mut stdin) = child.stdin {
             let mut line = serde_json::to_string(&stdin_msg)?;
@@ -151,6 +156,39 @@ impl Driver for ClaudeDriver {
                     }
                 }
             }
+            Some("user") => {
+                if let Some(content) = event
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
+                    for block in content {
+                        if block.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
+                            let content_val = block.get("content");
+                            let text = match content_val {
+                                Some(serde_json::Value::String(s)) => s.clone(),
+                                Some(serde_json::Value::Array(arr)) => arr
+                                    .iter()
+                                    .filter_map(|b| {
+                                        if b.get("type").and_then(|v| v.as_str()) == Some("text") {
+                                            b.get("text")
+                                                .and_then(|v| v.as_str())
+                                                .map(str::to_string)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n"),
+                                _ => String::new(),
+                            };
+                            if !text.is_empty() {
+                                events.push(ParsedEvent::ToolResult { content: text });
+                            }
+                        }
+                    }
+                }
+            }
             Some("result") => {
                 let session_id = event
                     .get("session_id")
@@ -205,8 +243,6 @@ impl Driver for ClaudeDriver {
         match name {
             "mcp__chat__send_message" => "Sending message\u{2026}".to_string(),
             "mcp__chat__check_messages" => "Checking messages\u{2026}".to_string(),
-            "mcp__chat__wait_for_message" => "Waiting for messages\u{2026}".to_string(),
-            "mcp__chat__receive_message" => "Receiving messages\u{2026}".to_string(),
             "mcp__chat__upload_file" => "Uploading file\u{2026}".to_string(),
             "mcp__chat__view_file" => "Viewing file\u{2026}".to_string(),
             "mcp__chat__list_tasks" => "Listing tasks\u{2026}".to_string(),

--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -411,3 +411,94 @@ impl Driver for ClaudeDriver {
         ])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::drivers::{Driver, ParsedEvent};
+
+    #[test]
+    fn parse_line_ignores_non_json() {
+        let d = ClaudeDriver;
+        assert!(d.parse_line("not json").is_empty());
+        assert!(d.parse_line("").is_empty());
+    }
+
+    #[test]
+    fn parse_line_session_init() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"system","subtype":"init","session_id":"sess-abc"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::SessionInit { session_id } if session_id == "sess-abc")
+        );
+    }
+
+    #[test]
+    fn parse_line_thinking_block() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"let me reason"}]}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Thinking { text } if text == "let me reason"));
+    }
+
+    #[test]
+    fn parse_line_text_block() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Text { text } if text == "hello"));
+    }
+
+    #[test]
+    fn parse_line_tool_use_block() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__chat__send_message","input":{}}]}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "mcp__chat__send_message")
+        );
+    }
+
+    #[test]
+    fn parse_line_tool_result_string() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::ToolResult { content } if content == "ok"));
+    }
+
+    #[test]
+    fn parse_line_tool_result_array() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"user","message":{"content":[{"type":"tool_result","content":[{"type":"text","text":"line1"},{"type":"text","text":"line2"}]}]}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolResult { content } if content == "line1\nline2")
+        );
+    }
+
+    #[test]
+    fn parse_line_turn_end_with_session() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"result","session_id":"sess-xyz"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::TurnEnd { session_id: Some(id) } if id == "sess-xyz")
+        );
+    }
+
+    #[test]
+    fn parse_line_multiple_content_blocks() {
+        let d = ClaudeDriver;
+        let events = d.parse_line(r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"done"},{"type":"tool_use","name":"bash","input":{}}]}}"#);
+        assert_eq!(events.len(), 3);
+        assert!(matches!(&events[0], ParsedEvent::Thinking { .. }));
+        assert!(matches!(&events[1], ParsedEvent::Text { text } if text == "done"));
+        assert!(matches!(&events[2], ParsedEvent::ToolCall { name, .. } if name == "bash"));
+    }
+}

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -534,4 +534,121 @@ mod tests {
 
         assert_eq!(status, RuntimeAuthStatus::Authed);
     }
+
+    #[test]
+    fn parse_line_ignores_non_json() {
+        let d = CodexDriver;
+        assert!(d.parse_line("plaintext").is_empty());
+        assert!(d.parse_line("").is_empty());
+    }
+
+    #[test]
+    fn parse_line_thread_started() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"thread.started","thread_id":"thread-1"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::SessionInit { session_id } if session_id == "thread-1")
+        );
+    }
+
+    #[test]
+    fn parse_line_turn_started() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"turn.started"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Thinking { .. }));
+    }
+
+    #[test]
+    fn parse_line_reasoning_item() {
+        let d = CodexDriver;
+        let events = d.parse_line(
+            r#"{"type":"item.updated","item":{"type":"reasoning","text":"thinking hard"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Thinking { text } if text == "thinking hard"));
+    }
+
+    #[test]
+    fn parse_line_agent_message_completed() {
+        let d = CodexDriver;
+        let events = d.parse_line(
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"all done"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Text { text } if text == "all done"));
+    }
+
+    #[test]
+    fn parse_line_agent_message_started_ignored() {
+        let d = CodexDriver;
+        // agent_message only produces Text on item.completed
+        assert!(d
+            .parse_line(
+                r#"{"type":"item.started","item":{"type":"agent_message","text":"partial"}}"#
+            )
+            .is_empty());
+    }
+
+    #[test]
+    fn parse_line_command_execution() {
+        let d = CodexDriver;
+        let events = d.parse_line(
+            r#"{"type":"item.started","item":{"type":"command_execution","command":"ls -la"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        let ParsedEvent::ToolCall { name, input } = &events[0] else {
+            panic!("expected ToolCall")
+        };
+        assert_eq!(name, "shell");
+        assert_eq!(input["command"], "ls -la");
+    }
+
+    #[test]
+    fn parse_line_mcp_tool_call_started() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"item.started","item":{"type":"mcp_tool_call","server":"chat","tool":"send_message","arguments":{}}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "mcp_chat_send_message")
+        );
+    }
+
+    #[test]
+    fn parse_line_mcp_tool_result() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"chat","tool":"send_message","output":"sent"}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::ToolResult { content } if content == "sent"));
+    }
+
+    #[test]
+    fn parse_line_turn_completed() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"turn.completed"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::TurnEnd { .. }));
+    }
+
+    #[test]
+    fn parse_line_turn_failed() {
+        let d = CodexDriver;
+        let events = d.parse_line(r#"{"type":"turn.failed","error":{"message":"rate limited"}}"#);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], ParsedEvent::Error { message } if message == "rate limited"));
+        assert!(matches!(&events[1], ParsedEvent::TurnEnd { .. }));
+    }
+
+    #[test]
+    fn parse_line_item_error() {
+        let d = CodexDriver;
+        let events = d.parse_line(
+            r#"{"type":"item.completed","item":{"type":"error","message":"context exceeded"}}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::Error { message } if message == "context exceeded")
+        );
+    }
 }

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -232,6 +232,14 @@ impl Driver for CodexDriver {
                                     name,
                                     input: arguments,
                                 });
+                            } else if event_type == "item.completed" {
+                                if let Some(output) = item.get("output").and_then(|v| v.as_str()) {
+                                    if !output.is_empty() {
+                                        events.push(ParsedEvent::ToolResult {
+                                            content: output.to_string(),
+                                        });
+                                    }
+                                }
                             }
                         }
                         "collab_tool_call" => {
@@ -318,10 +326,9 @@ impl Driver for CodexDriver {
                 tool_prefix: "mcp_chat_".to_string(),
                 extra_critical_rules: vec![
                     "- Do NOT use shell commands to send or receive messages. The MCP tools handle everything.".to_string(),
-                    "- ALWAYS call `mcp_chat_wait_for_message()` after completing any task so you return to the idle loop.".to_string(),
                 ],
                 post_startup_notes: vec![
-                    "**IMPORTANT**: Your process may exit after an idle wait completes. The server will resume you when new work arrives.".to_string(),
+                    "**IMPORTANT**: Your process may exit after completing a task. The server will wake you when new work arrives.".to_string(),
                 ],
                 include_stdin_notification_section: false,
                 teams: config.teams.clone(),
@@ -333,8 +340,6 @@ impl Driver for CodexDriver {
         match name {
             "mcp_chat_send_message" => "Sending message\u{2026}".to_string(),
             "mcp_chat_check_messages" => "Checking messages\u{2026}".to_string(),
-            "mcp_chat_wait_for_message" => "Waiting for messages\u{2026}".to_string(),
-            "mcp_chat_receive_message" => "Receiving messages\u{2026}".to_string(),
             "mcp_chat_upload_file" => "Uploading file\u{2026}".to_string(),
             "mcp_chat_view_file" => "Viewing file\u{2026}".to_string(),
             "mcp_chat_list_tasks" => "Listing tasks\u{2026}".to_string(),

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -447,4 +447,70 @@ mod tests {
             assert_eq!(status.auth_status, None);
         }
     }
+
+    #[test]
+    fn parse_line_ignores_non_json() {
+        let d = KimiDriver;
+        assert!(d.parse_line("not json").is_empty());
+        assert!(d.parse_line("").is_empty());
+    }
+
+    #[test]
+    fn parse_line_assistant_text_string() {
+        let d = KimiDriver;
+        let events = d.parse_line(r#"{"role":"assistant","content":"hello world"}"#);
+        // No tool calls → TurnEnd appended after Text
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], ParsedEvent::Text { text } if text == "hello world"));
+        assert!(matches!(&events[1], ParsedEvent::TurnEnd { .. }));
+    }
+
+    #[test]
+    fn parse_line_assistant_text_block_array() {
+        let d = KimiDriver;
+        let events =
+            d.parse_line(r#"{"role":"assistant","content":[{"type":"text","text":"hi"}]}"#);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], ParsedEvent::Text { text } if text == "hi"));
+        assert!(matches!(&events[1], ParsedEvent::TurnEnd { .. }));
+    }
+
+    #[test]
+    fn parse_line_assistant_tool_use_block() {
+        let d = KimiDriver;
+        let events = d.parse_line(r#"{"role":"assistant","content":[{"type":"tool_use","name":"mcp__chat__send_message","input":{}}]}"#);
+        // has_tool_calls = true → no TurnEnd
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "send_message"));
+    }
+
+    #[test]
+    fn parse_line_assistant_tool_calls_field() {
+        let d = KimiDriver;
+        let events = d.parse_line(r#"{"role":"assistant","content":null,"tool_calls":[{"function":{"name":"mcp__chat__check_messages","arguments":"{}"}}]}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "check_messages")
+        );
+    }
+
+    #[test]
+    fn parse_line_tool_result() {
+        let d = KimiDriver;
+        let events = d.parse_line(r#"{"role":"tool","content":"message sent"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolResult { content } if content == "message sent")
+        );
+    }
+
+    #[test]
+    fn parse_line_error() {
+        let d = KimiDriver;
+        let events = d.parse_line(r#"{"role":"error","message":"quota exceeded"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::Error { message } if message == "quota exceeded")
+        );
+    }
 }

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -182,7 +182,16 @@ impl Driver for KimiDriver {
                     events.push(ParsedEvent::TurnEnd { session_id: None });
                 }
             }
-            Some("tool") => {}
+            Some("tool") => {
+                let content = event
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !content.is_empty() {
+                    events.push(ParsedEvent::ToolResult { content });
+                }
+            }
             Some("error") => {
                 let message = event
                     .get("message")
@@ -213,9 +222,8 @@ impl Driver for KimiDriver {
                 tool_prefix: "".to_string(),
                 extra_critical_rules: vec![
                     "- Do NOT use bash/curl/sqlite to send or receive messages. The MCP tools handle everything.".to_string(),
-                    "- Call `wait_for_message()` when you are idle so the agent stays in the receive loop.".to_string(),
-                    "- After `wait_for_message()` or `check_messages()` returns a real user message, you must either send a reply or deliberately explain why no reply is needed before going idle again.".to_string(),
-                    "- Direct messages and explicit @mentions are addressed to you. Do not silently consume them and return to waiting.".to_string(),
+                    "- After `check_messages()` returns a real user message, you must either send a reply or deliberately explain why no reply is needed before stopping.".to_string(),
+                    "- Direct messages and explicit @mentions are addressed to you. Do not silently consume them and stop.".to_string(),
                     "- Never treat raw assistant stdout as a user-visible reply. Any reply meant for humans must be delivered with `send_message()`.".to_string(),
                 ],
                 post_startup_notes: vec![],
@@ -229,8 +237,6 @@ impl Driver for KimiDriver {
         match name {
             "send_message" => "Sending message…".to_string(),
             "check_messages" => "Checking messages…".to_string(),
-            "wait_for_message" => "Waiting for messages…".to_string(),
-            "receive_message" => "Receiving messages…".to_string(),
             "upload_file" => "Uploading file…".to_string(),
             "view_file" => "Viewing file…".to_string(),
             "list_tasks" => "Listing tasks…".to_string(),

--- a/src/agent/drivers/mod.rs
+++ b/src/agent/drivers/mod.rs
@@ -33,6 +33,9 @@ pub enum ParsedEvent {
         name: String,
         input: serde_json::Value,
     },
+    ToolResult {
+        content: String,
+    },
     TurnEnd {
         session_id: Option<String>,
     },

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -186,10 +186,9 @@ impl Driver for OpencodeDriver {
                 tool_prefix: "chat_".to_string(),
                 extra_critical_rules: vec![
                     "- Do NOT use shell commands to send or receive messages. The MCP tools handle everything.".to_string(),
-                    "- ALWAYS call `chat_wait_for_message()` after completing any task so you return to the idle loop.".to_string(),
                 ],
                 post_startup_notes: vec![
-                    "**IMPORTANT**: Your process may exit after an idle wait completes. The server will resume you when new work arrives.".to_string(),
+                    "**IMPORTANT**: Complete your work and stop. The server will wake you when new work arrives.".to_string(),
                 ],
                 include_stdin_notification_section: false,
                 teams: config.teams.clone(),
@@ -201,8 +200,6 @@ impl Driver for OpencodeDriver {
         match name {
             "chat_send_message" => "Sending message\u{2026}".to_string(),
             "chat_check_messages" => "Checking messages\u{2026}".to_string(),
-            "chat_wait_for_message" => "Waiting for messages\u{2026}".to_string(),
-            "chat_receive_message" => "Receiving messages\u{2026}".to_string(),
             "chat_upload_file" => "Uploading file\u{2026}".to_string(),
             "chat_view_file" => "Viewing file\u{2026}".to_string(),
             "chat_list_tasks" => "Listing tasks\u{2026}".to_string(),
@@ -255,7 +252,7 @@ impl Driver for OpencodeDriver {
                 }
             }
             "web_search" => str_field("query"),
-            "chat_check_messages" | "chat_wait_for_message" => String::new(),
+            "chat_check_messages" => String::new(),
             "chat_send_message" => {
                 let t = str_field("target");
                 if t.is_empty() {

--- a/src/agent/drivers/opencode.rs
+++ b/src/agent/drivers/opencode.rs
@@ -457,4 +457,83 @@ mod tests {
             ParsedEvent::SessionInit { session_id } if session_id == "sess-99"
         ));
     }
+
+    #[test]
+    fn parse_line_ignores_non_json() {
+        let d = OpencodeDriver;
+        assert!(d.parse_line("not json").is_empty());
+        assert!(d.parse_line("").is_empty());
+    }
+
+    #[test]
+    fn parse_line_step_start() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"step_start","sessionID":"sess-oc-1"}"#);
+        assert_eq!(events.len(), 2);
+        assert!(
+            matches!(&events[0], ParsedEvent::SessionInit { session_id } if session_id == "sess-oc-1")
+        );
+        assert!(matches!(&events[1], ParsedEvent::Thinking { .. }));
+    }
+
+    #[test]
+    fn parse_line_reasoning() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"reasoning","part":{"text":"pondering"}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Thinking { text } if text == "pondering"));
+    }
+
+    #[test]
+    fn parse_line_text() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"text","part":{"text":"done"}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Text { text } if text == "done"));
+    }
+
+    #[test]
+    fn parse_line_tool_use_pending() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"tool_use","part":{"state":"pending","tool":"chat_send_message","input":{}}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "chat_send_message")
+        );
+    }
+
+    #[test]
+    fn parse_line_tool_use_completed_ignored() {
+        let d = OpencodeDriver;
+        // only pending/running states emit ToolCall
+        assert!(d.parse_line(r#"{"type":"tool_use","part":{"state":"completed","tool":"chat_send_message","input":{}}}"#).is_empty());
+    }
+
+    #[test]
+    fn parse_line_step_finish_with_session() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"step_finish","sessionID":"sess-oc-2"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::TurnEnd { session_id: Some(id) } if id == "sess-oc-2")
+        );
+    }
+
+    #[test]
+    fn parse_line_error_nested() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"error","error":{"message":"network failure"}}"#);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], ParsedEvent::Error { message } if message == "network failure")
+        );
+    }
+
+    #[test]
+    fn parse_line_error_flat() {
+        let d = OpencodeDriver;
+        let events = d.parse_line(r#"{"type":"error","message":"timeout"}"#);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], ParsedEvent::Error { message } if message == "timeout"));
+    }
 }

--- a/src/agent/drivers/prompt.rs
+++ b/src/agent/drivers/prompt.rs
@@ -31,7 +31,7 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
     let startup_steps = [
         "1. **Read MEMORY.md** (in your cwd). This is your memory index — it tells you what you know and where to find it.".to_string(),
         "2. Follow the instructions in MEMORY.md to read any other memory files you need (e.g. channel summaries, role definitions, user preferences).".to_string(),
-        "3. If there is no concrete incoming message to handle, stop and wait. New messages will be delivered to you automatically via stdin.".to_string(),
+        "3. If there is no concrete incoming message to handle, stop and wait. New messages will be delivered to you automatically.".to_string(),
         format!("4. When you receive a message, process it and reply with {}.", t("send_message")),
         format!("5. **Complete ALL your work before stopping.** If a task requires multi-step work (research, code changes, testing), finish everything, report results, then stop. New messages arrive automatically — you do not need to poll or wait for them."),
     ];

--- a/src/agent/drivers/prompt.rs
+++ b/src/agent/drivers/prompt.rs
@@ -33,7 +33,7 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
         "2. Follow the instructions in MEMORY.md to read any other memory files you need (e.g. channel summaries, role definitions, user preferences).".to_string(),
         "3. If there is no concrete incoming message to handle, stop and wait. New messages will be delivered to you automatically.".to_string(),
         format!("4. When you receive a message, process it and reply with {}.", t("send_message")),
-        format!("5. **Complete ALL your work before stopping.** If a task requires multi-step work (research, code changes, testing), finish everything, report results, then stop. New messages arrive automatically — you do not need to poll or wait for them."),
+        "5. **Complete ALL your work before stopping.** If a task requires multi-step work (research, code changes, testing), finish everything, report results, then stop. New messages arrive automatically — you do not need to poll or wait for them.".to_string(),
     ];
 
     let display_name = &config.display_name;

--- a/src/agent/drivers/prompt.rs
+++ b/src/agent/drivers/prompt.rs
@@ -31,10 +31,9 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
     let startup_steps = [
         "1. **Read MEMORY.md** (in your cwd). This is your memory index — it tells you what you know and where to find it.".to_string(),
         "2. Follow the instructions in MEMORY.md to read any other memory files you need (e.g. channel summaries, role definitions, user preferences).".to_string(),
-        format!("3. If you have no work in progress, call {}() to enter the idle loop.", t("wait_for_message")),
+        "3. If there is no concrete incoming message to handle, stop and wait. New messages will be delivered to you automatically via stdin.".to_string(),
         format!("4. When you receive a message, process it and reply with {}.", t("send_message")),
-        format!("5. While work is still in progress, do NOT call {}(). At natural checkpoints, you may call {}() to check for newly arrived messages.", t("wait_for_message"), t("check_messages")),
-        format!("6. After you have finished all work and sent your updates, call {}() again to return to the idle loop.", t("wait_for_message")),
+        format!("5. **Complete ALL your work before stopping.** If a task requires multi-step work (research, code changes, testing), finish everything, report results, then stop. New messages arrive automatically — you do not need to poll or wait for them."),
     ];
 
     let display_name = &config.display_name;
@@ -49,7 +48,6 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
     let startup_steps_text = startup_steps.join("\n");
 
     let check_messages = t("check_messages");
-    let wait_for_message = t("wait_for_message");
     let send_message = t("send_message");
     let list_server = t("list_server");
     let read_history = t("read_history");
@@ -84,18 +82,17 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
         "You have MCP tools from the \"chat\" server. Use ONLY these for communication:\n\n",
     );
     prompt.push_str(&format!(
-        "1. **{wait_for_message}** — Block and wait for new messages only when you have no work left to do.\n\
-         2. **{check_messages}** — Check for newly arrived messages without going idle.\n\
-         3. **{send_message}** — Send a message to a channel or DM.\n\
-         4. **{list_server}** — List all channels in this server, which ones you have joined, plus all agents and humans.\n\
-         5. **{read_history}** — Read past messages from a channel or DM.\n\
-         6. **{list_tasks}** — View a channel's task board.\n\
-         7. **{create_tasks}** — Create tasks on a channel's task board (supports batch).\n\
-         8. **{claim_tasks}** — Claim tasks by number (supports batch, handles conflicts).\n\
-         9. **{unclaim_task}** — Release your claim on a task.\n\
-         10. **{update_task_status}** — Change a task's status (e.g. to in_review or done).\n\
-         11. **{upload_file}** — Upload an image file to attach to a message. Returns an attachment ID to pass to send_message.\n\
-         12. **{view_file}** — Download an attached image by its attachment ID so you can inspect it when a message includes relevant attachments.",
+        "1. **{check_messages}** — Non-blocking check for new messages. Use freely during work — at natural breakpoints or after notifications.\n\
+         2. **{send_message}** — Send a message to a channel or DM.\n\
+         3. **{list_server}** — List all channels in this server, which ones you have joined, plus all agents and humans.\n\
+         4. **{read_history}** — Read past messages from a channel or DM.\n\
+         5. **{list_tasks}** — View a channel's task board.\n\
+         6. **{create_tasks}** — Create tasks on a channel's task board (supports batch).\n\
+         7. **{claim_tasks}** — Claim tasks by number (supports batch, handles conflicts).\n\
+         8. **{unclaim_task}** — Release your claim on a task.\n\
+         9. **{update_task_status}** — Change a task's status (e.g. to in_review or done).\n\
+         10. **{upload_file}** — Upload an image file to attach to a message. Returns an attachment ID to pass to send_message.\n\
+         11. **{view_file}** — Download an attached image by its attachment ID so you can inspect it when a message includes relevant attachments.",
     ));
 
     prompt.push_str("\n\nCRITICAL RULES:\n");
@@ -268,9 +265,9 @@ pub fn build_base_system_prompt(config: &AgentConfig, opts: &PromptOptions) -> S
             "- After completing your current step, call `{check_messages}()` to check for messages.\n"
         ));
         prompt.push_str("- Do not ignore notifications for too long — acknowledge new messages in a timely manner.\n");
-        prompt.push_str(&format!(
-            "- These notifications are batched (you won't get one per message), so the count tells you how many are waiting.\n- `{check_messages}()` returns immediately; `{wait_for_message}()` is only for returning to the idle loop."
-        ));
+        prompt.push_str(
+            "- These notifications are batched (you won't get one per message), so the count tells you how many are waiting.\n- `check_messages()` returns immediately with any pending messages."
+        );
     }
 
     // Optional initial role section

--- a/src/agent/lifecycle.rs
+++ b/src/agent/lifecycle.rs
@@ -3,7 +3,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::agent::activity_log::{ActivityEntry, ActivityLogResponse};
+use crate::agent::activity_log::ActivityLogResponse;
 use crate::store::messages::ReceivedMessage;
 
 pub trait AgentLifecycle: Send + Sync {
@@ -30,9 +30,6 @@ pub trait AgentLifecycle: Send + Sync {
     ) -> ActivityLogResponse;
 
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)>;
-
-    /// Append a UI-visible activity entry for an agent.
-    fn push_activity_entry(&self, agent_name: &str, entry: ActivityEntry);
 }
 
 pub(crate) struct NoopAgentLifecycle;
@@ -75,6 +72,4 @@ impl AgentLifecycle for NoopAgentLifecycle {
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)> {
         vec![]
     }
-
-    fn push_activity_entry(&self, _agent_name: &str, _entry: ActivityEntry) {}
 }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -21,8 +21,8 @@ struct RunningAgent {
     process: Child,
     driver: Arc<dyn Driver>,
     session_id: Option<String>,
-    is_in_receive_message: bool,
     pending_notification_count: u32,
+    last_tool_name: Option<String>,
 }
 
 pub struct AgentManager {
@@ -93,7 +93,7 @@ impl AgentManager {
                     .clone()
                     .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
             ),
-            AgentRuntime::Claude => None,
+            AgentRuntime::Claude => agent.session_id.clone(),
         };
 
         let config = AgentConfig {
@@ -177,15 +177,25 @@ impl AgentManager {
                     process: child,
                     driver: driver.clone(),
                     session_id: running_session_id,
-                    is_in_receive_message: false,
                     pending_notification_count: 0,
+                    last_tool_name: None,
                 },
             );
         }
 
         self.store
             .update_agent_status(agent_name, AgentStatus::Active)?;
-        activity_log::set_activity_state(&self.activity_logs, agent_name, "working", "Starting…");
+        activity_log::set_activity_state(
+            &self.activity_logs,
+            agent_name,
+            "working",
+            "Starting\u{2026}",
+        );
+        activity_log::push_activity(
+            &self.activity_logs,
+            agent_name,
+            ActivityEntry::Start { is_resume },
+        );
 
         self.spawn_output_reader(agent_name.to_string(), stdout, driver, instance_id);
         if let Some(stderr) = stderr {
@@ -240,10 +250,7 @@ impl AgentManager {
             None => return Ok(()),
         };
 
-        if !running.driver.supports_stdin_notification()
-            || running.is_in_receive_message
-            || running.session_id.is_none()
-        {
+        if !running.driver.supports_stdin_notification() || running.session_id.is_none() {
             return Ok(());
         }
 
@@ -257,7 +264,7 @@ impl AgentManager {
             let mut agents = agents_ref.lock().await;
             if let Some(running) = agents.get_mut(&name) {
                 let current_count = running.pending_notification_count;
-                if current_count == 0 || running.is_in_receive_message || current_count != count {
+                if current_count == 0 || current_count != count {
                     running.pending_notification_count = 0;
                     return;
                 }
@@ -328,11 +335,6 @@ impl AgentManager {
 
                 if driver.runtime() == AgentRuntime::Kimi {
                     debug!(agent = %name, raw_stdout = %line, "raw agent stdout");
-                    activity_log::push_activity(
-                        &activity_logs,
-                        &name,
-                        ActivityEntry::RawOutput { text: line.clone() },
-                    );
                 }
 
                 for event in driver.parse_line(&line) {
@@ -430,7 +432,6 @@ async fn handle_parsed_event(
             activity_log::set_activity_state(logs, agent_name, "online", "Ready");
         }
         ParsedEvent::Thinking { ref text } => {
-            running.is_in_receive_message = false;
             let preview: String = text.chars().take(120).collect();
             let preview = if text.chars().count() > 120 {
                 format!("{preview}…")
@@ -443,10 +444,8 @@ async fn handle_parsed_event(
                 agent_name,
                 ActivityEntry::Thinking { text: text.clone() },
             );
-            activity_log::set_activity_state(logs, agent_name, "thinking", "Thinking…");
         }
         ParsedEvent::Text { ref text } => {
-            running.is_in_receive_message = false;
             let preview: String = text.chars().take(120).collect();
             let preview = if text.chars().count() > 120 {
                 format!("{preview}…")
@@ -464,46 +463,34 @@ async fn handle_parsed_event(
             ref name,
             ref input,
         } => {
-            let receive_tool = format!("{}receive_message", driver.mcp_tool_prefix());
-            let wait_tool = format!("{}wait_for_message", driver.mcp_tool_prefix());
-            if *name == receive_tool || *name == wait_tool {
-                running.is_in_receive_message = true;
-                running.pending_notification_count = 0;
-                info!(agent = %agent_name, "waiting for messages");
-                let display_name = driver.tool_display_name(name);
-                activity_log::push_activity(
-                    logs,
-                    agent_name,
-                    ActivityEntry::ToolStart {
-                        tool_name: display_name,
-                        tool_input: String::new(),
-                    },
-                );
-                activity_log::set_activity_state(
-                    logs,
-                    agent_name,
-                    "online",
-                    "Waiting for messages",
-                );
-            } else {
-                running.is_in_receive_message = false;
-                let display_name = driver.tool_display_name(name);
-                let tool_input = driver.summarize_tool_input(name, input);
-                info!(agent = %agent_name, tool = %name, input = %tool_input, "tool call");
-                activity_log::push_activity(
-                    logs,
-                    agent_name,
-                    ActivityEntry::ToolStart {
-                        tool_name: display_name.clone(),
-                        tool_input,
-                    },
-                );
-                activity_log::set_activity_state(logs, agent_name, "working", &display_name);
-            }
+            let display_name = driver.tool_display_name(name);
+            let tool_input = driver.summarize_tool_input(name, input);
+            info!(agent = %agent_name, tool = %name, input = %tool_input, "tool call");
+            running.last_tool_name = Some(display_name.clone());
+            activity_log::push_activity(
+                logs,
+                agent_name,
+                ActivityEntry::ToolCall {
+                    tool_name: display_name.clone(),
+                    tool_input,
+                },
+            );
+            activity_log::set_activity_state(logs, agent_name, "working", &display_name);
+        }
+        ParsedEvent::ToolResult { ref content } => {
+            info!(agent = %agent_name, "tool result");
+            let tool_name = running.last_tool_name.clone().unwrap_or_default();
+            activity_log::push_activity(
+                logs,
+                agent_name,
+                ActivityEntry::ToolResult {
+                    tool_name,
+                    content: content.clone(),
+                },
+            );
         }
         ParsedEvent::TurnEnd { session_id } => {
             info!(agent = %agent_name, "turn ended");
-            running.is_in_receive_message = false;
             if let Some(ref sid) = session_id {
                 running.session_id = Some(sid.clone());
                 let _ = store.update_agent_session(agent_name, Some(sid));
@@ -512,14 +499,6 @@ async fn handle_parsed_event(
         }
         ParsedEvent::Error { ref message } => {
             error!(agent = %agent_name, message = %message, "agent error");
-            activity_log::push_activity(
-                logs,
-                agent_name,
-                ActivityEntry::Status {
-                    activity: "error".to_string(),
-                    detail: message.clone(),
-                },
-            );
         }
     }
 }
@@ -558,10 +537,6 @@ impl AgentLifecycle for AgentManager {
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)> {
         activity_log::all_activity_states(&self.activity_logs)
     }
-
-    fn push_activity_entry(&self, agent_name: &str, entry: ActivityEntry) {
-        activity_log::push_activity(&self.activity_logs, agent_name, entry);
-    }
 }
 
 // ── Prompt builder for start/resume ──
@@ -598,7 +573,7 @@ fn build_start_prompt(
         }
         prompt.push_str(
             "\n\nUse read_history to catch up on important channels, \
-             then call the wait_for_message tool to return to the idle loop.",
+             then stop. New messages will be delivered to you automatically.",
         );
         if driver.supports_stdin_notification() {
             prompt.push_str(&format!(
@@ -609,10 +584,8 @@ fn build_start_prompt(
         }
         prompt
     } else {
-        let mut prompt = format!(
-            "No new messages while you were away. \
-             Call {prefix}wait_for_message() to listen for new messages."
-        );
+        let mut prompt =
+            "No new messages while you were away. Nothing to do right now — just stop.".to_string();
         if driver.supports_stdin_notification() {
             prompt.push_str(&format!(
                 "\n\nNote: While you are busy, you may receive \
@@ -656,10 +629,6 @@ fn build_wake_message_prompt(
             prompt.push_str(&format!("\n- {channel_name}: {count} unread"));
         }
     }
-
-    prompt.push_str(&format!(
-        "\n\nAfter you finish the triggered work, return to {prefix}wait_for_message()."
-    ));
 
     prompt
 }
@@ -805,7 +774,7 @@ mod tests {
     }
 
     #[test]
-    fn wake_prompt_for_resumed_agent_mentions_check_and_wait_tools() {
+    fn wake_prompt_for_resumed_agent_mentions_check_tool() {
         let config = sample_config(Some("thread-123"));
         let driver = FakeDriver;
         let prompt = build_start_prompt(
@@ -818,7 +787,10 @@ mod tests {
 
         assert!(prompt.contains("woken by a new unread message"));
         assert!(prompt.contains("mcp_chat_check_messages() now"));
-        assert!(prompt.contains("mcp_chat_wait_for_message()"));
+        assert!(
+            !prompt.contains("wait_for_message"),
+            "push-idle: agents no longer use wait_for_message"
+        );
         assert!(prompt.contains("Please investigate the Codex restart path."));
         assert!(
             !prompt.contains("BASE PROMPT"),
@@ -896,8 +868,8 @@ mod tests {
                     process: first,
                     driver: driver.clone(),
                     session_id: None,
-                    is_in_receive_message: false,
                     pending_notification_count: 0,
+                    last_tool_name: None,
                 },
             );
         }
@@ -924,8 +896,8 @@ mod tests {
                     process: second,
                     driver,
                     session_id: None,
-                    is_in_receive_message: false,
                     pending_notification_count: 0,
+                    last_tool_name: None,
                 },
             );
         }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -130,7 +130,7 @@ impl AgentManager {
         }
         tokio::fs::create_dir_all(agent_data_dir.join("notes")).await?;
 
-        let is_resume = config.session_id.is_some();
+        let is_resume = agent.session_id.is_some();
         let unread_summary = self.store.get_unread_summary(agent_name)?;
 
         let prompt = build_start_prompt(
@@ -444,6 +444,7 @@ async fn handle_parsed_event(
                 agent_name,
                 ActivityEntry::Thinking { text: text.clone() },
             );
+            activity_log::set_activity_state(logs, agent_name, "thinking", "Thinking\u{2026}");
         }
         ParsedEvent::Text { ref text } => {
             let preview: String = text.chars().take(120).collect();
@@ -499,6 +500,7 @@ async fn handle_parsed_event(
         }
         ParsedEvent::Error { ref message } => {
             error!(agent = %agent_name, message = %message, "agent error");
+            activity_log::set_activity_state(logs, agent_name, "error", message);
         }
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -169,18 +169,6 @@ impl ChatBridge {
     }
 
     #[tool(
-        description = "Receive new messages. Use block=true to wait for new messages. Returns messages formatted with target, sender, and content."
-    )]
-    async fn receive_message(
-        &self,
-        Parameters(params): Parameters<ReceiveMessageParams>,
-    ) -> Result<String, rmcp::ErrorData> {
-        let block = params.block.unwrap_or(true);
-        let timeout_ms = params.timeout_ms.unwrap_or(59_000);
-        self.receive_and_format(block, timeout_ms).await
-    }
-
-    #[tool(
         description = "Check for new messages without waiting. Returns immediately with any pending messages, or 'No new messages.' if none are queued."
     )]
     async fn check_messages(
@@ -188,36 +176,6 @@ impl ChatBridge {
         _params: Parameters<EmptyParams>,
     ) -> Result<String, rmcp::ErrorData> {
         self.receive_and_format(false, 0).await
-    }
-
-    #[tool(
-        description = "Block and wait for new messages. Only use this when you have no work left to do and want to return to the idle loop."
-    )]
-    async fn wait_for_message(
-        &self,
-        _params: Parameters<EmptyParams>,
-    ) -> Result<String, rmcp::ErrorData> {
-        const POLL_INTERVAL_MS: u64 = 25_000;
-        const MAX_WAIT_MS: u64 = 270_000;
-
-        let start = std::time::Instant::now();
-        loop {
-            let elapsed_ms = start.elapsed().as_millis() as u64;
-            if elapsed_ms >= MAX_WAIT_MS {
-                let final_poll = self.receive_and_format(true, 1_000).await?;
-                if final_poll == "No new messages." {
-                    return Ok("No new messages. Take a rest — new messages will be delivered to you directly. Do not take any further action until notified.".to_string());
-                }
-                return Ok(final_poll);
-            }
-
-            let remaining_ms = MAX_WAIT_MS - elapsed_ms;
-            let this_poll_ms = std::cmp::min(POLL_INTERVAL_MS, remaining_ms);
-            let poll = self.receive_and_format(true, this_poll_ms).await?;
-            if poll != "No new messages." {
-                return Ok(poll);
-            }
-        }
     }
 
     #[tool(

--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -13,20 +13,6 @@ pub(super) struct SendMessageParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub(super) struct ReceiveMessageParams {
-    /// Whether to block (wait) for new messages (default true)
-    #[serde(default = "default_true")]
-    pub(super) block: Option<bool>,
-    /// How long to wait in ms when blocking (default 59000)
-    #[serde(default)]
-    pub(super) timeout_ms: Option<u64>,
-}
-
-pub(super) fn default_true() -> Option<bool> {
-    Some(true)
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub(super) struct EmptyParams {}
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -441,7 +441,6 @@ async fn send_message_to_channel(
     };
     info!(agent = %actor_id, msg = %short_id, "send_message ok");
 
-
     let mut consensus_message_id = None;
     if sender_type == SenderType::Agent && channel.channel_type == ChannelType::Team {
         if let Some(team) = store

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -8,7 +8,6 @@ use tracing::{debug, info, warn};
 
 use super::dto::ChannelInfo;
 use super::{api_err, format_anyhow_error, internal_err, ApiResult, AppState};
-use crate::agent::activity_log::ActivityEntry;
 use crate::agent::collaboration::make_collaboration_model;
 use crate::store::agents::AgentStatus;
 use crate::store::channels::Channel;
@@ -244,40 +243,6 @@ fn content_preview(text: &str) -> String {
     }
 }
 
-/// Convert a delivered message into the label shown in the activity timeline.
-fn activity_channel_label(message: &ReceivedMessage) -> String {
-    match message.channel_type.as_str() {
-        "channel" => format!("#{}", message.channel_name),
-        "dm" => format!("dm:@{}", message.channel_name),
-        "thread" => {
-            let parent_type = message.parent_channel_type.as_deref().unwrap_or("channel");
-            let parent_name = message
-                .parent_channel_name
-                .as_deref()
-                .unwrap_or(&message.channel_name);
-            match parent_type {
-                "dm" => format!("dm:@{} thread", parent_name),
-                _ => format!("#{} thread", parent_name),
-            }
-        }
-        _ => message.channel_name.clone(),
-    }
-}
-
-/// Record received messages in the activity log so the UI can show communication flow.
-fn push_received_activity(state: &AppState, agent_id: &str, messages: &[ReceivedMessage]) {
-    for message in messages {
-        state.lifecycle.push_activity_entry(
-            agent_id,
-            ActivityEntry::MessageReceived {
-                channel_label: activity_channel_label(message),
-                sender_name: message.sender_name.clone(),
-                content: content_preview(&message.content),
-            },
-        );
-    }
-}
-
 fn resolve_history_target(
     store: &Store,
     agent_id: &str,
@@ -475,15 +440,7 @@ async fn send_message_to_channel(
         &message_id
     };
     info!(agent = %actor_id, msg = %short_id, "send_message ok");
-    if sender_type == SenderType::Agent {
-        state.lifecycle.push_activity_entry(
-            actor_id,
-            ActivityEntry::MessageSent {
-                target: target_label,
-                content: preview,
-            },
-        );
-    }
+
 
     let mut consensus_message_id = None;
     if sender_type == SenderType::Agent && channel.channel_type == ChannelType::Team {
@@ -652,7 +609,7 @@ pub async fn handle_receive(
         for m in &messages {
             info!(agent = %agent_id, target = %format!("{}:{}", m.channel_type, m.channel_name), sender = %m.sender_name, content = %m.content.chars().take(120).collect::<String>(), "  ← message");
         }
-        push_received_activity(&state, &agent_id, &messages);
+
         return Ok(Json(ReceiveResponse { messages }));
     }
     if !blocking {
@@ -682,7 +639,7 @@ pub async fn handle_receive(
                     for m in &messages {
                         info!(agent = %agent_id, target = %format!("{}:{}", m.channel_type, m.channel_name), sender = %m.sender_name, content = %m.content.chars().take(120).collect::<String>(), "  ← message");
                     }
-                    push_received_activity(&state, &agent_id, &messages);
+
                     return Ok(Json(ReceiveResponse { messages }));
                 }
             }

--- a/tests/driver_tests.rs
+++ b/tests/driver_tests.rs
@@ -23,8 +23,8 @@ fn test_claude_prompt_uses_split_message_tools() {
     let prompt = driver.build_system_prompt(&config, "agent-id");
 
     assert!(
-        prompt.contains("mcp__chat__wait_for_message"),
-        "Claude prompts must teach the blocking idle tool explicitly"
+        !prompt.contains("mcp__chat__wait_for_message"),
+        "push-idle: agents no longer use wait_for_message"
     );
     assert!(
         prompt.contains("mcp__chat__check_messages"),
@@ -54,8 +54,8 @@ fn test_codex_prompt_uses_split_message_tools() {
     let prompt = driver.build_system_prompt(&config, "agent-id");
 
     assert!(
-        prompt.contains("mcp_chat_wait_for_message"),
-        "Codex prompts must reference the blocking idle tool"
+        !prompt.contains("mcp_chat_wait_for_message"),
+        "push-idle: agents no longer use wait_for_message"
     );
     assert!(
         prompt.contains("mcp_chat_check_messages"),
@@ -97,8 +97,8 @@ fn test_kimi_prompt_uses_split_message_tools() {
     let prompt = driver.build_system_prompt(&config, "agent-id");
 
     assert!(
-        prompt.contains("wait_for_message"),
-        "Kimi prompts must teach the blocking idle tool explicitly with the Kimi-native tool name"
+        !prompt.contains("wait_for_message"),
+        "push-idle: agents no longer use wait_for_message"
     );
     assert!(
         prompt.contains("check_messages"),
@@ -144,8 +144,8 @@ fn test_opencode_prompt_uses_split_message_tools() {
     let prompt = driver.build_system_prompt(&config, "agent-id");
 
     assert!(
-        prompt.contains("chat_wait_for_message"),
-        "OpenCode prompts must reference the blocking idle tool"
+        !prompt.contains("chat_wait_for_message"),
+        "push-idle: agents no longer use wait_for_message"
     );
     assert!(
         prompt.contains("chat_check_messages"),

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -1,6 +1,6 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use chorus::agent::activity_log::{ActivityEntry, ActivityLogResponse};
+use chorus::agent::activity_log::ActivityLogResponse;
 use chorus::agent::runtime_status::{RuntimeAuthStatus, RuntimeStatus, RuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
 use chorus::server::dto::ChannelInfo;
@@ -167,10 +167,6 @@ impl AgentLifecycle for MockLifecycle {
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)> {
         activity_log::all_activity_states(&self.activity_logs)
     }
-
-    fn push_activity_entry(&self, agent_name: &str, entry: ActivityEntry) {
-        activity_log::push_activity(&self.activity_logs, agent_name, entry);
-    }
 }
 
 impl AgentLifecycle for FailStartLifecycle {
@@ -211,8 +207,6 @@ impl AgentLifecycle for FailStartLifecycle {
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)> {
         vec![]
     }
-
-    fn push_activity_entry(&self, _agent_name: &str, _entry: ActivityEntry) {}
 }
 
 fn setup_with_lifecycle() -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
@@ -1936,77 +1930,6 @@ async fn test_history_accepts_dm_target() {
     let hist: HistoryResponse = serde_json::from_slice(&body).unwrap();
     assert_eq!(hist.messages.len(), 1);
     assert_eq!(hist.messages[0].content, "hello in dm");
-}
-
-#[tokio::test]
-async fn test_activity_log_includes_message_send_and_receive_events() {
-    let (store, app, lifecycle) = setup_with_lifecycle();
-    store
-        .update_agent_status("bot1", AgentStatus::Active)
-        .unwrap();
-
-    store
-        .create_message(CreateMessage {
-            channel_name: "general",
-            thread_parent_id: None,
-            sender_name: "alice",
-            sender_type: SenderType::Human,
-            content: "hello bot1",
-            attachment_ids: &[],
-            suppress_event: false,
-        })
-        .unwrap();
-
-    let recv_resp = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/internal/agent/bot1/receive?block=false")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(recv_resp.status(), StatusCode::OK);
-
-    let send_req = serde_json::json!({ "target": "#general", "content": "reply from bot1" });
-    let send_resp = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/bot1/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(send_resp.status(), StatusCode::OK);
-
-    let activity = lifecycle.get_activity_log_data("bot1", None);
-    let kinds: Vec<&str> = activity
-        .entries
-        .iter()
-        .map(|entry| match &entry.entry {
-            ActivityEntry::MessageReceived { .. } => "message_received",
-            ActivityEntry::MessageSent { .. } => "message_sent",
-            ActivityEntry::Status { .. } => "status",
-            ActivityEntry::Thinking { .. } => "thinking",
-            ActivityEntry::ToolStart { .. } => "tool_start",
-            ActivityEntry::Text { .. } => "text",
-            ActivityEntry::RawOutput { .. } => "raw_output",
-        })
-        .collect();
-
-    assert!(
-        kinds.contains(&"message_received"),
-        "activity log should surface received messages to the UI"
-    );
-    assert!(
-        kinds.contains(&"message_sent"),
-        "activity log should surface sent messages to the UI"
-    );
 }
 
 #[tokio::test]

--- a/ui/src/components/agents/activity/ActivityPanel.tsx
+++ b/ui/src/components/agents/activity/ActivityPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import type { ReactNode } from "react";
 import {
   BrainCircuit,
   MessageSquare,
@@ -33,7 +34,7 @@ interface Props {
 
 // ── Tool icon + label lookup ──────────────────────────────────────
 
-type ToolMeta = { icon: React.ReactNode; label: string };
+type ToolMeta = { icon: ReactNode; label: string };
 
 function toolMeta(rawName: string): ToolMeta {
   const name = rawName ?? "";

--- a/ui/src/components/agents/activity/ActivityPanel.tsx
+++ b/ui/src/components/agents/activity/ActivityPanel.tsx
@@ -23,6 +23,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { getAgentActivityLog } from "../../../data";
+import { ActivityEntryKind } from "../../../data/agents";
 import type { ActivityLogEntry } from "../../../data";
 import "./ActivityPanel.css";
 
@@ -297,15 +298,15 @@ function ToolResultRow({ item }: { item: ActivityLogEntry }) {
 
 function ActivityRow({ item }: { item: ActivityLogEntry }) {
   switch (item.entry.kind) {
-    case "start":
+    case ActivityEntryKind.Start:
       return <StartRow item={item} />;
-    case "thinking":
+    case ActivityEntryKind.Thinking:
       return <ThinkingRow item={item} />;
-    case "tool_call":
+    case ActivityEntryKind.ToolCall:
       return <ToolRow item={item} />;
-    case "tool_result":
+    case ActivityEntryKind.ToolResult:
       return <ToolResultRow item={item} />;
-    case "text":
+    case ActivityEntryKind.Text:
       return <TextRow item={item} />;
     default:
       return null;

--- a/ui/src/components/agents/activity/ActivityPanel.tsx
+++ b/ui/src/components/agents/activity/ActivityPanel.tsx
@@ -1,8 +1,6 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   BrainCircuit,
-  ArrowDownLeft,
-  ArrowUpRight,
   MessageSquare,
   FileText,
   FilePen,
@@ -21,79 +19,100 @@ import {
   Circle,
   ChevronDown,
   ChevronUp,
-} from 'lucide-react'
-import { getAgentActivityLog } from '../../../data'
-import type { ActivityLogEntry } from '../../../data'
-import './ActivityPanel.css'
+  Play,
+  RotateCcw,
+} from "lucide-react";
+import { getAgentActivityLog } from "../../../data";
+import type { ActivityLogEntry } from "../../../data";
+import "./ActivityPanel.css";
 
 interface Props {
-  agentName: string
+  agentName: string;
 }
 
 // ── Tool icon + label lookup ──────────────────────────────────────
 
-type ToolMeta = { icon: React.ReactNode; label: string }
+type ToolMeta = { icon: React.ReactNode; label: string };
 
 function toolMeta(rawName: string): ToolMeta {
-  const name = rawName ?? ''
+  const name = rawName ?? "";
 
   // MCP chat tools
-  if (name.startsWith('mcp__chat__') || name.startsWith('chat__')) {
-    const op = name.replace(/^(mcp__)?chat__/, '')
+  if (name.startsWith("mcp__chat__") || name.startsWith("chat__")) {
+    const op = name.replace(/^(mcp__)?chat__/, "");
     const map: Record<string, ToolMeta> = {
-      send_message:      { icon: <MessageSquare size={13} />, label: 'Send message' },
-      receive_message:   { icon: <Inbox size={13} />,         label: 'Receive message' },
-      read_history:      { icon: <History size={13} />,       label: 'Read history' },
-      get_history:       { icon: <History size={13} />,       label: 'Read history' },
-      list_server:       { icon: <Server size={13} />,        label: 'List server' },
-      get_server_info:   { icon: <Server size={13} />,        label: 'Server info' },
-      list_tasks:        { icon: <ClipboardList size={13} />, label: 'List tasks' },
-      create_tasks:      { icon: <ClipboardList size={13} />, label: 'Create tasks' },
-      claim_tasks:       { icon: <ClipboardList size={13} />, label: 'Claim tasks' },
-      unclaim_task:      { icon: <ClipboardList size={13} />, label: 'Unclaim task' },
-      update_task_status:{ icon: <CheckSquare size={13} />,   label: 'Update task' },
-      upload_file:       { icon: <Upload size={13} />,        label: 'Upload file' },
-      view_file:         { icon: <FileText size={13} />,      label: 'View file' },
-      resolve_channel:   { icon: <Server size={13} />,        label: 'Resolve channel' },
-    }
-    return map[op] ?? { icon: <Zap size={13} />, label: op }
+      send_message: {
+        icon: <MessageSquare size={13} />,
+        label: "Send message",
+      },
+      receive_message: { icon: <Inbox size={13} />, label: "Receive message" },
+      read_history: { icon: <History size={13} />, label: "Read history" },
+      get_history: { icon: <History size={13} />, label: "Read history" },
+      list_server: { icon: <Server size={13} />, label: "List server" },
+      get_server_info: { icon: <Server size={13} />, label: "Server info" },
+      list_tasks: { icon: <ClipboardList size={13} />, label: "List tasks" },
+      create_tasks: {
+        icon: <ClipboardList size={13} />,
+        label: "Create tasks",
+      },
+      claim_tasks: { icon: <ClipboardList size={13} />, label: "Claim tasks" },
+      unclaim_task: {
+        icon: <ClipboardList size={13} />,
+        label: "Unclaim task",
+      },
+      update_task_status: {
+        icon: <CheckSquare size={13} />,
+        label: "Update task",
+      },
+      upload_file: { icon: <Upload size={13} />, label: "Upload file" },
+      view_file: { icon: <FileText size={13} />, label: "View file" },
+      resolve_channel: { icon: <Server size={13} />, label: "Resolve channel" },
+    };
+    return map[op] ?? { icon: <Zap size={13} />, label: op };
   }
 
   // Standard Claude Code tools
   const map: Record<string, ToolMeta> = {
-    Read:        { icon: <FileText size={13} />,    label: 'Read file' },
-    read_file:   { icon: <FileText size={13} />,    label: 'Read file' },
-    Write:       { icon: <FileOutput size={13} />,  label: 'Write file' },
-    write_file:  { icon: <FileOutput size={13} />,  label: 'Write file' },
-    Edit:        { icon: <FilePen size={13} />,     label: 'Edit file' },
-    edit_file:   { icon: <FilePen size={13} />,     label: 'Edit file' },
-    Bash:        { icon: <Terminal size={13} />,    label: 'Run command' },
-    bash:        { icon: <Terminal size={13} />,    label: 'Run command' },
-    Grep:        { icon: <Search size={13} />,      label: 'Search code' },
-    grep:        { icon: <Search size={13} />,      label: 'Search code' },
-    Glob:        { icon: <FolderSearch size={13} />,label: 'Find files' },
-    glob:        { icon: <FolderSearch size={13} />,label: 'Find files' },
-    WebFetch:    { icon: <Globe size={13} />,       label: 'Fetch URL' },
-    web_fetch:   { icon: <Globe size={13} />,       label: 'Fetch URL' },
-    WebSearch:   { icon: <Globe size={13} />,       label: 'Web search' },
-    web_search:  { icon: <Globe size={13} />,       label: 'Web search' },
-    TodoWrite:   { icon: <CheckSquare size={13} />, label: 'Update todos' },
-    Task:        { icon: <Zap size={13} />,         label: 'Spawn agent' },
-  }
+    Read: { icon: <FileText size={13} />, label: "Read file" },
+    read_file: { icon: <FileText size={13} />, label: "Read file" },
+    Write: { icon: <FileOutput size={13} />, label: "Write file" },
+    write_file: { icon: <FileOutput size={13} />, label: "Write file" },
+    Edit: { icon: <FilePen size={13} />, label: "Edit file" },
+    edit_file: { icon: <FilePen size={13} />, label: "Edit file" },
+    Bash: { icon: <Terminal size={13} />, label: "Run command" },
+    bash: { icon: <Terminal size={13} />, label: "Run command" },
+    Grep: { icon: <Search size={13} />, label: "Search code" },
+    grep: { icon: <Search size={13} />, label: "Search code" },
+    Glob: { icon: <FolderSearch size={13} />, label: "Find files" },
+    glob: { icon: <FolderSearch size={13} />, label: "Find files" },
+    WebFetch: { icon: <Globe size={13} />, label: "Fetch URL" },
+    web_fetch: { icon: <Globe size={13} />, label: "Fetch URL" },
+    WebSearch: { icon: <Globe size={13} />, label: "Web search" },
+    web_search: { icon: <Globe size={13} />, label: "Web search" },
+    TodoWrite: { icon: <CheckSquare size={13} />, label: "Update todos" },
+    Task: { icon: <Zap size={13} />, label: "Spawn agent" },
+  };
 
   // Use tool_display_name passed from backend (already human-readable)
-  return map[name] ?? { icon: <Zap size={13} />, label: name.replace(/_/g, ' ') }
+  return (
+    map[name] ?? { icon: <Zap size={13} />, label: name.replace(/_/g, " ") }
+  );
 }
 
 // ── Status dot color ──────────────────────────────────────────────
 
 function statusColor(activity: string): string {
   switch (activity) {
-    case 'online':   return 'var(--status-online)'
-    case 'thinking': return 'var(--status-sleeping)'
-    case 'working':  return 'var(--status-sleeping)'
-    case 'error':    return 'var(--color-destructive)'
-    default:         return 'var(--status-inactive)'
+    case "online":
+      return "var(--status-online)";
+    case "thinking":
+      return "var(--status-sleeping)";
+    case "working":
+      return "var(--status-sleeping)";
+    case "error":
+      return "var(--color-destructive)";
+    default:
+      return "var(--status-inactive)";
   }
 }
 
@@ -101,84 +120,91 @@ function statusColor(activity: string): string {
 
 function fmtTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(undefined, {
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-  })
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 function formatActivityLabel(activity: string): string {
   switch (activity) {
-    case 'online': return 'Online'
-    case 'offline': return 'Offline'
-    case 'thinking': return 'Thinking'
-    case 'working': return 'Working'
-    case 'error': return 'Error'
-    default: return activity ? activity.charAt(0).toUpperCase() + activity.slice(1) : 'Unknown'
+    case "online":
+      return "Online";
+    case "offline":
+      return "Offline";
+    case "thinking":
+      return "Thinking";
+    case "working":
+      return "Working";
+    case "error":
+      return "Error";
+    default:
+      return activity
+        ? activity.charAt(0).toUpperCase() + activity.slice(1)
+        : "Unknown";
   }
-}
-
-function activityClassName(activity: string): string {
-  return `activity-tone-${activity || 'offline'}`
 }
 
 // ── Expandable text block ─────────────────────────────────────────
 
-const COLLAPSE_LINES = 3
+const COLLAPSE_LINES = 3;
 
-function ExpandableText({ text, maxLines = COLLAPSE_LINES }: { text: string; maxLines?: number }) {
-  const [expanded, setExpanded] = useState(false)
-  const lines = text.split('\n')
-  const needsExpand = lines.length > maxLines || text.length > 300
+function ExpandableText({
+  text,
+  maxLines = COLLAPSE_LINES,
+}: {
+  text: string;
+  maxLines?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const lines = text.split("\n");
+  const needsExpand = lines.length > maxLines || text.length > 300;
   const display = expanded
     ? text
-    : lines.slice(0, maxLines).join('\n').slice(0, 300)
+    : lines.slice(0, maxLines).join("\n").slice(0, 300);
 
   return (
     <span className="activity-expandable">
       <span className="activity-expandable-text">
         {display}
-        {!expanded && needsExpand && '…'}
+        {!expanded && needsExpand && "…"}
       </span>
       {needsExpand && (
         <button
           className="activity-expand-btn"
           onClick={() => setExpanded((x) => !x)}
-          title={expanded ? 'Collapse' : 'Expand'}
+          title={expanded ? "Collapse" : "Expand"}
         >
-          {expanded
-            ? <ChevronUp size={11} />
-            : <ChevronDown size={11} />}
-          {expanded ? 'less' : 'more'}
+          {expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+          {expanded ? "less" : "more"}
         </button>
       )}
     </span>
-  )
+  );
 }
 
 // ── Individual entry renderers ────────────────────────────────────
-
-function StatusRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
-  const color = statusColor(entry.activity ?? '')
-  const activity = entry.activity ?? 'offline'
+function StartRow({ item }: { item: ActivityLogEntry }) {
+  const { entry, timestamp_ms } = item;
+  const isResume = entry.is_resume;
   return (
-    <div className={`activity-item activity-item-status ${activityClassName(activity)}`}>
-      <span className="activity-status-dot" style={{ color }}>
-        <Circle size={8} fill="currentColor" />
+    <div className="activity-item activity-item-start">
+      <span className="activity-item-icon activity-icon-start">
+        {isResume ? <RotateCcw size={13} /> : <Play size={13} />}
       </span>
       <div className="activity-item-main">
         <div className="activity-item-heading">
-          <span className="activity-status-pill">{formatActivityLabel(activity)}</span>
-          {entry.detail ? <span className="activity-item-meta">{entry.detail}</span> : null}
+          <span className="activity-item-label">
+            {isResume ? "Resumed" : "Started"}
+          </span>
         </div>
-        <div className="activity-item-body activity-item-muted">State transition</div>
       </div>
       <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
     </div>
-  )
+  );
 }
-
 function ThinkingRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
+  const { entry, timestamp_ms } = item;
   return (
     <div className="activity-item activity-item-thinking">
       <span className="activity-item-icon activity-icon-think">
@@ -189,32 +215,30 @@ function ThinkingRow({ item }: { item: ActivityLogEntry }) {
           <span className="activity-item-label">Thinking</span>
         </div>
         <div className="activity-item-body">
-          <ExpandableText text={entry.text ?? ''} maxLines={2} />
+          <ExpandableText text={entry.text ?? ""} maxLines={2} />
         </div>
       </div>
       <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
     </div>
-  )
+  );
 }
 
 function ToolRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
+  const { entry, timestamp_ms } = item;
   // entry.tool_name is already the human-readable display name from backend
   // We look up a matching icon by trying the raw name first, fallback to display name
-  const meta = toolMeta(entry.tool_name ?? '')
-  const input = entry.tool_input ?? ''
+  const meta = toolMeta(entry.tool_name ?? "");
+  const input = entry.tool_input ?? "";
 
   return (
     <div className="activity-item activity-item-tool">
-      <span className="activity-item-icon activity-icon-tool">
-        {meta.icon}
-      </span>
+      <span className="activity-item-icon activity-icon-tool">{meta.icon}</span>
       <div className="activity-item-main">
         <div className="activity-item-heading">
-          <span className="activity-item-label">
-            Tool
+          <span className="activity-item-label">Tool</span>
+          <span className="activity-item-meta">
+            {entry.tool_name || meta.label}
           </span>
-          <span className="activity-item-meta">{entry.tool_name || meta.label}</span>
         </div>
         {input && (
           <div className="activity-item-body activity-tool-input">
@@ -224,11 +248,11 @@ function ToolRow({ item }: { item: ActivityLogEntry }) {
       </div>
       <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
     </div>
-  )
+  );
 }
 
 function TextRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
+  const { entry, timestamp_ms } = item;
   return (
     <div className="activity-item activity-item-text-entry">
       <span className="activity-item-icon activity-icon-text">
@@ -239,161 +263,146 @@ function TextRow({ item }: { item: ActivityLogEntry }) {
           <span className="activity-item-label">Output</span>
         </div>
         <div className="activity-item-body">
-          <ExpandableText text={entry.text ?? ''} maxLines={3} />
+          <ExpandableText text={entry.text ?? ""} maxLines={3} />
         </div>
       </div>
       <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
     </div>
-  )
+  );
 }
 
-function RawOutputRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
+function ToolResultRow({ item }: { item: ActivityLogEntry }) {
+  const { entry, timestamp_ms } = item;
+  const meta = toolMeta(entry.tool_name ?? "");
   return (
-    <div className="activity-item activity-item-raw-output">
-      <span className="activity-item-icon activity-icon-raw-output">
-        <Terminal size={13} />
+    <div className="activity-item activity-item-tool-result">
+      <span className="activity-item-icon activity-icon-tool-result">
+        {meta.icon}
       </span>
       <div className="activity-item-main">
         <div className="activity-item-heading">
-          <span className="activity-item-label">Raw output</span>
+          <span className="activity-item-label">Result</span>
+          {entry.tool_name && (
+            <span className="activity-item-meta">{entry.tool_name}</span>
+          )}
         </div>
-        <div className="activity-item-body">
-          <ExpandableText text={entry.text ?? ''} maxLines={4} />
-        </div>
-      </div>
-      <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
-    </div>
-  )
-}
-
-function MessageReceivedRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
-  return (
-    <div className="activity-item activity-item-message activity-item-message-received">
-      <span className="activity-item-icon activity-icon-message-received">
-        <ArrowDownLeft size={13} />
-      </span>
-      <div className="activity-item-main">
-        <div className="activity-item-heading">
-          <span className="activity-item-label">Received</span>
-          <span className="activity-item-meta">from {entry.sender_name}</span>
-          {entry.channel_label ? <span className="activity-item-chip">{entry.channel_label}</span> : null}
-        </div>
-        <div className="activity-item-body">
-          <ExpandableText text={entry.content ?? ''} maxLines={2} />
+        <div className="activity-item-body activity-item-muted">
+          <ExpandableText text={entry.content ?? ""} maxLines={2} />
         </div>
       </div>
       <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
     </div>
-  )
-}
-
-function MessageSentRow({ item }: { item: ActivityLogEntry }) {
-  const { entry, timestamp_ms } = item
-  return (
-    <div className="activity-item activity-item-message activity-item-message-sent">
-      <span className="activity-item-icon activity-icon-message-sent">
-        <ArrowUpRight size={13} />
-      </span>
-      <div className="activity-item-main">
-        <div className="activity-item-heading">
-          <span className="activity-item-label">Sent</span>
-          {entry.target ? <span className="activity-item-chip">{entry.target}</span> : null}
-        </div>
-        <div className="activity-item-body">
-          <ExpandableText text={entry.content ?? ''} maxLines={2} />
-        </div>
-      </div>
-      <span className="activity-item-time">{fmtTime(timestamp_ms)}</span>
-    </div>
-  )
+  );
 }
 
 function ActivityRow({ item }: { item: ActivityLogEntry }) {
   switch (item.entry.kind) {
-    case 'status': return <StatusRow item={item} />
-    case 'thinking': return <ThinkingRow item={item} />
-    case 'tool_start': return <ToolRow item={item} />
-    case 'text': return <TextRow item={item} />
-    case 'raw_output': return <RawOutputRow item={item} />
-    case 'message_received': return <MessageReceivedRow item={item} />
-    case 'message_sent': return <MessageSentRow item={item} />
-    default: return null
+    case "start":
+      return <StartRow item={item} />;
+    case "thinking":
+      return <ThinkingRow item={item} />;
+    case "tool_call":
+      return <ToolRow item={item} />;
+    case "tool_result":
+      return <ToolResultRow item={item} />;
+    case "text":
+      return <TextRow item={item} />;
+    default:
+      return null;
   }
 }
 
 // ── Main panel ────────────────────────────────────────────────────
 
 export function ActivityPanel({ agentName }: Props) {
-  const [entries, setEntries] = useState<ActivityLogEntry[]>([])
-  const [agentActivity, setAgentActivity] = useState('offline')
-  const [agentDetail, setAgentDetail] = useState('')
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const lastSeqRef = useRef<number | undefined>(undefined)
-  const listRef = useRef<HTMLDivElement>(null)
+  const [entries, setEntries] = useState<ActivityLogEntry[]>([]);
+  const [agentActivity, setAgentActivity] = useState("offline");
+  const [agentDetail, setAgentDetail] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const lastSeqRef = useRef<number | undefined>(undefined);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const load = useCallback(async () => {
     try {
-      const res = await getAgentActivityLog(agentName, lastSeqRef.current)
+      const res = await getAgentActivityLog(agentName, lastSeqRef.current);
       if (res.entries.length > 0) {
         setEntries((prev) => {
-          const combined = [...prev, ...res.entries]
-          return combined.slice(-500)
-        })
-        lastSeqRef.current = res.entries[res.entries.length - 1].seq
+          const combined = [...prev, ...res.entries];
+          return combined.slice(-500);
+        });
+        lastSeqRef.current = res.entries[res.entries.length - 1].seq;
       }
-      setAgentActivity(res.agent_activity)
-      setAgentDetail(res.agent_detail)
-      setError(null)
+      setAgentActivity(res.agent_activity);
+      setAgentDetail(res.agent_detail);
+      setError(null);
     } catch (e) {
-      setError(String(e))
+      setError(String(e));
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [agentName])
+  }, [agentName]);
 
   useEffect(() => {
-    setEntries([])
-    setAgentActivity('offline')
-    setAgentDetail('')
-    setLoading(true)
-    lastSeqRef.current = undefined
-    load()
-    const interval = setInterval(load, 2000)
-    return () => clearInterval(interval)
-  }, [load])
+    setEntries([]);
+    setAgentActivity("offline");
+    setAgentDetail("");
+    setLoading(true);
+    lastSeqRef.current = undefined;
+    load();
+    const interval = setInterval(load, 2000);
+    return () => clearInterval(interval);
+  }, [load]);
 
   useEffect(() => {
     if (listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight
+      listRef.current.scrollTop = listRef.current.scrollHeight;
     }
-  }, [entries])
+  }, [entries]);
 
-  const dotColor = statusColor(agentActivity)
+  const dotColor = statusColor(agentActivity);
 
   if (loading && entries.length === 0) {
     return (
       <div className="activity-panel">
-        <ActivityHeader agentName={agentName} dotColor={dotColor} activity={agentActivity} detail={agentDetail} />
+        <ActivityHeader
+          agentName={agentName}
+          dotColor={dotColor}
+          activity={agentActivity}
+          detail={agentDetail}
+        />
         <div className="activity-empty">Loading…</div>
       </div>
-    )
+    );
   }
 
   if (error && entries.length === 0) {
     return (
       <div className="activity-panel">
-        <ActivityHeader agentName={agentName} dotColor={dotColor} activity={agentActivity} detail={agentDetail} />
-        <div className="activity-empty" style={{ color: 'var(--color-primary)' }}>{error}</div>
+        <ActivityHeader
+          agentName={agentName}
+          dotColor={dotColor}
+          activity={agentActivity}
+          detail={agentDetail}
+        />
+        <div
+          className="activity-empty"
+          style={{ color: "var(--color-primary)" }}
+        >
+          {error}
+        </div>
       </div>
-    )
+    );
   }
 
   return (
     <div className="activity-panel">
-      <ActivityHeader agentName={agentName} dotColor={dotColor} activity={agentActivity} detail={agentDetail} />
+      <ActivityHeader
+        agentName={agentName}
+        dotColor={dotColor}
+        activity={agentActivity}
+        detail={agentDetail}
+      />
       {entries.length === 0 ? (
         <div className="activity-empty">No activity yet.</div>
       ) : (
@@ -404,22 +413,30 @@ export function ActivityPanel({ agentName }: Props) {
         </div>
       )}
     </div>
-  )
+  );
 }
 
 function ActivityHeader({
-  agentName, dotColor, activity, detail,
+  agentName,
+  dotColor,
+  activity,
+  detail,
 }: {
-  agentName: string; dotColor: string; activity: string; detail: string
+  agentName: string;
+  dotColor: string;
+  activity: string;
+  detail: string;
 }) {
   return (
     <div className="activity-header">
-      <span className="activity-title">ACTIVITY LOG — {agentName.toUpperCase()}</span>
+      <span className="activity-title">
+        ACTIVITY LOG — {agentName.toUpperCase()}
+      </span>
       <span className="activity-status" style={{ color: dotColor }}>
         <Circle size={8} fill="currentColor" />
         <span>{formatActivityLabel(activity)}</span>
         {detail && <span className="activity-status-detail"> · {detail}</span>}
       </span>
     </div>
-  )
+  );
 }

--- a/ui/src/components/agents/profile/ProfilePanel.tsx
+++ b/ui/src/components/agents/profile/ProfilePanel.tsx
@@ -228,6 +228,21 @@ export function ProfilePanel() {
           >
             {agent.status}
           </span>
+          {agent.session_id && (
+            <>
+              <span className="profile-config-key">Session</span>
+              <span
+                className="badge"
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: "10px",
+                  letterSpacing: 0,
+                }}
+              >
+                {agent.session_id}
+              </span>
+            </>
+          )}
         </div>
         <div
           className={`runtime-status-banner runtime-status-banner-${runtimeSummary.tone}`}

--- a/ui/src/data/agents.ts
+++ b/ui/src/data/agents.ts
@@ -53,25 +53,19 @@ export interface ActivityResponse {
 }
 
 export type ActivityEntryKind =
+  | 'start'
   | 'thinking'
-  | 'tool_start'
+  | 'tool_call'
+  | 'tool_result'
   | 'text'
-  | 'raw_output'
-  | 'message_received'
-  | 'message_sent'
-  | 'status'
 
 export interface ActivityEntry {
   kind: ActivityEntryKind
+  is_resume?: boolean
   text?: string
   content?: string
   tool_name?: string
   tool_input?: string
-  channel_label?: string
-  sender_name?: string
-  target?: string
-  activity?: string
-  detail?: string
 }
 
 export interface ActivityLogEntry {

--- a/ui/src/data/agents.ts
+++ b/ui/src/data/agents.ts
@@ -52,12 +52,13 @@ export interface ActivityResponse {
   messages: ActivityMessage[]
 }
 
-export type ActivityEntryKind =
-  | 'start'
-  | 'thinking'
-  | 'tool_call'
-  | 'tool_result'
-  | 'text'
+export enum ActivityEntryKind {
+  Start = 'start',
+  Thinking = 'thinking',
+  ToolCall = 'tool_call',
+  ToolResult = 'tool_result',
+  Text = 'text',
+}
 
 export interface ActivityEntry {
   kind: ActivityEntryKind


### PR DESCRIPTION
## Summary

Two features and two quality improvements to the agent activity log.

### Changes

**Backend**

- `ActivityEntry::Start { is_resume: bool }` — new variant pushed when an agent process starts or resumes. Lets the activity log show a clear "Started" / "Resumed" marker at the top of each session.
- `ActivityEntry::ToolResult` now carries `tool_name: String` — the last tool name is tracked on `RunningAgent` and forwarded to the result entry so call/result pairs are visually paired in the UI.
- Push-idle model cleanup: removed `receive_message` / `wait_for_message` MCP tools from `ChatBridge`; removed related dead types and blocking poll logic across all drivers and tests.

**Frontend**

- `ProfilePanel`: full `session_id` displayed (was truncated to 8 chars).
- `ActivityEntryKind` converted from a string union type to a `const enum` — switch statements in `ActivityPanel` use `ActivityEntryKind.Start` etc.
- `StartRow` renders a `Play` / `RotateCcw` icon with "Started" / "Resumed" label.
- `ToolResultRow` now shows the same tool icon and name as `ToolRow`, providing visual symmetry between call and result entries.

### Verification

- `cargo check` passes
- `tsc --noEmit` passes