### PR TITLE
docs(ci): add copilot-instructions.md symlink to AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` as a symlink to `AGENTS.md` so GitHub Copilot picks up the project's working contract automatically.