### PR TITLE
fix: handle mutex poison gracefully and improve agent restart error reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -354,20 +354,28 @@ async fn serve(port: u16, data_dir_str: String) -> anyhow::Result<()> {
         for agent_name in active_agents {
             tracing::info!(agent = %agent_name, "auto-restarting active agent");
             if let Err(e) = manager.start_agent(&agent_name, None).await {
-                tracing::error!(agent = %agent_name, err = %e, "failed to restart agent — marking inactive so subsequent delivery can retry");
+                let error_detail = format!("{e:#}");
+                tracing::error!(agent = %agent_name, err = %error_detail, "failed to restart agent — marking inactive so subsequent delivery can retry");
                 // Mark inactive so next message delivery can attempt a fresh start
                 if let Err(e) = store.update_agent_status(&agent_name, AgentStatus::Inactive) {
                     tracing::error!(agent = %agent_name, err = %e, "also failed to mark agent inactive — manual intervention required");
                 }
-                failed_agents.push(agent_name);
+                failed_agents.push((agent_name, error_detail));
             }
         }
         if !failed_agents.is_empty() {
             eprintln!(
                 "Warning: {} agent(s) failed to auto-restart and were marked inactive: {}",
                 failed_agents.len(),
-                failed_agents.join(", ")
+                failed_agents
+                    .iter()
+                    .map(|(agent_name, _)| agent_name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             );
+            for (agent_name, error_detail) in &failed_agents {
+                eprintln!("  - {agent_name}: {error_detail}");
+            }
             eprintln!("They will be retried on next message delivery. To restart immediately: `chorus agent start <name>`");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,8 @@ async fn serve(port: u16, data_dir_str: String) -> anyhow::Result<()> {
         server_url.clone(),
     ));
 
-    // Auto-restart agents that were active before server restart
+    // Auto-restart agents that were active before server restart.
+    // Track failures per agent so repeated failures can be surfaced.
     {
         let active_agents: Vec<String> = store
             .get_agents()
@@ -349,11 +350,25 @@ async fn serve(port: u16, data_dir_str: String) -> anyhow::Result<()> {
             .filter(|a| a.status == AgentStatus::Active)
             .map(|a| a.name)
             .collect();
+        let mut failed_agents = Vec::new();
         for agent_name in active_agents {
             tracing::info!(agent = %agent_name, "auto-restarting active agent");
             if let Err(e) = manager.start_agent(&agent_name, None).await {
-                tracing::warn!(agent = %agent_name, err = %e, "failed to restart agent");
+                tracing::error!(agent = %agent_name, err = %e, "failed to restart agent — marking inactive so subsequent delivery can retry");
+                // Mark inactive so next message delivery can attempt a fresh start
+                if let Err(e) = store.update_agent_status(&agent_name, AgentStatus::Inactive) {
+                    tracing::error!(agent = %agent_name, err = %e, "also failed to mark agent inactive — manual intervention required");
+                }
+                failed_agents.push(agent_name);
             }
+        }
+        if !failed_agents.is_empty() {
+            eprintln!(
+                "Warning: {} agent(s) failed to auto-restart and were marked inactive: {}",
+                failed_agents.len(),
+                failed_agents.join(", ")
+            );
+            eprintln!("They will be retried on next message delivery. To restart immediately: `chorus agent start <name>`");
         }
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -96,9 +96,25 @@ impl Store {
         self.data_dir.join("teams")
     }
 
+    /// Lock the database connection, handling mutex poison gracefully.
+    /// If the mutex is poisoned (from a previous panic), the lock is recovered
+    /// and the operation proceeds. This avoids crashing the server on panics
+    /// in other threads.
+    fn lock_conn(&self) -> std::sync::MutexGuard<'_, Connection> {
+        match self.conn.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("Database mutex was poisoned, recovering");
+                self.conn.clear_poison();
+                poisoned.into_inner()
+            }
+        }
+    }
+
     /// Expose the raw connection guard for use in integration tests only.
     /// Not intended for production use.
     pub fn conn_for_test(&self) -> std::sync::MutexGuard<'_, rusqlite::Connection> {
+        // Tests may expect a clean state; panicking is acceptable here.
         self.conn.lock().unwrap()
     }
 
@@ -119,7 +135,7 @@ impl Store {
     // ── Sender type lookup ──
 
     pub fn lookup_sender_type(&self, name: &str) -> Result<Option<SenderType>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.lock_conn();
         Self::lookup_sender_type_inner(&conn, name)
     }
 

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1628,3 +1628,25 @@ fn test_record_swarm_signal_ignores_non_quorum_agent() {
         "quorum should still be unresolved after non-quorum signal"
     );
 }
+
+#[test]
+fn test_lookup_sender_type_recovers_after_mutex_poison() {
+    use chorus::store::messages::SenderType;
+
+    let store = Store::open(":memory:").unwrap();
+    store.create_human("alice").unwrap();
+
+    let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _conn = store.conn_for_test();
+        panic!("poison the store connection mutex");
+    }));
+    assert!(
+        panic_result.is_err(),
+        "expected intentional panic to poison mutex"
+    );
+
+    let sender_type = store.lookup_sender_type("alice").unwrap();
+    assert_eq!(sender_type, Some(SenderType::Human));
+
+    let _conn = store.conn_for_test();
+}


### PR DESCRIPTION
## Summary
- `lock_conn()` recovers from poisoned mutex instead of panicking, preventing server crashes
- Agent auto-restart failures logged at `error` level with actionable stderr summary
- Failed agents marked `Inactive` so subsequent delivery can trigger a fresh start

## Files
- `src/store/mod.rs` — `lock_conn()` helper with poison recovery
- `src/main.rs` — error-level logging + mark failed agents Inactive for retry

## Review feedback addressed
- Issue 1 (High): Now marks failed agents as `Inactive` so delivery can retry starting them
- Issue 2 (Medium): Broad poison-recovery sweep deferred to follow-up PR