### PR TITLE
fix: handle mutex poison gracefully and improve agent restart error reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,8 @@ async fn serve(port: u16, data_dir_str: String) -> anyhow::Result<()> {
         server_url.clone(),
     ));
 
-    // Auto-restart agents that were active before server restart
+    // Auto-restart agents that were active before server restart.
+    // Track failures per agent so repeated failures can be surfaced.
     {
         let active_agents: Vec<String> = store
             .get_agents()
@@ -349,11 +350,21 @@ async fn serve(port: u16, data_dir_str: String) -> anyhow::Result<()> {
             .filter(|a| a.status == AgentStatus::Active)
             .map(|a| a.name)
             .collect();
+        let mut failed_agents = Vec::new();
         for agent_name in active_agents {
             tracing::info!(agent = %agent_name, "auto-restarting active agent");
             if let Err(e) = manager.start_agent(&agent_name, None).await {
-                tracing::warn!(agent = %agent_name, err = %e, "failed to restart agent");
+                tracing::error!(agent = %agent_name, err = %e, "failed to restart agent — it will not be available until manually started");
+                failed_agents.push(agent_name);
             }
+        }
+        if !failed_agents.is_empty() {
+            eprintln!(
+                "Warning: {} agent(s) failed to auto-restart: {}",
+                failed_agents.len(),
+                failed_agents.join(", ")
+            );
+            eprintln!("Check agent logs for details. Restart manually with `chorus agent start <name>`");
         }
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -96,9 +96,24 @@ impl Store {
         self.data_dir.join("teams")
     }
 
+    /// Lock the database connection, handling mutex poison gracefully.
+    /// If the mutex is poisoned (from a previous panic), the lock is recovered
+    /// and the operation proceeds. This avoids crashing the server on panics
+    /// in other threads.
+    fn lock_conn(&self) -> std::sync::MutexGuard<'_, Connection> {
+        match self.conn.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("Database mutex was poisoned, recovering");
+                poisoned.into_inner()
+            }
+        }
+    }
+
     /// Expose the raw connection guard for use in integration tests only.
     /// Not intended for production use.
     pub fn conn_for_test(&self) -> std::sync::MutexGuard<'_, rusqlite::Connection> {
+        // Tests may expect a clean state; panicking is acceptable here.
         self.conn.lock().unwrap()
     }
 
@@ -119,7 +134,7 @@ impl Store {
     // ── Sender type lookup ──
 
     pub fn lookup_sender_type(&self, name: &str) -> Result<Option<SenderType>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.lock_conn();
         Self::lookup_sender_type_inner(&conn, name)
     }
 


### PR DESCRIPTION
## Summary
- lock_conn() recovers from poisoned mutex instead of panicking
- Agent auto-restart failures now logged at error level with actionable stderr summary

## Files
- src/store/mod.rs  
- src/main.rs