### PR TITLE
feat(chat): scope @ mention suggestions to channel members

### DIFF
--- a/src/agent/drivers/acp.rs
+++ b/src/agent/drivers/acp.rs
@@ -251,12 +251,12 @@ impl<R: AcpRuntime> AcpDriver<R> {
             }
             "toolCall" | "tool_call" => {
                 // kimi uses `title` for the tool name; other runtimes use `toolName`
-                let name = update
+                let raw_name = update
                     .get("toolName")
                     .or_else(|| update.get("title"))
                     .and_then(|v| v.as_str())
-                    .unwrap_or("unknown_tool")
-                    .to_string();
+                    .unwrap_or("unknown_tool");
+                let name = strip_mcp_prefix(raw_name).to_string();
                 let input = update
                     .get("args")
                     .or_else(|| update.get("input"))
@@ -419,10 +419,22 @@ fn json_rpc_request(id: u64, method: &str, params: serde_json::Value) -> String 
 
 /// Strip any known MCP server prefix to get the bare tool name.
 pub(crate) fn strip_mcp_prefix(name: &str) -> &str {
-    name.strip_prefix("mcp__chat__")
+    // Standard MCP prefix forms: mcp__chat__, mcp_chat_, chat_
+    if let Some(s) = name
+        .strip_prefix("mcp__chat__")
         .or_else(|| name.strip_prefix("mcp_chat_"))
         .or_else(|| name.strip_prefix("chat_"))
-        .unwrap_or(name)
+    {
+        return s;
+    }
+    // Claude ACP formats tool titles as "Tool: <server>/<tool_name>"
+    // e.g. "Tool: chat/send_message" → "send_message"
+    if name.starts_with("Tool: ") {
+        if let Some(slash) = name.find('/') {
+            return &name[slash + 1..];
+        }
+    }
+    name
 }
 
 // ── Driver impl ──
@@ -637,18 +649,10 @@ impl<R: AcpRuntime> Driver for AcpDriver<R> {
                 let content = str_field("content");
                 if content.is_empty() {
                     target
+                } else if target.is_empty() {
+                    content
                 } else {
-                    let preview: String = content.chars().take(80).collect();
-                    let preview = if content.chars().count() > 80 {
-                        format!("{preview}\u{2026}")
-                    } else {
-                        preview
-                    };
-                    if target.is_empty() {
-                        preview
-                    } else {
-                        format!("{target}: {preview}")
-                    }
+                    format!("{target}: {content}")
                 }
             }
             "read_history" => {
@@ -713,18 +717,18 @@ impl<R: AcpRuntime> Driver for AcpDriver<R> {
                 }
                 let p = str_field("command");
                 if !p.is_empty() {
-                    let truncated: String = p.chars().take(100).collect();
-                    return if p.chars().count() > 100 {
-                        format!("{truncated}\u{2026}")
-                    } else {
-                        truncated
-                    };
+                    return p;
                 }
                 let p = str_field("query");
                 if !p.is_empty() {
                     return p;
                 }
                 let p = str_field("url");
+                if !p.is_empty() {
+                    return p;
+                }
+                // `input` is used by Claude's Terminal/Bash tool.
+                let p = str_field("input");
                 if !p.is_empty() {
                     return p;
                 }
@@ -755,6 +759,9 @@ mod tests {
         assert_eq!(strip_mcp_prefix("chat_send_message"), "send_message");
         assert_eq!(strip_mcp_prefix("send_message"), "send_message");
         assert_eq!(strip_mcp_prefix("Bash"), "Bash");
+        // Claude ACP title format
+        assert_eq!(strip_mcp_prefix("Tool: chat/send_message"), "send_message");
+        assert_eq!(strip_mcp_prefix("Tool: chat/read_history"), "read_history");
     }
 
     // ── parse_line: JSON-RPC responses ──

--- a/src/agent/drivers/acp.rs
+++ b/src/agent/drivers/acp.rs
@@ -891,9 +891,7 @@ mod tests {
 
         let events = d.parse_line(r##"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"kind":"toolCall","toolCallId":"call-1","toolName":"mcp__chat__send_message","title":"Send Message","status":"running","args":{"target":"#all","content":"hi"}}}}"##);
         assert_eq!(events.len(), 1);
-        assert!(
-            matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "mcp__chat__send_message")
-        );
+        assert!(matches!(&events[0], ParsedEvent::ToolCall { name, .. } if name == "send_message"));
         if let ParsedEvent::ToolCall { input, .. } = &events[0] {
             assert_eq!(input["target"], "#all");
         }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -512,7 +512,11 @@ async fn handle_parsed_event(
         } => {
             let display_name = driver.tool_display_name(name);
             let tool_input = driver.summarize_tool_input(name, input);
-            info!(agent = %agent_name, tool = %name, input = %tool_input, "tool call");
+            if tool_input.is_empty() {
+                info!(agent = %agent_name, tool = %name, "tool call");
+            } else {
+                info!(agent = %agent_name, tool = %name, input = %tool_input, "tool call");
+            }
             running.last_tool_raw_name = Some(name.clone());
             activity_log::push_activity(
                 logs,

--- a/ui/src/components/chat/MessageInput.tsx
+++ b/ui/src/components/chat/MessageInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { Paperclip, Plus } from "lucide-react";
 import { useStore } from "../../store";
-import { useAgents, useTeams, useHumans, useChannels } from "../../hooks/data";
+import { useAgents, useTeams, useHumans, useChannels, useChannelMembers } from "../../hooks/data";
 import { useHistory } from "../../hooks/useHistory";
 import { sendMessage, createTasks, uploadFile } from "../../data";
 import { MentionTextarea } from "./MentionTextarea";
@@ -21,6 +21,7 @@ export function MessageInput({ target, conversationId, history }: Props) {
   const teams = useTeams();
   const humans = useHumans();
   const { systemChannels } = useChannels();
+  const channelMembers = useChannelMembers(currentChannel?.id ?? null);
   const [content, setContent] = useState("");
   const [alsoTask, setAlsoTask] = useState(false);
   const [sending, setSending] = useState(false);
@@ -39,11 +40,19 @@ export function MessageInput({ target, conversationId, history }: Props) {
     return () => window.clearTimeout(timer);
   }, [toasts]);
 
-  const members: MentionMember[] = [
+  const allMembers: MentionMember[] = [
     ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
     ...humans.map((h) => ({ name: h.name, type: "human" as const })),
     ...teams.map((team) => ({ name: team.name, type: "team" as const })),
   ];
+
+  // In a channel context, only suggest members who belong to the channel.
+  // In DM or no-channel context, show all members.
+  const members: MentionMember[] = currentChannel?.id
+    ? allMembers.filter((m) =>
+        channelMembers.some((cm) => cm.memberName === m.name),
+      )
+    : allMembers;
 
   const isReadOnlySystem = !!(
     currentChannel &&

--- a/ui/src/components/chat/MessageInput.tsx
+++ b/ui/src/components/chat/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { Paperclip, Plus } from "lucide-react";
 import { useStore } from "../../store";
 import {
@@ -46,19 +46,29 @@ export function MessageInput({ target, conversationId, history }: Props) {
     return () => window.clearTimeout(timer);
   }, [toasts]);
 
-  const allMembers: MentionMember[] = [
-    ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
-    ...humans.map((h) => ({ name: h.name, type: "human" as const })),
-    ...teams.map((team) => ({ name: team.name, type: "team" as const })),
-  ];
+  const allMembers: MentionMember[] = useMemo(
+    () => [
+      ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
+      ...humans.map((h) => ({ name: h.name, type: "human" as const })),
+      ...teams.map((team) => ({ name: team.name, type: "team" as const })),
+    ],
+    [agents, humans, teams],
+  );
+
+  const channelMemberSet = useMemo(
+    () => new Set(channelMembers.map((cm) => cm.memberName)),
+    [channelMembers],
+  );
 
   // In a channel context, only suggest members who belong to the channel.
   // In DM or no-channel context, show all members.
-  const members: MentionMember[] = currentChannel?.id
-    ? allMembers.filter((m) =>
-        channelMembers.some((cm) => cm.memberName === m.name),
-      )
-    : allMembers;
+  const members = useMemo(
+    () =>
+      currentChannel?.id
+        ? allMembers.filter((m) => channelMemberSet.has(m.name))
+        : allMembers,
+    [allMembers, channelMemberSet, currentChannel?.id],
+  );
 
   const isReadOnlySystem = !!(
     currentChannel &&

--- a/ui/src/components/chat/MessageInput.tsx
+++ b/ui/src/components/chat/MessageInput.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState, useRef } from "react";
 import { Paperclip, Plus } from "lucide-react";
 import { useStore } from "../../store";
-import { useAgents, useTeams, useHumans, useChannels, useChannelMembers } from "../../hooks/data";
+import {
+  useAgents,
+  useTeams,
+  useHumans,
+  useChannels,
+  useChannelMembers,
+} from "../../hooks/data";
 import { useHistory } from "../../hooks/useHistory";
 import { sendMessage, createTasks, uploadFile } from "../../data";
 import { MentionTextarea } from "./MentionTextarea";

--- a/ui/src/components/chat/ThreadPanel.tsx
+++ b/ui/src/components/chat/ThreadPanel.tsx
@@ -7,6 +7,7 @@ import {
   useHumans,
   useInbox,
   useTarget,
+  useChannelMembers,
 } from "../../hooks/data";
 import { useHistory } from "../../hooks/useHistory";
 import { MessageItem } from "./MessageItem";
@@ -33,11 +34,17 @@ export function ThreadPanel({ variant = "drawer" }: ThreadPanelProps) {
   const teams = useTeams();
   const humans = useHumans();
   const { getAgentConversationId } = useInbox();
-  const members: MentionMember[] = [
+  const channelMembers = useChannelMembers(currentChannel?.id ?? null);
+  const allMembers: MentionMember[] = [
     ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
     ...humans.map((h) => ({ name: h.name, type: "human" as const })),
     ...teams.map((team) => ({ name: team.name, type: "team" as const })),
   ];
+  const members: MentionMember[] = currentChannel?.id
+    ? allMembers.filter((m) =>
+        channelMembers.some((cm) => cm.memberName === m.name),
+      )
+    : allMembers;
   const mainTarget = useTarget();
   const threadTarget =
     mainTarget && openThreadMsg ? `${mainTarget}:${openThreadMsg.id}` : null;

--- a/ui/src/components/chat/ThreadPanel.tsx
+++ b/ui/src/components/chat/ThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { X, Paperclip } from "lucide-react";
 import { useStore } from "../../store";
 import {
@@ -35,16 +35,25 @@ export function ThreadPanel({ variant = "drawer" }: ThreadPanelProps) {
   const humans = useHumans();
   const { getAgentConversationId } = useInbox();
   const channelMembers = useChannelMembers(currentChannel?.id ?? null);
-  const allMembers: MentionMember[] = [
-    ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
-    ...humans.map((h) => ({ name: h.name, type: "human" as const })),
-    ...teams.map((team) => ({ name: team.name, type: "team" as const })),
-  ];
-  const members: MentionMember[] = currentChannel?.id
-    ? allMembers.filter((m) =>
-        channelMembers.some((cm) => cm.memberName === m.name),
-      )
-    : allMembers;
+  const allMembers: MentionMember[] = useMemo(
+    () => [
+      ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
+      ...humans.map((h) => ({ name: h.name, type: "human" as const })),
+      ...teams.map((team) => ({ name: team.name, type: "team" as const })),
+    ],
+    [agents, humans, teams],
+  );
+  const channelMemberSet = useMemo(
+    () => new Set(channelMembers.map((cm) => cm.memberName)),
+    [channelMembers],
+  );
+  const members = useMemo(
+    () =>
+      currentChannel?.id
+        ? allMembers.filter((m) => channelMemberSet.has(m.name))
+        : allMembers,
+    [allMembers, channelMemberSet, currentChannel?.id],
+  );
   const mainTarget = useTarget();
   const threadTarget =
     mainTarget && openThreadMsg ? `${mainTarget}:${openThreadMsg.id}` : null;

--- a/ui/src/data/channels.ts
+++ b/ui/src/data/channels.ts
@@ -158,6 +158,7 @@ export const channelQueryKeys = {
   whoami: ['whoami'] as const,
   channels: (user: string) => ['channels', user] as const,
   humans: ['humans'] as const,
+  members: (channelId: string) => ['channelMembers', channelId] as const,
 } as const
 
 export const whoamiQuery = queryOptions({
@@ -179,4 +180,11 @@ export const humansQuery = (currentUser: string) =>
     queryKey: channelQueryKeys.humans,
     queryFn: listHumans,
     enabled: !!currentUser,
+  })
+
+export const channelMembersQuery = (channelId: string | null) =>
+  queryOptions({
+    queryKey: channelQueryKeys.members(channelId ?? ''),
+    queryFn: () => getChannelMembers(channelId!),
+    enabled: !!channelId,
   })

--- a/ui/src/data/channels.ts
+++ b/ui/src/data/channels.ts
@@ -158,7 +158,7 @@ export const channelQueryKeys = {
   whoami: ['whoami'] as const,
   channels: (user: string) => ['channels', user] as const,
   humans: ['humans'] as const,
-  members: (channelId: string) => ['channelMembers', channelId] as const,
+  members: (channelId: string | null) => ['channelMembers', channelId] as const,
 } as const
 
 export const whoamiQuery = queryOptions({
@@ -184,7 +184,7 @@ export const humansQuery = (currentUser: string) =>
 
 export const channelMembersQuery = (channelId: string | null) =>
   queryOptions({
-    queryKey: channelQueryKeys.members(channelId ?? ''),
-    queryFn: () => getChannelMembers(channelId!),
+    queryKey: channelQueryKeys.members(channelId),
+    queryFn: () => getChannelMembers(channelId as string),
     enabled: !!channelId,
   })

--- a/ui/src/data/index.ts
+++ b/ui/src/data/index.ts
@@ -43,6 +43,7 @@ export {
   channelQueryKeys,
   whoamiQuery,
   channelsQuery,
+  channelMembersQuery,
   humansQuery,
   type ChannelSlices,
   type ChannelInfo,

--- a/ui/src/hooks/data.ts
+++ b/ui/src/hooks/data.ts
@@ -4,6 +4,7 @@ import { useStore } from '../store/uiStore'
 import {
   agentsQuery,
   channelsQuery,
+  channelMembersQuery,
   teamsQuery,
   humansQuery,
   getChannelThreads,
@@ -119,6 +120,12 @@ export function useHumans() {
   const currentUser = useStore((s) => s.currentUser)
   const { data } = useQuery(humansQuery(currentUser))
   return data ?? []
+}
+
+/** Members of a specific channel. Returns empty array for DMs or when no channelId. */
+export function useChannelMembers(channelId: string | null) {
+  const { data } = useQuery(channelMembersQuery(channelId))
+  return data?.members ?? []
 }
 
 /**


### PR DESCRIPTION
When typing @ in a channel's message input or thread reply, the autocomplete now only shows members who belong to that channel, instead of all agents/humans/teams globally.

## Changes
- `data/channels.ts`: Added `channelMembersQuery` (react-query options) and a `members` query key
- `data/index.ts`: Export `channelMembersQuery`
- `hooks/data.ts`: Added `useChannelMembers(channelId)` hook
- `components/chat/MessageInput.tsx`: Filter mention list to channel members when in a channel
- `components/chat/ThreadPanel.tsx`: Same filtering for thread reply input

In DM and no-channel contexts, all members remain available.