### PR TITLE
fix(drivers): add required env field to Claude ACP session/new mcpServers + dev env setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,21 @@ Commands are documented in `docs/DEV.md` and the top of this file. Key non-obvio
 - `cd ui && npm run test` (vitest) has 2 pre-existing failures in `Telescope.test.tsx` — the shimmer component wraps each character in individual `<span>` elements, so `toContain("reading…")` no longer matches the innerHTML. These are not caused by environment issues.
 - Pre-commit hooks (`.hooks/pre-commit`) run `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`.
 
+### Agent runtimes
+
+All four runtimes and their ACP adapters are pre-installed in the snapshot:
+
+| Runtime | Binary | Install | ACP adapter |
+|---------|--------|---------|-------------|
+| Claude | `claude` | `npm i -g @anthropic-ai/claude-code` | `claude-agent-acp` (`npm i -g @zed-industries/claude-agent-acp`) |
+| Codex | `codex` | `npm i -g @openai/codex` | `codex-acp` (`npm i -g @zed-industries/codex-acp`) |
+| Kimi | `kimi` | `uv tool install --python 3.13 kimi-cli` (requires `uv` at `~/.local/bin/uv`) | Native (`kimi acp` subcommand) |
+| OpenCode | `opencode` | `npm i -g opencode-ai` | Native (`opencode acp` subcommand) |
+
+- `uv` is installed at `~/.local/bin` — ensure `$HOME/.local/bin` is on PATH for `kimi` to resolve.
+- Runtimes require their own API keys/auth (not part of Chorus itself). Check `GET /api/runtimes` for auth status.
+- Chorus detects all four in ACP driver mode when the adapter binary (or native binary) is on PATH.
+
 ### Lint
 
 - `cargo fmt --check` — Rust formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,3 +164,34 @@ Before stopping, confirm:
 - [ ] Verification matches risk of change
 - [ ] Required e2e/browser QA run for user-facing critical paths, or gap called out
 - [ ] `AGENTS.md` or related docs updated if shipped behavior/workflow changed
+
+---
+
+## Cursor Cloud specific instructions
+
+### System dependencies
+
+- **Rust stable >=1.83** — the update script runs `rustup default stable` to ensure the latest stable toolchain is active. If a transitive crate requires a newer edition (e.g. `edition2024`), this keeps the toolchain current.
+- **OpenSSL dev headers** (`libssl-dev`, `pkg-config`) — required by `reqwest`/`openssl-sys`. Already installed in the base snapshot; if a fresh VM errors on `openssl-sys`, run `sudo apt-get install -y libssl-dev pkg-config`.
+- **Node.js >=18** and **npm** — pre-installed; used for the Vite dev server and vitest.
+- **SQLite** — bundled via `rusqlite`, no system install needed.
+
+### Running services
+
+Commands are documented in `docs/DEV.md` and the top of this file. Key non-obvious notes:
+
+- **Backend**: `RUST_LOG=chorus=info cargo run -- serve --port 3001`. First run compiles from scratch (~35s). The server auto-creates `~/.chorus/chorus.db`.
+- **Frontend**: `cd ui && npm run dev`. Proxies `/api/*` and `/internal/*` to the backend on port 3001 by default. Override with `CHORUS_API_PORT=<N>`.
+- The backend must be fully ready (responding on `/api/whoami`) before the frontend proxy will work. Wait or poll before testing.
+
+### Testing caveats
+
+- `cargo test` (51 tests) passes cleanly — uses real SQLite in tempdirs.
+- `cd ui && npm run test` (vitest) has 2 pre-existing failures in `Telescope.test.tsx` — the shimmer component wraps each character in individual `<span>` elements, so `toContain("reading…")` no longer matches the innerHTML. These are not caused by environment issues.
+- Pre-commit hooks (`.hooks/pre-commit`) run `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`.
+
+### Lint
+
+- `cargo fmt --check` — Rust formatting
+- `cargo clippy --all-targets -- -D warnings` — Rust lints
+- `cd ui && npx tsc --noEmit` — TypeScript type checking

--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -28,7 +28,8 @@ impl AcpRuntime for ClaudeAcpRuntime {
             "mcpServers": [{
                 "name": "chat",
                 "command": ctx.bridge_binary,
-                "args": ["bridge", "--agent-id", &ctx.agent_id, "--server-url", &ctx.server_url]
+                "args": ["bridge", "--agent-id", &ctx.agent_id, "--server-url", &ctx.server_url],
+                "env": []
             }]
         })
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cursor Cloud environment setup and fixes a Claude ACP driver bug.

### Changes

1. **`AGENTS.md`** — Added `## Cursor Cloud specific instructions` section with system deps, service startup notes, testing caveats, lint commands, and agent runtime install details.

2. **`src/agent/drivers/claude.rs`** — Fixed `session_new_params` to include required `env: []` field in MCP server config. The `@zed-industries/claude-agent-acp` adapter (v0.23+) validates `session/new` params with a Zod schema requiring `env: z.array(zEnvVariable)` on stdio MCP server entries. Without it, the adapter rejects with "Invalid params".

### Agent Runtimes Installed

| Runtime | Binary | Version | ACP Adapter | Driver Mode |
|---------|--------|---------|-------------|-------------|
| Claude | `claude` | 2.1.108 | `claude-agent-acp` | ACP |
| Codex | `codex` | 0.120.0 | `codex-acp` | ACP |
| Kimi | `kimi` | 1.34.0 | Native (`kimi acp`) | ACP |
| OpenCode | `opencode` | 1.4.4 | Native (`opencode acp`) | ACP |

### Verification

| Check | Result |
|-------|--------|
| `cargo fmt --check` | Pass |
| `cargo clippy --all-targets -- -D warnings` | Pass |
| `cargo test` | 51/51 pass |
| `npx tsc --noEmit` | Pass |
| `npm run test` (vitest) | 48/50 pass (2 pre-existing) |
| Claude agent creation + startup | Pass |
| Claude agent responds to DM | Pass ("I'm running on MiniMax-M2.7-highspeed.") |
| Claude agent cross-channel messaging | Pass (sent message to #hello-world) |

### Demo

[claude_agent_chat_and_cross_channel_messaging.mp4](https://cursor.com/agents/bc-03fb5a13-cfe9-4903-86c8-15f4b62a2e5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaude_agent_chat_and_cross_channel_messaging.mp4)

Claude agent chatting and sending a cross-channel message to #hello-world.

[Claude agent response in Chorus UI](https://cursor.com/agents/bc-03fb5a13-cfe9-4903-86c8-15f4b62a2e5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaude_agent_response.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03fb5a13-cfe9-4903-86c8-15f4b62a2e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03fb5a13-cfe9-4903-86c8-15f4b62a2e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

