### PR TITLE
refactor(bridge): remove legacy stdio, retrofit Iron Rule, ship fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,3 +149,11 @@ Before stopping, confirm:
 - [ ] Verification matches risk of change
 - [ ] Required e2e/browser QA run for user-facing critical paths, or gap called out
 - [ ] `AGENTS.md` or related docs updated if shipped behavior/workflow changed
+
+## Health Stack
+
+- typecheck: cd ui && tsc --noEmit
+- lint: cargo clippy -- -D warnings
+- test: cargo test
+- test-ui: cd ui && npm run test
+- shell: shellcheck dev.sh

--- a/docs/BRIDGE_MIGRATION.md
+++ b/docs/BRIDGE_MIGRATION.md
@@ -1,8 +1,7 @@
 # Bridge Migration Guide
 
-Chorus is migrating from per-agent stdio bridge processes to a single shared HTTP
-bridge. This guide covers what changed, how to use the new bridge, how to convert a
-driver, and what comes next.
+Chorus runs a single shared HTTP bridge that serves all agents. This guide covers how
+it works, how to use it, how to implement a driver against it, and what comes next.
 
 For deep architectural context, see the design rationale in this guide
 (Section 4, "For Architects") and the phased migration plan below.
@@ -11,18 +10,13 @@ For deep architectural context, see the design rationale in this guide
 
 ## 1. Overview
 
-### What changed and why
+### Architecture
 
-**Before:** Each agent spawned its own `chorus bridge --agent-id <key> --server-url
-<url>` stdio process. The bridge process held a hardcoded agent identity and handled
-all MCP tool calls for that one agent. N agents = N bridge processes, each with its
-own OS event loop and HTTP connection pool. Every driver duplicated the same
-boilerplate to construct the MCP config.
-
-**After:** One `chorus bridge-serve` daemon runs on localhost and serves all agents.
-Each agent connects to a unique URL path (`/<agent_key>/mcp`) over Streamable HTTP.
-The bridge routes tool calls to the correct agent based on the URL path. Session
-management is handled per-agent inside the same process.
+One shared HTTP MCP bridge runs alongside the Chorus server and serves all agents.
+Each agent pairs with the bridge to obtain a per-agent opaque token, then connects via
+Streamable HTTP to `{bridge_url}/token/{token}/mcp`. The bridge routes tool calls to
+the correct agent based on the token. Session management is handled per-agent inside
+the same process.
 
 The long-term goal is for the bridge to become a **local agent control plane**: a
 durable daemon that decouples agent identity (inbox, history, tasks, permissions) from
@@ -31,32 +25,33 @@ do their work, and can crash or be swapped without losing agent state. The same 
 will eventually talk to Chorus local, Chorus cloud, Slack, Discord, or any other IM
 backend — one bridge, all agents, any platform.
 
-### Which architecture is active
-
-Both paths are active simultaneously:
-
-| Path | Status | How it works |
-|---|---|---|
-| Old stdio bridge | Default (unchanged) | Driver spawns `chorus bridge --agent-id <key>` per agent |
-| New shared HTTP bridge | Opt-in per driver | Driver sets `bridge_endpoint`, bridge-serve must be running |
-
-Migration is per-driver. When a driver is converted, all agents of that runtime use the
-shared bridge. Other runtimes continue using the stdio bridge until their driver is
-converted.
+Drivers never fall back to stdio — the shared HTTP bridge is the only transport. If
+the bridge is not running when an agent starts, the agent start fails loudly rather
+than silently spawning a per-agent process.
 
 ---
 
 ## 2. For Users (running Chorus)
 
-### Starting the shared bridge
+### Starting the bridge
 
-Run `chorus bridge-serve` alongside `chorus serve`:
+`chorus serve` starts the shared bridge in the same process automatically:
 
 ```bash
-# Terminal 1 — Chorus backend
 chorus serve --port 3001
+```
 
-# Terminal 2 — Shared bridge (connects to the backend)
+By default the bridge listens on `127.0.0.1:4321`. Override with `--bridge-port`:
+
+```bash
+chorus serve --port 3001 --bridge-port 4400
+```
+
+The standalone `chorus bridge-serve` command is still available for users who want to
+run the bridge in a separate process (for example, to share one bridge across multiple
+chorus instances):
+
+```bash
 chorus bridge-serve --listen 127.0.0.1:4321 --server-url http://localhost:3001
 ```
 
@@ -84,112 +79,58 @@ chorus bridge-smoke-test
 `bridge-smoke-test` starts a temporary bridge, sends a real MCP `initialize` request,
 verifies the session ID comes back, then shuts down. Passes = the MCP layer is working.
 
-### When to use the shared bridge vs the old stdio bridge
-
-**Shared bridge (`chorus bridge-serve`):**
-- Running multiple agents and want fewer OS processes
-- Driver for your runtime has been converted to `bridge_endpoint`
-- Debugging the bridge itself
-
-**Old stdio bridge (default, no action needed):**
-- Single-agent setups
-- Using a runtime whose driver has not yet been converted
-- Backward-compatibility requirement — the stdio path is stable and unchanged
-
-You do not need to change anything to keep using the old stdio bridge. It remains the
-default until `bridge_endpoint` is explicitly set.
-
 ---
 
-## 3. For Driver Authors (converting a driver)
+## 3. For Driver Authors (implementing a driver)
 
-### The change in one sentence
+### The contract
 
-Replace the hardcoded stdio MCP config with a branch: if `bridge_endpoint` is set,
-point at the shared HTTP bridge; otherwise fall back to the old stdio spawn.
+`AgentSpec::bridge_endpoint` is always set to a live bridge URL before the driver is
+attached. The driver:
 
-### Before (current pattern — all four drivers look like this)
+1. Requests a per-agent pairing token via `request_pairing_token(endpoint, agent_key)`
+   (defined in `src/agent/drivers/v2/mod.rs`). This `POST`s to `{endpoint}/admin/pair`
+   and returns an opaque token that is consumed on the first MCP `initialize`.
+2. Constructs the runtime's MCP config using
+   `{endpoint}/token/{token}/mcp` as the URL.
+3. Spawns the runtime with that config.
+
+### Pattern
 
 ```rust
-// claude.rs, kimi.rs, opencode.rs, codex.rs — same idea in each
+let token = super::request_pairing_token(&self.spec.bridge_endpoint, &self.key)
+    .await
+    .context("failed to pair with shared bridge")?;
+
 let mcp_config = serde_json::json!({
     "mcpServers": {
         "chat": {
-            "command": &self.spec.bridge_binary,
-            "args": ["bridge", "--agent-id", &self.key, "--server-url", &self.spec.server_url]
+            "type": "http",   // exact key depends on the runtime's config format
+            "url": format!(
+                "{}/token/{}/mcp",
+                self.spec.bridge_endpoint.trim_end_matches('/'),
+                token
+            )
         }
     }
 });
 ```
 
-Codex (app-server) does this via `-c` flags instead of a config file, but it is the
-same conceptual pattern: stdio transport, per-agent binary, hardcoded agent identity
-in the spawn args.
+Codex (app-server) passes this via `-c` overrides instead of a config file, but the
+shape is the same — see `src/agent/drivers/v2/codex.rs`.
 
-### After (shared bridge path)
+### Per-runtime config format
 
-```rust
-let mcp_config = if let Some(endpoint) = &self.spec.bridge_endpoint {
-    // Shared HTTP bridge — agent identity lives in the URL path, not the spawn args.
-    serde_json::json!({
-        "mcpServers": {
-            "chat": {
-                "url": format!("{}/{}/mcp", endpoint, self.key),
-                "type": "http"   // exact key depends on the runtime's config format
-            }
-        }
-    })
-} else {
-    // Legacy stdio bridge — unchanged from before.
-    serde_json::json!({
-        "mcpServers": {
-            "chat": {
-                "command": &self.spec.bridge_binary,
-                "args": ["bridge", "--agent-id", &self.key, "--server-url", &self.spec.server_url]
-            }
-        }
-    })
-};
-```
+Each runtime expresses HTTP MCP transport differently. Matching the right shape is
+load-bearing — sending the wrong keys produces confusing "invalid params" errors:
 
-The `bridge_endpoint` field is already present on `AgentSpec` as
-`pub bridge_endpoint: Option<String>`. It defaults to `None` in all constructors. No
-schema or database changes are needed to add the field to a driver — it's already
-there.
-
-### What `bridge_endpoint` looks like at runtime
-
-When `bridge-serve` is running on the default port:
-
-```
-bridge_endpoint = Some("http://127.0.0.1:4321")
-```
-
-For an agent with `key = "bot-1"`, the driver constructs:
-
-```
-http://127.0.0.1:4321/bot-1/mcp
-```
-
-The bridge lazily creates a `StreamableHttpService<ChatBridge>` for each new
-`agent_key` it sees. If the key has never connected before, the session is created on
-the first `initialize` request.
-
-### Per-runtime notes
-
-Not all runtimes support Streamable HTTP MCP natively. Check the MCP config format for
-each runtime before converting its driver:
-
-| Runtime | MCP config key | HTTP support | Notes |
-|---|---|---|---|
-| Claude Code | `"type": "http"` (in `mcpServers`) | Needs verification | Uses `stream-json` over stdio by default |
-| Codex (app-server) | `-c mcp_servers.chat.type="http"` | Needs verification | Config passed via `-c` flags, not a file |
-| Kimi | `"type"` field in `mcpServers` | Needs verification | — |
-| OpenCode | `"type": "local"` or `"http"` | Needs verification | Config written to `opencode.json` |
-
-If a runtime does not support HTTP MCP natively, a stdio-to-HTTP adapter is needed
-(see Phase 2 in section 4). Do not convert that driver until the adapter exists or
-native HTTP support is confirmed.
+| Runtime | Config shape |
+|---|---|
+| Claude Code | `{"type": "http", "url": "…"}` in `mcpServers.chat` (config file) |
+| Codex (app-server) | `-c mcp_servers.chat.url="…"` plus `enabled=true` / `required=true` |
+| Kimi (file) | `{"transport": "http", "url": "…"}` in `mcpServers.chat` |
+| Kimi (ACP inline) | `{"type": "http", "name": "chat", "url": "…", "headers": []}` in `session/new` params |
+| OpenCode | `{"type": "remote", "url": "…"}` in `mcp.chat` |
 
 ### Driver connection failures
 
@@ -198,77 +139,51 @@ The bridge can crash or be restarted. When that happens:
 - The session registry (in-memory) is lost
 - Runtimes that hold a live MCP session will see a connection error
 
-Drivers should handle this with exponential backoff retry. The stdio bridge has the
-same failure mode — the bridge process crashes, the runtime sees a broken pipe. The
-error surface is identical; only the transport changes.
+Drivers should handle this with exponential backoff retry.
 
-### Wiring `bridge_endpoint` from the manager
+### `bridge_endpoint` at runtime
 
-The manager constructs `AgentSpec` and currently always sets `bridge_endpoint: None`.
-To enable the shared bridge for an agent, populate this field before passing the spec
-to the driver:
-
-```rust
-// In AgentManager or wherever the spec is built:
-let bridge_endpoint = chorus::bridge::discovery::read_bridge_info()
-    .map(|info| format!("http://127.0.0.1:{}", info.port));
-
-let spec = AgentSpec {
-    // ... other fields ...
-    bridge_binary: self.bridge_binary.clone(),
-    server_url: self.server_url.clone(),
-    bridge_endpoint,
-};
-```
-
-`read_bridge_info()` returns `None` if the file does not exist or if the recorded PID
-is not alive (stale file). In that case the driver falls back to stdio automatically.
+`AgentManager::start_agent` reads `~/.chorus/bridge.json` via
+`chorus::bridge::discovery::read_bridge_info()` and fails loudly if no bridge is
+running. `chorus serve` starts the bridge in-process on startup, so under normal
+operation the discovery file is always present. If it's missing, start the bridge
+explicitly via `chorus bridge-serve` or restart `chorus serve`.
 
 ---
 
 ## 4. For Architects (phased migration plan)
 
-### Phase 1 — Shared HTTP transport (current)
+### Phase 1 — Shared HTTP transport
 
 **Status:** Shipped.
 
 What is in place:
-- `chorus bridge-serve --listen <addr> --server-url <url>` starts the daemon
-- Routes: `/{agent_key}/mcp` (MCP Streamable HTTP), `/health` (plain text)
-- Each `agent_key` gets its own `StreamableHttpService<ChatBridge>` created on first
-  request — no pre-registration required
+- `chorus serve` starts the bridge in-process; standalone `chorus bridge-serve` also
+  available for users who want to run the bridge separately
+- Routes: `/token/{token}/mcp` (MCP Streamable HTTP), `/admin/pair` (token issue),
+  `/health` (plain text)
+- Per-agent `StreamableHttpService<ChatBridge>` created lazily on first request after
+  a successful pairing — no pre-registration of agent keys required
 - `~/.chorus/bridge.json` written on startup (port, PID, timestamp); removed on clean
   shutdown
 - `read_bridge_info()` in `src/bridge/discovery.rs` validates the PID is alive before
   returning the info, preventing stale-file confusion
 - `chorus bridge-smoke-test` for "it works" confirmation
-- Old stdio `chorus bridge --agent-id <key>` remains as fallback — unchanged
-
-Identity model: `agent_key` is visible in the URL path. Any local process that can
-read the MCP config file can connect to any agent's endpoint. This is acceptable for
-Phase 1 (same attack surface as the old stdio bridge).
-
-Security: localhost-only (`127.0.0.1`). No authentication. Single-user, single-machine
-threat model.
+- No stdio fallback — drivers fail loudly if the bridge is unavailable
 
 ### Phase 2 — Pairing tokens and opaque identity
 
-What changes:
-- `chorus bridge-pair --agent <key>` generates a one-time opaque token
-- Token has a TTL (default 5 minutes); `bridge-pair` can regenerate if it expires
-- Driver passes the token in the MCP `initialize` request (custom header or init params)
-- Bridge maps token → agent persona at session setup time; token is consumed after a
-  successful `InitializeResult`
-- `agent_key` is no longer visible in the transport layer — the URL path carries the
-  opaque token instead
-- Agent personas survive runtime crash. A new runtime re-pairs to the same persona
-- Convert remaining drivers (Codex, Kimi, OpenCode)
-- Remove old stdio bridge
+**Status:** Shipped.
 
-Open question: how does the token get from `chorus bridge-pair` output into the driver
-config? Options: (a) environment variable injected by the driver at spawn time, (b)
-driver reads a well-known file written by `bridge-pair`, (c) driver config references
-a shell command that calls `bridge-pair`.
+What is in place:
+- Driver `start()` calls `request_pairing_token(endpoint, agent_key)` which hits
+  `/admin/pair` and receives an opaque token
+- Token has a TTL; expires unused after a short grace period
+- Bridge maps token → agent persona at session setup time; consumed on the first
+  successful `InitializeResult`
+- `agent_key` is not visible in the transport layer — the URL path carries the
+  opaque token
+- Legacy per-agent stdio bridge code path removed
 
 ### Phase 3 — Bidirectional Platform connection
 
@@ -299,22 +214,9 @@ What changes:
 
 ## 5. Rollback
 
-If the shared bridge has issues and you need to revert a driver to the stdio path:
-
-1. **Revert the driver code** — either `git revert` the commit that added the
-   `bridge_endpoint` branch, or manually change the driver back to always use the stdio
-   config and remove the `bridge_endpoint` check.
-
-2. **Ensure `bridge_endpoint: None` in the spec** — the default is already `None` in
-   all `AgentSpec` constructors. If you wired auto-discovery into the manager, revert
-   that too.
-
-3. **No data migration needed** — agent records in `chorus.db` do not store
-   `bridge_endpoint`. The field lives only in the in-memory `AgentSpec` built at
-   runtime. Reverting the code is sufficient.
-
-4. **Stop `chorus bridge-serve`** — once no drivers reference the shared bridge, the
-   daemon can be shut down.
+There is no stdio bridge to fall back to. If the shared bridge fails to start, fix
+the underlying cause (port conflict, permissions on `~/.chorus/bridge.json`, etc.);
+drivers will not silently spawn per-agent bridges.
 
 ---
 
@@ -350,14 +252,15 @@ affected agent runtime, which will send a fresh `initialize` request.
 
 The bridge crashed without running its cleanup hook, leaving `~/.chorus/bridge.json`
 pointing at a dead PID. The `read_bridge_info()` helper detects this (it sends signal 0
-to the PID and returns `None` if the process is gone), so drivers will fall back to
-stdio automatically. To clean up manually:
+to the PID and returns `None` if the process is gone) and `AgentManager::start_agent`
+will fail loudly. To clean up manually:
 
 ```bash
 rm ~/.chorus/bridge.json
 ```
 
-Then start `chorus bridge-serve` fresh.
+Then restart `chorus serve` (which will start a fresh bridge) or start
+`chorus bridge-serve` standalone.
 
 ### Debug commands
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -59,23 +59,23 @@ CHORUS_API_PORT=3002 npm run dev
 
 See `ui/vite.config.ts` for the proxy configuration.
 
-**Shared MCP bridge** (optional, terminal 3):
+**Shared MCP bridge:**
+
+`chorus serve` starts the shared bridge in-process automatically (default port 4321,
+configurable via `--bridge-port`). You don't need to run anything extra. If you want
+to run the bridge standalone:
 
 ```bash
 chorus bridge-serve --listen 127.0.0.1:4321 --server-url http://localhost:3001
 ```
-
-The shared bridge is an optional daemon that routes MCP tool calls for all agents over
-one HTTP server instead of one stdio process per agent. It is not required — agents fall
-back to the per-agent stdio bridge automatically when `bridge-serve` is not running.
 
 ```bash
 # Verify the bridge layer works (no Chorus server required)
 chorus bridge-smoke-test
 ```
 
-See `docs/BRIDGE_MIGRATION.md` for the full architecture, driver conversion guide, and
-phased migration plan.
+See `docs/BRIDGE_MIGRATION.md` for the full architecture and driver implementation
+guide.
 
 ---
 

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -69,34 +69,26 @@ New driver work usually touches these files:
 - `qa/cases/playwright/<RUNTIME-CASE>.spec.ts`
   - runtime-specific DM reply verification
 
-## Shared Bridge vs Stdio Bridge
+## Shared Bridge
 
-Every driver gets an `AgentSpec` when it is spawned. `AgentSpec` carries an optional
-`bridge_endpoint: Option<String>` field:
+Every driver gets an `AgentSpec` when it is spawned. `AgentSpec.bridge_endpoint` is a
+required `String` pointing at the shared HTTP bridge (for example
+`"http://127.0.0.1:4321"`); populated by `AgentManager::start_agent` from
+`~/.chorus/bridge.json`. If the bridge is not running the manager fails loudly —
+there is no stdio fallback.
 
-- `None` (default) — driver spawns a per-agent `chorus bridge --agent-id <key>` stdio
-  process as the MCP server. This is the stable default path.
-- `Some("http://127.0.0.1:4321")` — driver points the runtime's MCP config at the
-  shared `chorus bridge-serve` daemon using Streamable HTTP. The URL path
-  (`/<agent_key>/mcp`) identifies the agent; no per-agent process is needed.
+In each driver's `start()`:
 
-The field is populated by auto-discovery (`src/bridge/discovery.rs`). If
-`~/.chorus/bridge.json` exists and the recorded PID is alive, the manager fills in the
-endpoint automatically. Otherwise it stays `None` and the stdio path is used unchanged.
-
-When implementing a new driver's MCP config, branch on `bridge_endpoint`:
-
-```rust
-let mcp_config = if let Some(endpoint) = &self.spec.bridge_endpoint {
-    json!({ "mcpServers": { "chat": { "url": format!("{}/{}/mcp", endpoint, self.key), "type": "http" } } })
-} else {
-    json!({ "mcpServers": { "chat": { "command": &self.spec.bridge_binary,
-        "args": ["bridge", "--agent-id", &self.key, "--server-url", &self.spec.server_url] } } })
-};
-```
+1. Request a per-agent pairing token:
+   ```rust
+   let token = super::request_pairing_token(&self.spec.bridge_endpoint, &self.key).await?;
+   ```
+2. Point the runtime's MCP config at `{bridge_endpoint}/token/{token}/mcp` using the
+   runtime-specific config shape (see `docs/BRIDGE_MIGRATION.md` for a per-runtime
+   table).
 
 See `docs/BRIDGE_MIGRATION.md` for per-runtime MCP config format details and the full
-conversion guide.
+implementation guide.
 
 ---
 
@@ -126,8 +118,9 @@ Before writing much code, answer these questions from the real runtime:
 
 Use a tiny one-off probe before integrating fully:
 
-1. Create a temporary MCP config that points at:
-   - `chorus bridge --agent-id <test-agent> --server-url <local-server>`
+1. Start `chorus bridge-serve` pointed at a local chorus server, then pair an agent
+   with `chorus bridge-pair --agent <test-agent>` and point the runtime's MCP config
+   at `http://127.0.0.1:4321/token/<token>/mcp`.
 2. Run the runtime directly in its print/JSON mode
 3. Send one minimal prompt that asks it to call `send_message`
 4. Capture raw stdout and stderr

--- a/src/agent/drivers/v2/claude.rs
+++ b/src/agent/drivers/v2/claude.rs
@@ -24,11 +24,7 @@ use super::*;
 /// bridge at `{endpoint}/token/{token}/mcp`. Factored out so config-shape
 /// tests don't need a live bridge.
 fn build_mcp_config(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!(
-        "{}/token/{}/mcp",
-        bridge_endpoint.trim_end_matches('/'),
-        token
-    );
+    let url = crate::bridge::token_mcp_url(bridge_endpoint, token);
     serde_json::json!({
         "mcpServers": {
             "chat": {

--- a/src/agent/drivers/v2/claude.rs
+++ b/src/agent/drivers/v2/claude.rs
@@ -24,7 +24,11 @@ use super::*;
 /// bridge at `{endpoint}/token/{token}/mcp`. Factored out so config-shape
 /// tests don't need a live bridge.
 fn build_mcp_config(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    let url = format!(
+        "{}/token/{}/mcp",
+        bridge_endpoint.trim_end_matches('/'),
+        token
+    );
     serde_json::json!({
         "mcpServers": {
             "chat": {

--- a/src/agent/drivers/v2/claude.rs
+++ b/src/agent/drivers/v2/claude.rs
@@ -20,37 +20,19 @@ use super::*;
 
 /// Build the `mcpServers.chat` config block for `.chorus-claude-mcp.json`.
 ///
-/// Two shapes, branching on whether a shared HTTP bridge is available:
-/// - `spec.bridge_endpoint = Some(_)` + `token = Some(_)`: native HTTP MCP,
-///   connecting to `{endpoint}/token/{token}/mcp`.
-/// - otherwise: per-agent stdio bridge spawned by Claude (`command` shape).
-///
-/// Factored out so config-shape tests don't need a live bridge.
-fn build_mcp_config(agent_key: &str, spec: &AgentSpec, token: Option<&str>) -> serde_json::Value {
-    match (&spec.bridge_endpoint, token) {
-        (Some(endpoint), Some(tok)) => {
-            let url = format!("{}/token/{}/mcp", endpoint.trim_end_matches('/'), tok);
-            serde_json::json!({
-                "mcpServers": {
-                    "chat": {
-                        "type": "http",
-                        "url": url
-                    }
-                }
-            })
+/// Produces the native HTTP MCP shape, connecting the runtime to the shared
+/// bridge at `{endpoint}/token/{token}/mcp`. Factored out so config-shape
+/// tests don't need a live bridge.
+fn build_mcp_config(bridge_endpoint: &str, token: &str) -> serde_json::Value {
+    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    serde_json::json!({
+        "mcpServers": {
+            "chat": {
+                "type": "http",
+                "url": url
+            }
         }
-        _ => {
-            // Legacy stdio path — unchanged
-            serde_json::json!({
-                "mcpServers": {
-                    "chat": {
-                        "command": &spec.bridge_binary,
-                        "args": ["bridge", "--agent-id", agent_key, "--server-url", &spec.server_url]
-                    }
-                }
-            })
-        }
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -201,16 +183,10 @@ impl AgentHandle for ClaudeHandle {
         // Write MCP config file
         let wd = &self.spec.working_directory;
         let mcp_config_path = wd.join(".chorus-claude-mcp.json");
-        let token = if let Some(endpoint) = &self.spec.bridge_endpoint {
-            Some(
-                super::request_pairing_token(endpoint, &self.key)
-                    .await
-                    .context("failed to pair with shared bridge")?,
-            )
-        } else {
-            None
-        };
-        let mcp_config = build_mcp_config(&self.key, &self.spec, token.as_deref());
+        let token = super::request_pairing_token(&self.spec.bridge_endpoint, &self.key)
+            .await
+            .context("failed to pair with shared bridge")?;
+        let mcp_config = build_mcp_config(&self.spec.bridge_endpoint, &token);
         std::fs::write(&mcp_config_path, serde_json::to_string(&mcp_config)?)
             .context("failed to write MCP config")?;
 
@@ -692,9 +668,7 @@ mod tests {
             reasoning_effort: None,
             env_vars: vec![],
             working_directory: PathBuf::from("/fake"),
-            bridge_binary: "bridge".into(),
-            server_url: "http://localhost:3001".into(),
-            bridge_endpoint: None,
+            bridge_endpoint: "http://127.0.0.1:1".into(),
         }
     }
 
@@ -733,33 +707,9 @@ mod tests {
     // ---- build_mcp_config tests ----
 
     #[test]
-    fn build_mcp_config_stdio_when_no_endpoint() {
-        // No bridge_endpoint → legacy stdio command shape.
-        let mut spec = test_spec();
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-        spec.server_url = "http://127.0.0.1:3001".to_string();
-        assert!(spec.bridge_endpoint.is_none());
-
-        let config = build_mcp_config("agent-abc", &spec, None);
-        let chat = &config["mcpServers"]["chat"];
-        assert_eq!(chat["command"], "/opt/chorus/bridge");
-        let args = chat["args"].as_array().expect("args is array");
-        assert_eq!(args[0], "bridge");
-        assert_eq!(args[1], "--agent-id");
-        assert_eq!(args[2], "agent-abc");
-        assert_eq!(args[3], "--server-url");
-        assert_eq!(args[4], "http://127.0.0.1:3001");
-        assert!(chat.get("type").is_none());
-        assert!(chat.get("url").is_none());
-    }
-
-    #[test]
-    fn build_mcp_config_http_when_endpoint_and_token() {
-        // With bridge_endpoint + token → native HTTP MCP shape.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let config = build_mcp_config("agent-abc", &spec, Some("tok-xyz"));
+    fn build_mcp_config_http_shape() {
+        // Native HTTP MCP shape — the only shape we produce.
+        let config = build_mcp_config("http://127.0.0.1:4321", "tok-xyz");
         let chat = &config["mcpServers"]["chat"];
         assert_eq!(chat["type"], "http");
         assert_eq!(chat["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
@@ -770,30 +720,9 @@ mod tests {
     #[test]
     fn build_mcp_config_trims_trailing_slash() {
         // Endpoint with trailing slash must not produce `//token/` in the URL.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321/".to_string());
-
-        let config = build_mcp_config("agent-abc", &spec, Some("tok-xyz"));
+        let config = build_mcp_config("http://127.0.0.1:4321/", "tok-xyz");
         let chat = &config["mcpServers"]["chat"];
         assert_eq!(chat["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
-    }
-
-    #[test]
-    fn build_mcp_config_falls_back_when_endpoint_but_no_token() {
-        // If token is None even though endpoint is Some, fall back to stdio.
-        // In production flow, start() always fetches a token when
-        // bridge_endpoint is Some, but this keeps the helper sound if its
-        // preconditions are violated.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let config = build_mcp_config("agent-abc", &spec, None);
-        let chat = &config["mcpServers"]["chat"];
-        assert!(
-            chat.get("command").is_some(),
-            "expected stdio fallback shape"
-        );
-        assert!(chat.get("url").is_none());
     }
 
     /// Feed captured JSONL through spawn_stdout_reader via a mock pipe and

--- a/src/agent/drivers/v2/codex.rs
+++ b/src/agent/drivers/v2/codex.rs
@@ -27,54 +27,23 @@ use super::*;
 
 /// Build the `-c mcp_servers.chat.*` override flags for `codex app-server`.
 ///
-/// Two shapes, branching on whether a shared HTTP bridge is available:
-/// - `spec.bridge_endpoint = Some(_)` + `token = Some(_)`: native HTTP MCP,
-///   connecting to `{endpoint}/token/{token}/mcp`.
-/// - otherwise: per-agent stdio bridge spawned by Codex (`command` shape).
-///
-/// Returns a flat `Vec<String>` ready to be extended onto the args list.
-/// Each config override is already preceded by its own `-c` flag.
+/// Produces the native HTTP MCP shape, connecting the runtime to the shared
+/// bridge at `{endpoint}/token/{token}/mcp`. Returns a flat `Vec<String>`
+/// ready to be extended onto the args list; each config override is already
+/// preceded by its own `-c` flag.
 ///
 /// Factored out so config-shape tests don't need a live bridge.
-fn build_codex_mcp_args(agent_key: &str, spec: &AgentSpec, token: Option<&str>) -> Vec<String> {
+fn build_codex_mcp_args(bridge_endpoint: &str, token: &str) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
 
-    match (&spec.bridge_endpoint, token) {
-        (Some(endpoint), Some(tok)) => {
-            // Shared HTTP bridge path
-            let url = format!("{}/token/{}/mcp", endpoint.trim_end_matches('/'), tok);
-            let url_json = serde_json::to_string(&url).expect("url serialization cannot fail");
-            args.push("-c".into());
-            args.push(format!("mcp_servers.chat.url={url_json}"));
-            args.push("-c".into());
-            args.push("mcp_servers.chat.enabled=true".into());
-            args.push("-c".into());
-            args.push("mcp_servers.chat.required=true".into());
-        }
-        _ => {
-            // Legacy stdio path — unchanged
-            let bridge_binary_json = serde_json::to_string(&spec.bridge_binary)
-                .expect("bridge_binary serialization cannot fail");
-            let bridge_args_json = serde_json::to_string(&[
-                "bridge",
-                "--agent-id",
-                agent_key,
-                "--server-url",
-                &spec.server_url,
-            ])
-            .expect("bridge_args serialization cannot fail");
-            args.push("-c".into());
-            args.push(format!("mcp_servers.chat.command={bridge_binary_json}"));
-            args.push("-c".into());
-            args.push(format!("mcp_servers.chat.args={bridge_args_json}"));
-            args.push("-c".into());
-            args.push("mcp_servers.chat.type=\"stdio\"".into());
-            args.push("-c".into());
-            args.push("mcp_servers.chat.enabled=true".into());
-            args.push("-c".into());
-            args.push("mcp_servers.chat.required=true".into());
-        }
-    }
+    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    let url_json = serde_json::to_string(&url).expect("url serialization cannot fail");
+    args.push("-c".into());
+    args.push(format!("mcp_servers.chat.url={url_json}"));
+    args.push("-c".into());
+    args.push("mcp_servers.chat.enabled=true".into());
+    args.push("-c".into());
+    args.push("mcp_servers.chat.required=true".into());
 
     args
 }
@@ -268,21 +237,14 @@ impl AgentHandle for CodexHandle {
         // passed in the `thread/start` JSON-RPC params instead.
         let mut args: Vec<String> = vec!["app-server".into()];
 
-        // Obtain a pairing token when the shared HTTP bridge is configured.
-        // If bridge_endpoint is None, skip the request and use the stdio path.
-        let token = if let Some(endpoint) = &self.spec.bridge_endpoint {
-            Some(
-                super::request_pairing_token(endpoint, &self.key)
-                    .await
-                    .context("failed to pair with shared bridge")?,
-            )
-        } else {
-            None
-        };
+        // Obtain a pairing token from the shared HTTP bridge.
+        let token = super::request_pairing_token(&self.spec.bridge_endpoint, &self.key)
+            .await
+            .context("failed to pair with shared bridge")?;
 
         // Register the bridge MCP server so Codex can call back into Chorus.
         // Uses the same `mcp_servers.*` config key format as ~/.codex/config.toml.
-        let mcp_args = build_codex_mcp_args(&self.key, &self.spec, token.as_deref());
+        let mcp_args = build_codex_mcp_args(&self.spec.bridge_endpoint, &token);
         args.extend(mcp_args);
 
         let mut cmd = Command::new("codex");
@@ -847,9 +809,7 @@ mod tests {
             reasoning_effort: None,
             env_vars: vec![],
             working_directory: PathBuf::from("/fake"),
-            bridge_binary: "bridge".into(),
-            server_url: "http://localhost:3001".into(),
-            bridge_endpoint: None,
+            bridge_endpoint: "http://127.0.0.1:1".into(),
         }
     }
 
@@ -901,54 +861,9 @@ mod tests {
     // ---- build_codex_mcp_args tests ----
 
     #[test]
-    fn build_codex_mcp_args_stdio_when_no_endpoint() {
-        // No bridge_endpoint → legacy stdio command shape.
-        let mut spec = test_spec();
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-        spec.server_url = "http://127.0.0.1:3001".to_string();
-        assert!(spec.bridge_endpoint.is_none());
-
-        let args = build_codex_mcp_args("agent-abc", &spec, None);
-
-        // Should contain command and args overrides, not url
-        let joined = args.join(" ");
-        assert!(
-            joined.contains("mcp_servers.chat.command="),
-            "expected command override, got: {joined}"
-        );
-        assert!(
-            joined.contains("mcp_servers.chat.args="),
-            "expected args override, got: {joined}"
-        );
-        assert!(
-            joined.contains("mcp_servers.chat.type="),
-            "expected type override, got: {joined}"
-        );
-        assert!(
-            !joined.contains("mcp_servers.chat.url="),
-            "unexpected url override in stdio path: {joined}"
-        );
-        // Each config value must be preceded by -c
-        let pairs: Vec<&str> = args
-            .chunks(2)
-            .flat_map(|c| c.iter().map(|s| s.as_str()))
-            .collect();
-        for i in (0..args.len()).step_by(2) {
-            assert_eq!(args[i], "-c", "expected -c at index {i}, got: {}", args[i]);
-        }
-        // enabled and required present
-        assert!(joined.contains("mcp_servers.chat.enabled=true"));
-        assert!(joined.contains("mcp_servers.chat.required=true"));
-        let _ = pairs; // suppress unused warning
-    }
-
-    #[test]
-    fn build_codex_mcp_args_http_when_endpoint_and_token() {
-        // With bridge_endpoint + token → native HTTP MCP url shape.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let args = build_codex_mcp_args("agent-abc", &spec, Some("tok-xyz"));
+    fn build_codex_mcp_args_http_shape() {
+        // Native HTTP MCP url shape — the only shape we produce.
+        let args = build_codex_mcp_args("http://127.0.0.1:4321", "tok-xyz");
 
         let joined = args.join(" ");
         assert!(
@@ -973,12 +888,15 @@ mod tests {
         );
         assert!(joined.contains("mcp_servers.chat.enabled=true"));
         assert!(joined.contains("mcp_servers.chat.required=true"));
+        // Each config value must be preceded by -c
+        for i in (0..args.len()).step_by(2) {
+            assert_eq!(args[i], "-c", "expected -c at index {i}, got: {}", args[i]);
+        }
         // Verify the URL value itself (it's JSON-encoded in the arg)
         let url_arg = args
             .iter()
             .find(|a| a.starts_with("mcp_servers.chat.url="))
             .expect("url arg not found");
-        // JSON-decoded value inside the arg
         let json_val = url_arg.trim_start_matches("mcp_servers.chat.url=");
         let decoded: String =
             serde_json::from_str(json_val).expect("url value should be JSON string");
@@ -988,10 +906,7 @@ mod tests {
     #[test]
     fn build_codex_mcp_args_trims_trailing_slash() {
         // Endpoint with trailing slash must not produce `//token/` in the URL.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321/".to_string());
-
-        let args = build_codex_mcp_args("agent-abc", &spec, Some("tok-xyz"));
+        let args = build_codex_mcp_args("http://127.0.0.1:4321/", "tok-xyz");
 
         let url_arg = args
             .iter()
@@ -1004,25 +919,6 @@ mod tests {
         assert!(
             !decoded.contains("//token/"),
             "double-slash in URL: {decoded}"
-        );
-    }
-
-    #[test]
-    fn build_codex_mcp_args_falls_back_when_endpoint_but_no_token() {
-        // If token is None even though endpoint is Some, fall back to stdio.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let args = build_codex_mcp_args("agent-abc", &spec, None);
-
-        let joined = args.join(" ");
-        assert!(
-            joined.contains("mcp_servers.chat.command="),
-            "expected stdio fallback shape, got: {joined}"
-        );
-        assert!(
-            !joined.contains("mcp_servers.chat.url="),
-            "unexpected url in stdio fallback: {joined}"
         );
     }
 }

--- a/src/agent/drivers/v2/codex.rs
+++ b/src/agent/drivers/v2/codex.rs
@@ -36,7 +36,11 @@ use super::*;
 fn build_codex_mcp_args(bridge_endpoint: &str, token: &str) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
 
-    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    let url = format!(
+        "{}/token/{}/mcp",
+        bridge_endpoint.trim_end_matches('/'),
+        token
+    );
     let url_json = serde_json::to_string(&url).expect("url serialization cannot fail");
     args.push("-c".into());
     args.push(format!("mcp_servers.chat.url={url_json}"));

--- a/src/agent/drivers/v2/codex.rs
+++ b/src/agent/drivers/v2/codex.rs
@@ -36,11 +36,7 @@ use super::*;
 fn build_codex_mcp_args(bridge_endpoint: &str, token: &str) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
 
-    let url = format!(
-        "{}/token/{}/mcp",
-        bridge_endpoint.trim_end_matches('/'),
-        token
-    );
+    let url = crate::bridge::token_mcp_url(bridge_endpoint, token);
     let url_json = serde_json::to_string(&url).expect("url serialization cannot fail");
     args.push("-c".into());
     args.push(format!("mcp_servers.chat.url={url_json}"));

--- a/src/agent/drivers/v2/fake.rs
+++ b/src/agent/drivers/v2/fake.rs
@@ -353,9 +353,7 @@ mod tests {
             reasoning_effort: None,
             env_vars: vec![],
             working_directory: PathBuf::from("/fake"),
-            bridge_binary: String::new(),
-            server_url: String::new(),
-            bridge_endpoint: None,
+            bridge_endpoint: "http://127.0.0.1:1".to_string(),
         }
     }
 

--- a/src/agent/drivers/v2/kimi.rs
+++ b/src/agent/drivers/v2/kimi.rs
@@ -28,7 +28,11 @@ use super::*;
 /// connect. Verified against the format emitted by `kimi mcp add --transport
 /// http`.
 fn build_mcp_config_file(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    let url = format!(
+        "{}/token/{}/mcp",
+        bridge_endpoint.trim_end_matches('/'),
+        token
+    );
     serde_json::json!({
         "mcpServers": {
             "chat": {
@@ -49,7 +53,11 @@ fn build_mcp_config_file(bridge_endpoint: &str, token: &str) -> serde_json::Valu
 /// See <https://agentclientprotocol.com/protocol/session-setup> — sending the
 /// wrong shape produces ACP "Invalid params" errors.
 fn build_acp_mcp_servers(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    let url = format!(
+        "{}/token/{}/mcp",
+        bridge_endpoint.trim_end_matches('/'),
+        token
+    );
     serde_json::json!([{
         "type": "http",
         "name": "chat",

--- a/src/agent/drivers/v2/kimi.rs
+++ b/src/agent/drivers/v2/kimi.rs
@@ -22,83 +22,40 @@ use super::*;
 
 /// Build the `.chorus-kimi-mcp.json` config file contents.
 ///
-/// Two shapes, branching on whether a shared HTTP bridge is available:
-/// - `spec.bridge_endpoint = Some(_)` + `token = Some(_)`: remote HTTP MCP,
-///   connecting to `{endpoint}/token/{token}/mcp`.
-/// - otherwise: per-agent stdio bridge spawned by Kimi.
-///
-/// Factored out so config-shape tests don't need a live bridge.
-fn build_mcp_config_file(
-    agent_key: &str,
-    spec: &AgentSpec,
-    token: Option<&str>,
-) -> serde_json::Value {
-    match (&spec.bridge_endpoint, token) {
-        (Some(endpoint), Some(tok)) => {
-            // Kimi requires `transport: "http"` alongside `url` — without it,
-            // the runtime defaults to stdio and fails to connect. Verified
-            // against the format emitted by `kimi mcp add --transport http`.
-            let url = format!("{}/token/{}/mcp", endpoint.trim_end_matches('/'), tok);
-            serde_json::json!({
-                "mcpServers": {
-                    "chat": {
-                        "url": url,
-                        "transport": "http"
-                    }
-                }
-            })
+/// Produces the remote HTTP MCP shape, connecting the runtime to the shared
+/// bridge at `{endpoint}/token/{token}/mcp`. Kimi requires `transport: "http"`
+/// alongside `url` — without it, the runtime defaults to stdio and fails to
+/// connect. Verified against the format emitted by `kimi mcp add --transport
+/// http`.
+fn build_mcp_config_file(bridge_endpoint: &str, token: &str) -> serde_json::Value {
+    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    serde_json::json!({
+        "mcpServers": {
+            "chat": {
+                "url": url,
+                "transport": "http"
+            }
         }
-        _ => {
-            serde_json::json!({
-                "mcpServers": {
-                    "chat": {
-                        "command": &spec.bridge_binary,
-                        "args": ["bridge", "--agent-id", agent_key, "--server-url", &spec.server_url]
-                    }
-                }
-            })
-        }
-    }
+    })
 }
 
 /// Build the `mcpServers` array for the ACP `session/new` inline params.
 ///
-/// Two shapes, branching on whether a shared HTTP bridge is available:
-/// - `spec.bridge_endpoint = Some(_)` + `token = Some(_)`: remote HTTP MCP,
-///   connecting to `{endpoint}/token/{token}/mcp`.
-/// - otherwise: per-agent stdio bridge with command + args + env.
+/// Produces the remote HTTP MCP shape. ACP spec for HTTP MCP servers in
+/// session/new params requires:
+///   - `type: "http"` (NOT `transport: "http"` like Kimi's file config format)
+///   - `headers` array (required, can be empty)
 ///
-/// Factored out so config-shape tests don't need a live bridge.
-fn build_acp_mcp_servers(
-    agent_key: &str,
-    spec: &AgentSpec,
-    token: Option<&str>,
-) -> serde_json::Value {
-    match (&spec.bridge_endpoint, token) {
-        (Some(endpoint), Some(tok)) => {
-            // ACP spec for HTTP MCP servers in session/new params requires:
-            //   - `type: "http"` (NOT `transport: "http"` like Kimi's file
-            //     config format)
-            //   - `headers` array (required, can be empty)
-            // See https://agentclientprotocol.com/protocol/session-setup
-            // Sending the wrong shape produces ACP "Invalid params" errors.
-            let url = format!("{}/token/{}/mcp", endpoint.trim_end_matches('/'), tok);
-            serde_json::json!([{
-                "type": "http",
-                "name": "chat",
-                "url": url,
-                "headers": []
-            }])
-        }
-        _ => {
-            serde_json::json!([{
-                "name": "chat",
-                "command": &spec.bridge_binary,
-                "args": ["bridge", "--agent-id", agent_key, "--server-url", &spec.server_url],
-                "env": []
-            }])
-        }
-    }
+/// See <https://agentclientprotocol.com/protocol/session-setup> — sending the
+/// wrong shape produces ACP "Invalid params" errors.
+fn build_acp_mcp_servers(bridge_endpoint: &str, token: &str) -> serde_json::Value {
+    let url = format!("{}/token/{}/mcp", bridge_endpoint.trim_end_matches('/'), token);
+    serde_json::json!([{
+        "type": "http",
+        "name": "chat",
+        "url": url,
+        "headers": []
+    }])
 }
 
 // ---------------------------------------------------------------------------
@@ -276,24 +233,16 @@ impl AgentHandle for KimiHandle {
             state: AgentState::Starting,
         });
 
-        // Resolve MCP transport: shared HTTP bridge (when `bridge_endpoint`
-        // is configured) or per-agent stdio bridge (legacy). If pairing
-        // fails we surface the error — no silent fallback to stdio, so
-        // misconfiguration is loud.
-        let pairing_token = if let Some(endpoint) = &self.spec.bridge_endpoint {
-            Some(
-                super::request_pairing_token(endpoint, &self.key)
-                    .await
-                    .context("failed to pair with shared bridge")?,
-            )
-        } else {
-            None
-        };
+        // Pair with the shared HTTP bridge. If pairing fails we surface the
+        // error — misconfiguration is loud.
+        let pairing_token = super::request_pairing_token(&self.spec.bridge_endpoint, &self.key)
+            .await
+            .context("failed to pair with shared bridge")?;
 
         // Write MCP config file
         let wd = &self.spec.working_directory;
         let mcp_config_path = wd.join(".chorus-kimi-mcp.json");
-        let mcp_config = build_mcp_config_file(&self.key, &self.spec, pairing_token.as_deref());
+        let mcp_config = build_mcp_config_file(&self.spec.bridge_endpoint, &pairing_token);
         std::fs::write(&mcp_config_path, serde_json::to_string(&mcp_config)?)
             .context("failed to write MCP config")?;
 
@@ -333,7 +282,7 @@ impl AgentHandle for KimiHandle {
         let init_req = acp_protocol::build_initialize_request(1);
         writeln!(stdin, "{init_req}").context("failed to write initialize request")?;
 
-        let mcp_servers = build_acp_mcp_servers(&self.key, &self.spec, pairing_token.as_deref());
+        let mcp_servers = build_acp_mcp_servers(&self.spec.bridge_endpoint, &pairing_token);
         let session_new_params = serde_json::json!({
             "cwd": self.spec.working_directory,
             "mcpServers": mcp_servers
@@ -798,9 +747,7 @@ mod tests {
             reasoning_effort: None,
             env_vars: vec![],
             working_directory: PathBuf::from("/fake"),
-            bridge_binary: String::new(),
-            server_url: String::new(),
-            bridge_endpoint: None,
+            bridge_endpoint: "http://127.0.0.1:1".to_string(),
         }
     }
 
@@ -836,30 +783,8 @@ mod tests {
     // ---- build_mcp_config_file tests ----
 
     #[test]
-    fn build_mcp_config_file_stdio_when_no_endpoint() {
-        let mut spec = test_spec();
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-        spec.server_url = "http://127.0.0.1:3001".to_string();
-        assert!(spec.bridge_endpoint.is_none());
-
-        let config = build_mcp_config_file("agent-abc", &spec, None);
-        let chat = &config["mcpServers"]["chat"];
-        assert_eq!(chat["command"], "/opt/chorus/bridge");
-        let args = chat["args"].as_array().expect("args is array");
-        assert_eq!(args[0], "bridge");
-        assert_eq!(args[1], "--agent-id");
-        assert_eq!(args[2], "agent-abc");
-        assert_eq!(args[3], "--server-url");
-        assert_eq!(args[4], "http://127.0.0.1:3001");
-        assert!(chat.get("url").is_none());
-    }
-
-    #[test]
-    fn build_mcp_config_file_http_when_endpoint_and_token() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let config = build_mcp_config_file("agent-abc", &spec, Some("tok-xyz"));
+    fn build_mcp_config_file_http_shape() {
+        let config = build_mcp_config_file("http://127.0.0.1:4321", "tok-xyz");
         let chat = &config["mcpServers"]["chat"];
         assert_eq!(chat["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
         assert_eq!(chat["transport"], "http");
@@ -868,58 +793,18 @@ mod tests {
 
     #[test]
     fn build_mcp_config_file_trims_trailing_slash() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321/".to_string());
-
-        let config = build_mcp_config_file("agent-abc", &spec, Some("tok-xyz"));
+        let config = build_mcp_config_file("http://127.0.0.1:4321/", "tok-xyz");
         assert_eq!(
             config["mcpServers"]["chat"]["url"],
             "http://127.0.0.1:4321/token/tok-xyz/mcp"
         );
     }
 
-    #[test]
-    fn build_mcp_config_file_falls_back_to_stdio_when_endpoint_but_no_token() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-
-        let config = build_mcp_config_file("agent-abc", &spec, None);
-        let chat = &config["mcpServers"]["chat"];
-        assert!(chat.get("url").is_none());
-        assert!(chat.get("command").is_some());
-    }
-
     // ---- build_acp_mcp_servers tests ----
 
     #[test]
-    fn build_acp_mcp_servers_stdio_when_no_endpoint() {
-        let mut spec = test_spec();
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-        spec.server_url = "http://127.0.0.1:3001".to_string();
-        assert!(spec.bridge_endpoint.is_none());
-
-        let servers = build_acp_mcp_servers("agent-abc", &spec, None);
-        let arr = servers.as_array().expect("array");
-        assert_eq!(arr.len(), 1);
-        let entry = &arr[0];
-        assert_eq!(entry["name"], "chat");
-        assert_eq!(entry["command"], "/opt/chorus/bridge");
-        let args = entry["args"].as_array().expect("args is array");
-        assert_eq!(args[0], "bridge");
-        assert_eq!(args[1], "--agent-id");
-        assert_eq!(args[2], "agent-abc");
-        assert_eq!(args[3], "--server-url");
-        assert_eq!(args[4], "http://127.0.0.1:3001");
-        assert!(entry.get("url").is_none());
-    }
-
-    #[test]
-    fn build_acp_mcp_servers_http_when_endpoint_and_token() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let servers = build_acp_mcp_servers("agent-abc", &spec, Some("tok-xyz"));
+    fn build_acp_mcp_servers_http_shape() {
+        let servers = build_acp_mcp_servers("http://127.0.0.1:4321", "tok-xyz");
         let arr = servers.as_array().expect("array");
         assert_eq!(arr.len(), 1);
         let entry = &arr[0];
@@ -933,25 +818,8 @@ mod tests {
 
     #[test]
     fn build_acp_mcp_servers_trims_trailing_slash() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321/".to_string());
-
-        let servers = build_acp_mcp_servers("agent-abc", &spec, Some("tok-xyz"));
+        let servers = build_acp_mcp_servers("http://127.0.0.1:4321/", "tok-xyz");
         let arr = servers.as_array().expect("array");
         assert_eq!(arr[0]["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
-    }
-
-    #[test]
-    fn build_acp_mcp_servers_falls_back_to_stdio_when_endpoint_but_no_token() {
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-
-        let servers = build_acp_mcp_servers("agent-abc", &spec, None);
-        let arr = servers.as_array().expect("array");
-        assert_eq!(arr.len(), 1);
-        let entry = &arr[0];
-        assert!(entry.get("url").is_none());
-        assert!(entry.get("command").is_some());
     }
 }

--- a/src/agent/drivers/v2/kimi.rs
+++ b/src/agent/drivers/v2/kimi.rs
@@ -28,11 +28,7 @@ use super::*;
 /// connect. Verified against the format emitted by `kimi mcp add --transport
 /// http`.
 fn build_mcp_config_file(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!(
-        "{}/token/{}/mcp",
-        bridge_endpoint.trim_end_matches('/'),
-        token
-    );
+    let url = crate::bridge::token_mcp_url(bridge_endpoint, token);
     serde_json::json!({
         "mcpServers": {
             "chat": {
@@ -53,11 +49,7 @@ fn build_mcp_config_file(bridge_endpoint: &str, token: &str) -> serde_json::Valu
 /// See <https://agentclientprotocol.com/protocol/session-setup> — sending the
 /// wrong shape produces ACP "Invalid params" errors.
 fn build_acp_mcp_servers(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let url = format!(
-        "{}/token/{}/mcp",
-        bridge_endpoint.trim_end_matches('/'),
-        token
-    );
+    let url = crate::bridge::token_mcp_url(bridge_endpoint, token);
     serde_json::json!([{
         "type": "http",
         "name": "chat",

--- a/src/agent/drivers/v2/mod.rs
+++ b/src/agent/drivers/v2/mod.rs
@@ -564,12 +564,10 @@ pub struct AgentSpec {
     pub reasoning_effort: Option<String>,
     pub env_vars: Vec<AgentEnvVar>,
     pub working_directory: PathBuf,
-    pub bridge_binary: String,
-    pub server_url: String,
-    /// Optional shared bridge HTTP endpoint. When `Some`, the driver connects
-    /// to this endpoint instead of spawning a per-agent stdio bridge process.
+    /// Shared bridge HTTP endpoint. All drivers connect to this endpoint for
+    /// MCP transport — the per-agent stdio bridge is no longer supported.
     /// Format: `http://127.0.0.1:4321` (port from bridge discovery or config).
-    pub bridge_endpoint: Option<String>,
+    pub bridge_endpoint: String,
 }
 
 /// Return value of [`RuntimeDriver::attach`].

--- a/src/agent/drivers/v2/opencode.rs
+++ b/src/agent/drivers/v2/opencode.rs
@@ -25,10 +25,9 @@ use super::*;
 /// bridge at `{endpoint}/token/{token}/mcp`. Factored out so config-shape
 /// tests don't need a live bridge.
 fn build_mcp_chat_config(bridge_endpoint: &str, token: &str) -> serde_json::Value {
-    let base = bridge_endpoint.trim_end_matches('/');
     serde_json::json!({
         "type": "remote",
-        "url": format!("{base}/token/{token}/mcp"),
+        "url": crate::bridge::token_mcp_url(bridge_endpoint, token),
     })
 }
 

--- a/src/agent/drivers/v2/opencode.rs
+++ b/src/agent/drivers/v2/opencode.rs
@@ -21,37 +21,15 @@ use super::*;
 
 /// Build the `mcp.chat` config block for `opencode.json`.
 ///
-/// Two shapes, branching on whether a shared HTTP bridge is available:
-/// - `spec.bridge_endpoint = Some(_)` + `token = Some(_)`: remote HTTP MCP,
-///   connecting to `{endpoint}/token/{token}/mcp`.
-/// - otherwise: per-agent stdio bridge spawned by OpenCode (`type = "local"`).
-///
-/// Factored out so config-shape tests don't need a live bridge.
-fn build_mcp_chat_config(
-    agent_key: &str,
-    spec: &AgentSpec,
-    token: Option<&str>,
-) -> serde_json::Value {
-    match (&spec.bridge_endpoint, token) {
-        (Some(endpoint), Some(tok)) => {
-            let base = endpoint.trim_end_matches('/');
-            serde_json::json!({
-                "type": "remote",
-                "url": format!("{base}/token/{tok}/mcp"),
-            })
-        }
-        _ => serde_json::json!({
-            "type": "local",
-            "command": [
-                &spec.bridge_binary,
-                "bridge",
-                "--agent-id",
-                agent_key,
-                "--server-url",
-                &spec.server_url,
-            ],
-        }),
-    }
+/// Produces the remote HTTP MCP shape, connecting the runtime to the shared
+/// bridge at `{endpoint}/token/{token}/mcp`. Factored out so config-shape
+/// tests don't need a live bridge.
+fn build_mcp_chat_config(bridge_endpoint: &str, token: &str) -> serde_json::Value {
+    let base = bridge_endpoint.trim_end_matches('/');
+    serde_json::json!({
+        "type": "remote",
+        "url": format!("{base}/token/{token}/mcp"),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -248,28 +226,21 @@ impl AgentHandle for OpencodeHandle {
             _ => self.spec.model.clone(),
         };
 
-        // Resolve MCP transport: shared HTTP bridge (when `bridge_endpoint`
-        // is configured) or per-agent stdio bridge (legacy). If pairing
-        // fails we surface the error — no silent fallback to stdio, so
-        // misconfiguration is loud.
-        let pairing_token = if let Some(endpoint) = &self.spec.bridge_endpoint {
-            Some(
-                super::request_pairing_token(endpoint, &self.key)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "failed to pair with bridge at {endpoint} for agent {}",
-                            self.key
-                        )
-                    })?,
-            )
-        } else {
-            None
-        };
+        // Pair with the shared HTTP bridge. If pairing fails we surface the
+        // error — misconfiguration is loud.
+        let endpoint = &self.spec.bridge_endpoint;
+        let pairing_token = super::request_pairing_token(endpoint, &self.key)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to pair with bridge at {endpoint} for agent {}",
+                    self.key
+                )
+            })?;
 
         // Write opencode.json to the working directory
         let config_path = wd.join("opencode.json");
-        let mcp_chat = build_mcp_chat_config(&self.key, &self.spec, pairing_token.as_deref());
+        let mcp_chat = build_mcp_chat_config(endpoint, &pairing_token);
         let opencode_config = serde_json::json!({
             "model": model_id,
             "mcp": {
@@ -776,9 +747,7 @@ mod tests {
             reasoning_effort: None,
             env_vars: vec![],
             working_directory: PathBuf::from("/fake"),
-            bridge_binary: String::new(),
-            server_url: String::new(),
-            bridge_endpoint: None,
+            bridge_endpoint: "http://127.0.0.1:1".to_string(),
         }
     }
 
@@ -812,32 +781,9 @@ mod tests {
     }
 
     #[test]
-    fn build_mcp_chat_config_stdio_when_no_endpoint() {
-        // No bridge_endpoint configured → fall back to stdio `type: "local"`.
-        let mut spec = test_spec();
-        spec.bridge_binary = "/opt/chorus/bridge".to_string();
-        spec.server_url = "http://127.0.0.1:3001".to_string();
-        assert!(spec.bridge_endpoint.is_none());
-
-        let config = build_mcp_chat_config("agent-abc", &spec, None);
-        assert_eq!(config["type"], "local");
-        let command = config["command"].as_array().expect("command is array");
-        assert_eq!(command[0], "/opt/chorus/bridge");
-        assert_eq!(command[1], "bridge");
-        assert_eq!(command[2], "--agent-id");
-        assert_eq!(command[3], "agent-abc");
-        assert_eq!(command[4], "--server-url");
-        assert_eq!(command[5], "http://127.0.0.1:3001");
-        assert!(config.get("url").is_none());
-    }
-
-    #[test]
-    fn build_mcp_chat_config_http_when_endpoint_and_token() {
-        // With bridge_endpoint + token → remote HTTP MCP.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let config = build_mcp_chat_config("agent-abc", &spec, Some("tok-xyz"));
+    fn build_mcp_chat_config_http_shape() {
+        // Remote HTTP MCP shape — the only shape we produce.
+        let config = build_mcp_chat_config("http://127.0.0.1:4321", "tok-xyz");
         assert_eq!(config["type"], "remote");
         assert_eq!(config["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
         assert!(config.get("command").is_none());
@@ -846,23 +792,7 @@ mod tests {
     #[test]
     fn build_mcp_chat_config_trims_trailing_slash() {
         // Endpoint with trailing slash must not produce `//token/` in the URL.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321/".to_string());
-
-        let config = build_mcp_chat_config("agent-abc", &spec, Some("tok-xyz"));
+        let config = build_mcp_chat_config("http://127.0.0.1:4321/", "tok-xyz");
         assert_eq!(config["url"], "http://127.0.0.1:4321/token/tok-xyz/mcp");
-    }
-
-    #[test]
-    fn build_mcp_chat_config_falls_back_when_endpoint_but_no_token() {
-        // Defensive: if caller forgot to request a token, we use stdio rather
-        // than writing a broken URL. In production flow, `start()` always
-        // fetches a token when `bridge_endpoint` is Some, but this keeps the
-        // helper sound if its preconditions are violated.
-        let mut spec = test_spec();
-        spec.bridge_endpoint = Some("http://127.0.0.1:4321".to_string());
-
-        let config = build_mcp_chat_config("agent-abc", &spec, None);
-        assert_eq!(config["type"], "local");
     }
 }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -39,8 +39,11 @@ pub struct AgentManager {
     trace_store: Arc<AgentTraceStore>,
     store: Arc<Store>,
     data_dir: PathBuf,
-    bridge_binary: String,
-    server_url: String,
+    /// Test-only override for the bridge endpoint. Production code leaves this
+    /// `None` and discovery reads `~/.chorus/bridge.json`; tests set it to a
+    /// synthetic URL so they don't depend on a real bridge being up.
+    #[cfg(test)]
+    bridge_endpoint_override: Option<String>,
 }
 
 pub fn build_driver_registry() -> HashMap<AgentRuntime, Arc<dyn RuntimeDriver>> {
@@ -53,12 +56,7 @@ pub fn build_driver_registry() -> HashMap<AgentRuntime, Arc<dyn RuntimeDriver>> 
 }
 
 impl AgentManager {
-    pub fn new(
-        store: Arc<Store>,
-        data_dir: PathBuf,
-        bridge_binary: String,
-        server_url: String,
-    ) -> Self {
+    pub fn new(store: Arc<Store>, data_dir: PathBuf) -> Self {
         Self {
             driver_registry: build_driver_registry(),
             agents: Arc::new(Mutex::new(HashMap::new())),
@@ -66,8 +64,8 @@ impl AgentManager {
             trace_store: Arc::new(AgentTraceStore::new()),
             store,
             data_dir,
-            bridge_binary,
-            server_url,
+            #[cfg(test)]
+            bridge_endpoint_override: None,
         }
     }
 
@@ -119,18 +117,12 @@ impl AgentManager {
             .ok_or_else(|| anyhow::anyhow!("no driver for runtime {:?}", rt))?
             .clone();
 
-        // Auto-discover the shared bridge — when `chorus serve --shared-bridge`
-        // is running, this populates bridge_endpoint so agents connect via HTTP
-        // MCP instead of spawning per-agent stdio processes. When no bridge is
-        // running, this is None and the legacy stdio path works unchanged.
-        let bridge_endpoint = crate::bridge::discovery::read_bridge_info()
-            .map(|info| format!("http://127.0.0.1:{}", info.port));
+        // Discover the shared bridge. `chorus serve` starts it in-process, so
+        // if it's missing the server didn't boot correctly — fail loudly
+        // rather than silently falling back to a (now-deleted) stdio path.
+        let bridge_endpoint = self.resolve_bridge_endpoint()?;
 
-        if let Some(ref endpoint) = bridge_endpoint {
-            info!(agent = %agent_name, %endpoint, "starting agent via shared bridge");
-        } else {
-            debug!(agent = %agent_name, "starting agent via per-agent stdio bridge");
-        }
+        info!(agent = %agent_name, endpoint = %bridge_endpoint, "starting agent via shared bridge");
 
         let spec = AgentSpec {
             display_name: agent.display_name.clone(),
@@ -140,8 +132,6 @@ impl AgentManager {
             reasoning_effort: agent.reasoning_effort.clone(),
             env_vars: agent.env_vars.clone(),
             working_directory: agent_data_dir.clone(),
-            bridge_binary: self.bridge_binary.clone(),
-            server_url: self.server_url.clone(),
             bridge_endpoint,
         };
 
@@ -359,6 +349,24 @@ impl AgentManager {
         self.agents.lock().await.keys().cloned().collect()
     }
 
+    /// Resolve the shared bridge endpoint. Fails loudly if no bridge is
+    /// running — there is no stdio fallback anymore.
+    fn resolve_bridge_endpoint(&self) -> anyhow::Result<String> {
+        #[cfg(test)]
+        if let Some(override_url) = &self.bridge_endpoint_override {
+            return Ok(override_url.clone());
+        }
+        crate::bridge::discovery::read_bridge_info()
+            .map(|info| format!("http://127.0.0.1:{}", info.port))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Shared MCP bridge is not running. This usually means `chorus serve` \
+                     didn't start it — this shouldn't happen. Check server logs for \
+                     bridge startup errors."
+                )
+            })
+    }
+
     #[cfg(test)]
     pub(crate) fn register_v2_driver(
         &mut self,
@@ -366,6 +374,11 @@ impl AgentManager {
         driver: Arc<dyn RuntimeDriver>,
     ) {
         self.driver_registry.insert(runtime, driver);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_bridge_endpoint_override(&mut self, url: impl Into<String>) {
+        self.bridge_endpoint_override = Some(url.into());
     }
 }
 
@@ -861,14 +874,12 @@ mod tests {
     use tempfile::tempdir;
 
     fn make_test_manager(store: Arc<Store>, dir: &std::path::Path) -> AgentManager {
-        let mut manager = AgentManager::new(
-            store,
-            dir.join("agents"),
-            "chorus".to_string(),
-            "http://127.0.0.1:3001".to_string(),
-        );
+        let mut manager = AgentManager::new(store, dir.join("agents"));
         let fake = Arc::new(FakeV2Driver::new(AgentRuntime::Codex));
         manager.register_v2_driver(AgentRuntime::Codex, fake);
+        // Tests use a synthetic endpoint — the FakeDriver ignores it, but the
+        // manager now insists on one since there's no stdio fallback.
+        manager.set_bridge_endpoint_override("http://127.0.0.1:1");
         manager
     }
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1007,26 +1007,43 @@ mod tests {
         let _ = manager.stop_agent("v2bot").await;
     }
 
-    // ── bridge endpoint helper ──
+    // ── resolve_bridge_endpoint ──
 
-    fn bridge_endpoint_from(info: Option<crate::bridge::discovery::BridgeInfo>) -> Option<String> {
-        info.map(|i| format!("http://127.0.0.1:{}", i.port))
+    #[test]
+    fn resolve_bridge_endpoint_returns_override_when_set() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(Store::open(":memory:").unwrap());
+        let mut manager = AgentManager::new(store, dir.path().join("agents"));
+        manager.set_bridge_endpoint_override("http://127.0.0.1:9999");
+        let got = manager.resolve_bridge_endpoint().unwrap();
+        assert_eq!(got, "http://127.0.0.1:9999");
     }
 
     #[test]
-    fn bridge_endpoint_from_info_formats_url() {
-        let info = crate::bridge::discovery::BridgeInfo {
-            port: 4321,
-            pid: 12345,
-            started_at: "2026-04-16T00:00:00Z".to_string(),
-        };
-        let result = bridge_endpoint_from(Some(info));
-        assert_eq!(result, Some("http://127.0.0.1:4321".to_string()));
-    }
-
-    #[test]
-    fn bridge_endpoint_from_none_is_none() {
-        assert_eq!(bridge_endpoint_from(None), None);
+    fn resolve_bridge_endpoint_fails_loudly_without_bridge() {
+        // No override set and (in this test harness) no bridge running on
+        // the local machine at the default discovery path — even if one
+        // were, `read_bridge_info` returns None for stale/dead PIDs, and
+        // the default path is unlikely to point at a live chorus in CI.
+        // Skip the assertion if a live discovery file happens to exist.
+        if crate::bridge::discovery::read_bridge_info().is_some() {
+            eprintln!(
+                "skipping resolve_bridge_endpoint_fails_loudly_without_bridge: \
+                 live bridge detected on this machine"
+            );
+            return;
+        }
+        let dir = tempdir().unwrap();
+        let store = Arc::new(Store::open(":memory:").unwrap());
+        let manager = AgentManager::new(store, dir.path().join("agents"));
+        let err = manager
+            .resolve_bridge_endpoint()
+            .expect_err("must fail when no override and no bridge");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Shared MCP bridge is not running"),
+            "error should name the condition: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src/bridge/discovery.rs
+++ b/src/bridge/discovery.rs
@@ -28,7 +28,35 @@ pub fn write_bridge_info(info: &BridgeInfo) -> std::io::Result<()> {
 /// the target, so a driver reading mid-write never observes a truncated file.
 /// On Unix the parent directory is tightened to 0700 and the file to 0600 to
 /// prevent other local users from reading the bridge port.
+///
+/// Refuses to overwrite a discovery file that still points to a live PID
+/// belonging to a different process. This guards against two concurrent
+/// `chorus serve` instances silently stomping each other's routing: without
+/// the check, agents started by instance A could be handed instance B's
+/// bridge port. Stale PIDs (from a crashed prior run) and the caller's own
+/// PID are allowed to overwrite.
 pub fn write_bridge_info_to(path: &std::path::Path, info: &BridgeInfo) -> std::io::Result<()> {
+    // Guard against live-PID stomp. Check before creating parent dirs so we
+    // don't even touch the filesystem when another chorus is already there.
+    if let Ok(existing_raw) = std::fs::read_to_string(path) {
+        if let Ok(existing) = serde_json::from_str::<BridgeInfo>(&existing_raw) {
+            let own_pid = std::process::id();
+            if existing.pid != own_pid && is_pid_alive(existing.pid) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "another chorus bridge is already running (pid={}, port={}); \
+                         refusing to overwrite {}",
+                        existing.pid,
+                        existing.port,
+                        path.display()
+                    ),
+                ));
+            }
+            // Otherwise (stale PID or our own PID) fall through and overwrite.
+        }
+    }
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
         #[cfg(unix)]
@@ -225,5 +253,82 @@ mod tests {
 
         remove_bridge_info_from(&path);
         assert!(!path.exists(), "file should be removed after cleanup");
+    }
+
+    #[test]
+    fn refuses_to_stomp_live_pid() {
+        // A second `chorus serve` must not silently take over routing from an
+        // already-running one. We simulate by writing a discovery file with
+        // a live PID (our own) but the *caller* pretends to be a different
+        // process by using a PID that is definitely not us.
+        let path = tmp_path("live_stomp.json");
+        let existing = BridgeInfo {
+            port: 9100,
+            pid: std::process::id(), // live — ourselves
+            started_at: "2026-04-16T00:00:00Z".to_string(),
+        };
+        // Write directly (bypass the guard since this is test setup).
+        std::fs::write(&path, serde_json::to_string(&existing).unwrap()).expect("setup write");
+
+        // Attempting to overwrite from a hypothetical other process.
+        // write_bridge_info_to checks `existing.pid != own_pid` — our own PID
+        // is allowed through, so we can't directly trigger the guard from
+        // this same process. Instead, write a record whose pid is a neighbour
+        // we know is alive (ourselves) but fake the caller identity by having
+        // the caller `info` argument differ. The guard looks at EXISTING pid,
+        // not info.pid, so this is the correct shape.
+        let incoming = BridgeInfo {
+            port: 9200,
+            pid: std::process::id(), // caller identifies as us
+            started_at: "2026-04-16T00:00:01Z".to_string(),
+        };
+        // Since existing.pid == own_pid, the guard allows overwrite (same
+        // process restart case). Confirm.
+        write_bridge_info_to(&path, &incoming).expect("same-pid overwrite ok");
+
+        // Now the tough case: existing points to a live *other* PID. We use
+        // PID 1 (init) which is always alive on Unix but ≠ our PID.
+        #[cfg(unix)]
+        {
+            let other_live = BridgeInfo {
+                port: 9300,
+                pid: 1, // init — always alive, never us
+                started_at: "2026-04-16T00:00:02Z".to_string(),
+            };
+            std::fs::write(&path, serde_json::to_string(&other_live).unwrap())
+                .expect("setup re-write");
+
+            let err = write_bridge_info_to(&path, &incoming)
+                .expect_err("guard must refuse live-PID stomp");
+            assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+            assert!(
+                err.to_string().contains("already running"),
+                "error should name the conflict: {err}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn overwrites_stale_pid() {
+        // A crashed prior `chorus serve` leaves a discovery file pointing to
+        // a dead PID. The next start must be allowed to overwrite it.
+        let path = tmp_path("stale_overwrite.json");
+        let stale = BridgeInfo {
+            port: 9400,
+            pid: 999_999_999, // not alive
+            started_at: "2026-04-16T00:00:00Z".to_string(),
+        };
+        std::fs::write(&path, serde_json::to_string(&stale).unwrap()).expect("setup stale write");
+
+        let fresh = sample_info();
+        write_bridge_info_to(&path, &fresh).expect("stale overwrite must succeed");
+
+        let read_back = read_bridge_info_from(&path).expect("new record readable");
+        assert_eq!(read_back.port, fresh.port);
+        assert_eq!(read_back.pid, fresh.pid);
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/bridge/discovery.rs
+++ b/src/bridge/discovery.rs
@@ -121,6 +121,23 @@ pub fn remove_bridge_info() {
     let _ = std::fs::remove_file(default_discovery_path());
 }
 
+/// RAII guard that removes the default discovery file on drop. Instantiate
+/// immediately after a successful `write_bridge_info` so every exit path —
+/// normal shutdown, early `?` return, or a panic during a long-running
+/// startup (e.g. `chorus serve` auto-restarting many agents) — cleans up.
+///
+/// Without this, a panic between `write_bridge_info` and the point where
+/// the bridge actually answers HTTP would leave a stale file that the
+/// live-PID stomp guard then treats as "another chorus is alive," blocking
+/// the next startup until a human runs `rm ~/.chorus/bridge.json`.
+pub struct DiscoveryGuard;
+
+impl Drop for DiscoveryGuard {
+    fn drop(&mut self) {
+        remove_bridge_info();
+    }
+}
+
 /// Remove a specific discovery file.
 pub fn remove_bridge_info_from(path: &std::path::Path) {
     let _ = std::fs::remove_file(path);
@@ -146,11 +163,16 @@ fn is_pid_alive(pid: u32) -> bool {
     }
 }
 
-/// On non-Unix platforms we cannot check process existence — assume alive to
-/// avoid silently dropping valid bridge info.
+/// On non-Unix platforms we cannot cheaply check process existence without
+/// pulling in a `windows`/`sysinfo` dependency. Return `false` so the
+/// stomp-guard becomes a no-op: stale discovery files are allowed to be
+/// overwritten, matching pre-guard behavior. If two live `chorus serve`
+/// instances race on Windows the last writer wins silently (same risk the
+/// Unix guard defends against). Revisit when Windows support is a first-class
+/// target.
 #[cfg(not(unix))]
 fn is_pid_alive(_pid: u32) -> bool {
-    true
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -286,13 +308,31 @@ mod tests {
         // process restart case). Confirm.
         write_bridge_info_to(&path, &incoming).expect("same-pid overwrite ok");
 
-        // Now the tough case: existing points to a live *other* PID. We use
-        // PID 1 (init) which is always alive on Unix but ≠ our PID.
+        // Now the tough case: existing points to a live *other* PID.
+        // Spawn a short-lived child whose PID is guaranteed != ours, then
+        // use that PID while it's still alive. Wrap in a Drop guard so an
+        // assertion panic below doesn't leave the child alive for 10s.
         #[cfg(unix)]
         {
+            struct ChildGuard(std::process::Child);
+            impl Drop for ChildGuard {
+                fn drop(&mut self) {
+                    let _ = self.0.kill();
+                    let _ = self.0.wait();
+                }
+            }
+
+            let child = std::process::Command::new("sleep")
+                .arg("10")
+                .spawn()
+                .expect("can spawn sleep");
+            let child_pid = child.id();
+            let _child_guard = ChildGuard(child);
+            assert_ne!(child_pid, std::process::id(), "child PID must differ");
+
             let other_live = BridgeInfo {
                 port: 9300,
-                pid: 1, // init — always alive, never us
+                pid: child_pid,
                 started_at: "2026-04-16T00:00:02Z".to_string(),
             };
             std::fs::write(&path, serde_json::to_string(&other_live).unwrap())
@@ -305,6 +345,7 @@ mod tests {
                 err.to_string().contains("already running"),
                 "error should name the conflict: {err}"
             );
+            // _child_guard's Drop impl kills the sleep as we leave scope.
         }
 
         let _ = std::fs::remove_file(&path);

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,7 +1,7 @@
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{ServerCapabilities, ServerInfo};
-use rmcp::{tool, tool_handler, tool_router, ServerHandler, ServiceExt};
+use rmcp::{tool, tool_handler, tool_router, ServerHandler};
 
 pub mod backend;
 pub mod discovery;
@@ -207,17 +207,6 @@ impl ServerHandler for ChatBridge {
             ..Default::default()
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Entry point
-// ---------------------------------------------------------------------------
-
-pub async fn run_bridge(agent_id: String, server_url: String) -> anyhow::Result<()> {
-    let bridge = ChatBridge::new(agent_id, server_url);
-    let service = bridge.serve(rmcp::transport::io::stdio()).await?;
-    service.waiting().await?;
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -15,6 +15,18 @@ mod types;
 use backend::{Backend, ChorusBackend};
 use types::*;
 
+/// Default TCP port for the shared MCP bridge. Canonical across CLI defaults
+/// (`chorus start --bridge-port`, `chorus serve --bridge-port`,
+/// `chorus bridge-serve --listen`) so changing it touches one place.
+pub const DEFAULT_BRIDGE_PORT: u16 = 4321;
+
+/// Build the token-pair URL a runtime uses to reach the shared bridge:
+/// `{endpoint}/token/{token}/mcp`. Trimming the trailing slash on `endpoint`
+/// is a defensive chore the five drivers used to duplicate; put it here once.
+pub fn token_mcp_url(endpoint: &str, token: &str) -> String {
+    format!("{}/token/{}/mcp", endpoint.trim_end_matches('/'), token)
+}
+
 // ---------------------------------------------------------------------------
 // ChatBridge
 // ---------------------------------------------------------------------------

--- a/src/bridge/serve.rs
+++ b/src/bridge/serve.rs
@@ -261,22 +261,6 @@ async fn handle_pair(
 }
 
 // ---------------------------------------------------------------------------
-// Discovery cleanup guard
-// ---------------------------------------------------------------------------
-
-/// Removes the bridge discovery file when dropped.
-///
-/// Placed in `run_bridge_server` after `write_bridge_info` so that the file is
-/// cleaned up on every exit path — normal shutdown, error return, or panic.
-struct DiscoveryGuard;
-
-impl Drop for DiscoveryGuard {
-    fn drop(&mut self) {
-        crate::bridge::discovery::remove_bridge_info();
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 
@@ -351,7 +335,7 @@ pub async fn run_bridge_server(listen_addr: &str, server_url: &str) -> anyhow::R
     })?;
     // Guard ensures the discovery file is removed on every exit path —
     // normal shutdown, early error return, or panic.
-    let _discovery_guard = DiscoveryGuard;
+    let _discovery_guard = crate::bridge::discovery::DiscoveryGuard;
 
     tracing::info!(port, "bridge server listening");
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,6 +56,9 @@ enum Commands {
         /// `<data_dir>/config.toml` > `~/agency-agents`.
         #[arg(long, env = "CHORUS_TEMPLATE_DIR")]
         template_dir: Option<String>,
+        /// Port for the shared MCP bridge, started in-process.
+        #[arg(long, default_value_t = chorus::bridge::DEFAULT_BRIDGE_PORT)]
+        bridge_port: u16,
     },
     /// Create and manage agents
     Agent {
@@ -97,7 +100,7 @@ enum Commands {
     #[command(name = "bridge-serve")]
     BridgeServe {
         /// Address to listen on (e.g. 127.0.0.1:4321)
-        #[arg(long, default_value = "127.0.0.1:4321")]
+        #[arg(long, default_value_t = format!("127.0.0.1:{}", chorus::bridge::DEFAULT_BRIDGE_PORT))]
         listen: String,
         /// Chorus backend server URL
         #[arg(long, default_value = "http://localhost:3001")]
@@ -126,7 +129,7 @@ enum Commands {
         #[arg(long, env = "CHORUS_TEMPLATE_DIR")]
         template_dir: Option<String>,
         /// Port for the shared MCP bridge, started in-process by `chorus serve`.
-        #[arg(long, default_value = "4321")]
+        #[arg(long, default_value_t = chorus::bridge::DEFAULT_BRIDGE_PORT)]
         bridge_port: u16,
         /// Deprecated: the shared bridge is now always started by
         /// `chorus serve` (there is no longer an opt-in). Accepted so existing
@@ -239,7 +242,8 @@ pub async fn run() -> anyhow::Result<()> {
             data_dir,
             no_open,
             template_dir,
-        }) => start::run(port, data_dir, no_open, template_dir).await,
+            bridge_port,
+        }) => start::run(port, data_dir, no_open, template_dir, bridge_port).await,
 
         None => {
             let data_dir_str = default_data_dir();
@@ -287,9 +291,10 @@ pub async fn run() -> anyhow::Result<()> {
             shared_bridge,
         }) => {
             if shared_bridge {
-                eprintln!(
-                    "warning: --shared-bridge is deprecated and has no effect. The \
-                     shared MCP bridge is always started by `chorus serve`."
+                tracing::warn!(
+                    "--shared-bridge is deprecated and has no effect. The shared MCP \
+                     bridge is always started by `chorus serve`. Remove the flag from \
+                     your scripts."
                 );
             }
             let data_dir_str = data_dir.unwrap_or_else(default_data_dir);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -128,6 +128,11 @@ enum Commands {
         /// Port for the shared MCP bridge, started in-process by `chorus serve`.
         #[arg(long, default_value = "4321")]
         bridge_port: u16,
+        /// Deprecated: the shared bridge is now always started by
+        /// `chorus serve` (there is no longer an opt-in). Accepted so existing
+        /// scripts continue to work; emits a warning and is otherwise ignored.
+        #[arg(long, hide = true)]
+        shared_bridge: bool,
     },
 }
 
@@ -279,7 +284,14 @@ pub async fn run() -> anyhow::Result<()> {
             data_dir,
             template_dir,
             bridge_port,
+            shared_bridge,
         }) => {
+            if shared_bridge {
+                eprintln!(
+                    "warning: --shared-bridge is deprecated and has no effect. The \
+                     shared MCP bridge is always started by `chorus serve`."
+                );
+            }
             let data_dir_str = data_dir.unwrap_or_else(default_data_dir);
             let template_dir_str = resolve_template_dir(&data_dir_str, template_dir);
             serve::run(port, data_dir_str, template_dir_str, bridge_port).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,14 +93,6 @@ enum Commands {
         #[arg(long)]
         data_dir: Option<String>,
     },
-    /// Run as an MCP stdio bridge for a specific agent (internal use by agent manager)
-    #[command(hide = true)]
-    Bridge {
-        #[arg(long)]
-        agent_id: String,
-        #[arg(long, default_value = "http://localhost:3001")]
-        server_url: String,
-    },
     /// Start the shared HTTP MCP bridge server (multi-agent)
     #[command(name = "bridge-serve")]
     BridgeServe {
@@ -133,12 +125,7 @@ enum Commands {
         data_dir: Option<String>,
         #[arg(long, env = "CHORUS_TEMPLATE_DIR")]
         template_dir: Option<String>,
-        /// Also start the shared MCP bridge on 127.0.0.1:<bridge_port> in the
-        /// same process. Agents started while this is running will auto-connect
-        /// via HTTP MCP instead of spawning per-agent stdio bridges.
-        #[arg(long)]
-        shared_bridge: bool,
-        /// Port for the shared bridge (only used when --shared-bridge is set).
+        /// Port for the shared MCP bridge, started in-process by `chorus serve`.
         #[arg(long, default_value = "4321")]
         bridge_port: u16,
     },
@@ -252,13 +239,8 @@ pub async fn run() -> anyhow::Result<()> {
         None => {
             let data_dir_str = default_data_dir();
             let template_dir_str = resolve_template_dir(&data_dir_str, None);
-            serve::run(3001, data_dir_str, template_dir_str, false, 4321).await
+            serve::run(3001, data_dir_str, template_dir_str, 4321).await
         }
-
-        Some(Commands::Bridge {
-            agent_id,
-            server_url,
-        }) => chorus::bridge::run_bridge(agent_id, server_url).await,
 
         Some(Commands::BridgeServe { listen, server_url }) => {
             chorus::bridge::serve::run_bridge_server(&listen, &server_url).await
@@ -296,19 +278,11 @@ pub async fn run() -> anyhow::Result<()> {
             port,
             data_dir,
             template_dir,
-            shared_bridge,
             bridge_port,
         }) => {
             let data_dir_str = data_dir.unwrap_or_else(default_data_dir);
             let template_dir_str = resolve_template_dir(&data_dir_str, template_dir);
-            serve::run(
-                port,
-                data_dir_str,
-                template_dir_str,
-                shared_bridge,
-                bridge_port,
-            )
-            .await
+            serve::run(port, data_dir_str, template_dir_str, bridge_port).await
         }
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -5,11 +5,10 @@
 //! agent templates, and starts the Axum HTTP server on `0.0.0.0:<port>`.
 //! Shuts down cleanly on Ctrl-C.
 //!
-//! When `shared_bridge` is `true`, also starts the shared MCP HTTP bridge on
-//! `127.0.0.1:<bridge_port>` in the same process.  Both the main server and
-//! the bridge share a single Ctrl-C handler via a `CancellationToken` — when
-//! the user hits Ctrl-C the token is cancelled and both listeners drain
-//! gracefully.
+//! Always starts the shared MCP HTTP bridge on `127.0.0.1:<bridge_port>` in
+//! the same process. Both the main server and the bridge share a single
+//! Ctrl-C handler via a `CancellationToken` — when the user hits Ctrl-C the
+//! token is cancelled and both listeners drain gracefully.
 
 use std::sync::Arc;
 
@@ -24,7 +23,6 @@ pub async fn run(
     port: u16,
     data_dir_str: String,
     template_dir_raw: String,
-    shared_bridge: bool,
     bridge_port: u16,
 ) -> anyhow::Result<()> {
     let data_dir = std::path::PathBuf::from(&data_dir_str);
@@ -46,13 +44,63 @@ pub async fn run(
     store.ensure_builtin_channels(&username)?;
 
     let server_url = format!("http://localhost:{port}");
-    let bridge_binary = std::env::current_exe()?.to_string_lossy().into_owned();
-    let manager = Arc::new(AgentManager::new(
-        store.clone(),
-        agents_dir,
-        bridge_binary,
-        server_url.clone(),
-    ));
+    let manager = Arc::new(AgentManager::new(store.clone(), agents_dir));
+
+    // Shared cancellation token — cancelled on Ctrl-C and used to shut down
+    // both the main server and the bridge together.
+    let shutdown_token = CancellationToken::new();
+
+    // Bind the shared bridge BEFORE auto-restarting agents — agents now
+    // require a live bridge (no more stdio fallback). If the bridge port is
+    // taken we fail to start.
+    let bridge_listen = format!("127.0.0.1:{bridge_port}");
+    let bridge_listener = tokio::net::TcpListener::bind(&bridge_listen)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "shared bridge: failed to bind {bridge_listen}: {e}. Is another chorus \
+                 already running? Pass `--bridge-port` to use a different port."
+            )
+        })?;
+    let bridge_local_addr = bridge_listener
+        .local_addr()
+        .expect("bridge listener has a local addr");
+    // Phase 1 bridge only supports loopback — guard in case the resolved
+    // address is somehow non-loopback (shouldn't happen with 127.0.0.1, but
+    // be defensive).
+    if !bridge_local_addr.ip().is_loopback() {
+        anyhow::bail!(
+            "shared bridge: refusing non-loopback bind {bridge_local_addr}; bridge will not start"
+        );
+    }
+    let actual_bridge_port = bridge_local_addr.port();
+
+    // Write discovery info so drivers can find the bridge.
+    if let Err(e) = chorus::bridge::discovery::write_bridge_info(
+        &chorus::bridge::discovery::BridgeInfo {
+            port: actual_bridge_port,
+            pid: std::process::id(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        },
+    ) {
+        tracing::warn!(err = %e, "shared bridge: failed to write discovery file; bridge will still run");
+    }
+
+    tracing::info!(port = actual_bridge_port, "shared bridge listening");
+
+    let (bridge_app, _bridge_ct) = chorus::bridge::serve::build_bridge_router(&server_url);
+    let bridge_shutdown = shutdown_token.clone();
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(bridge_listener, bridge_app)
+            .with_graceful_shutdown(async move { bridge_shutdown.cancelled().await })
+            .await
+        {
+            tracing::error!(err = %e, "shared bridge exited with error");
+        }
+        // Clean up discovery file when bridge shuts down.
+        chorus::bridge::discovery::remove_bridge_info();
+        tracing::info!("shared bridge stopped");
+    });
 
     // Auto-restart agents that were active before server restart.
     // Track failures per agent so repeated failures can be surfaced.
@@ -121,73 +169,8 @@ pub async fn run(
     tracing::info!("Use `chorus send '#all' 'hello'` to send messages");
     tracing::info!("Use `chorus agent create <name>` to create an agent");
 
-    // Shared cancellation token — cancelled on Ctrl-C and used to shut down
-    // both the main server and the optional bridge together.
-    let shutdown_token = CancellationToken::new();
-
-    // Start the shared bridge in the same process when requested.
-    if shared_bridge {
-        let bridge_listen = format!("127.0.0.1:{bridge_port}");
-        match tokio::net::TcpListener::bind(&bridge_listen).await {
-            Ok(bridge_listener) => {
-                let local_addr = bridge_listener
-                    .local_addr()
-                    .expect("bridge listener has a local addr");
-                // Phase 1 bridge only supports loopback — guard in case the
-                // resolved address is somehow non-loopback (shouldn't happen
-                // with 127.0.0.1, but be defensive).
-                if !local_addr.ip().is_loopback() {
-                    tracing::warn!(
-                        addr = %local_addr,
-                        "shared bridge: refusing non-loopback bind; bridge will not start"
-                    );
-                } else {
-                    let actual_port = local_addr.port();
-
-                    // Write discovery info so drivers can find the bridge.
-                    if let Err(e) = chorus::bridge::discovery::write_bridge_info(
-                        &chorus::bridge::discovery::BridgeInfo {
-                            port: actual_port,
-                            pid: std::process::id(),
-                            started_at: chrono::Utc::now().to_rfc3339(),
-                        },
-                    ) {
-                        tracing::warn!(err = %e, "shared bridge: failed to write discovery file; bridge will still run");
-                    }
-
-                    tracing::info!(port = actual_port, "shared bridge listening");
-
-                    let (bridge_app, _bridge_ct) =
-                        chorus::bridge::serve::build_bridge_router(&server_url);
-                    let bridge_shutdown = shutdown_token.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = axum::serve(bridge_listener, bridge_app)
-                            .with_graceful_shutdown(
-                                async move { bridge_shutdown.cancelled().await },
-                            )
-                            .await
-                        {
-                            tracing::error!(err = %e, "shared bridge exited with error");
-                        }
-                        // Clean up discovery file when bridge shuts down.
-                        chorus::bridge::discovery::remove_bridge_info();
-                        tracing::info!("shared bridge stopped");
-                    });
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    addr = %bridge_listen,
-                    err = %e,
-                    "shared bridge: failed to bind port; bridge will not start — \
-                     agents will fall back to per-agent stdio bridge"
-                );
-            }
-        }
-    }
-
     // Graceful shutdown on Ctrl+C — cancel the shared token so both the main
-    // server and any co-hosted bridge drain together.
+    // server and the co-hosted bridge drain together.
     let shutdown_token_ctrlc = shutdown_token.clone();
     let shutdown = async move {
         tokio::signal::ctrl_c().await.ok();

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -76,20 +76,41 @@ pub async fn run(
     let actual_bridge_port = bridge_local_addr.port();
 
     // Write discovery info so drivers can find the bridge.
-    if let Err(e) = chorus::bridge::discovery::write_bridge_info(
-        &chorus::bridge::discovery::BridgeInfo {
-            port: actual_bridge_port,
-            pid: std::process::id(),
-            started_at: chrono::Utc::now().to_rfc3339(),
-        },
-    ) {
-        tracing::warn!(err = %e, "shared bridge: failed to write discovery file; bridge will still run");
+    // `AlreadyExists` means another live `chorus serve` owns the discovery
+    // file — abort hard so we don't silently steal its agents' routing.
+    // Other errors (permissions, disk) warn-and-continue so the bridge still
+    // runs for same-process agents.
+    match chorus::bridge::discovery::write_bridge_info(&chorus::bridge::discovery::BridgeInfo {
+        port: actual_bridge_port,
+        pid: std::process::id(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    }) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            anyhow::bail!(
+                "shared bridge: {e}. Stop the other chorus server (or wait for it to exit) \
+                 before starting a new one."
+            );
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, "shared bridge: failed to write discovery file; bridge will still run");
+        }
     }
 
     tracing::info!(port = actual_bridge_port, "shared bridge listening");
 
-    let (bridge_app, _bridge_ct) = chorus::bridge::serve::build_bridge_router(&server_url);
+    let (bridge_app, bridge_ct) = chorus::bridge::serve::build_bridge_router(&server_url);
+    // Cascade the shared shutdown token into the bridge's internal CT so any
+    // in-flight MCP sessions (child tokens spawned per request) drain when
+    // Ctrl-C fires. Without this, axum stops accepting connections but active
+    // sessions hang until their own timeouts.
     let bridge_shutdown = shutdown_token.clone();
+    let bridge_cascade_trigger = shutdown_token.clone();
+    let bridge_ct_for_cascade = bridge_ct.clone();
+    tokio::spawn(async move {
+        bridge_cascade_trigger.cancelled().await;
+        bridge_ct_for_cascade.cancel();
+    });
     tokio::spawn(async move {
         if let Err(e) = axum::serve(bridge_listener, bridge_app)
             .with_graceful_shutdown(async move { bridge_shutdown.cancelled().await })

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -62,9 +62,9 @@ pub async fn run(
                  already running? Pass `--bridge-port` to use a different port."
             )
         })?;
-    let bridge_local_addr = bridge_listener
-        .local_addr()
-        .expect("bridge listener has a local addr");
+    let bridge_local_addr = bridge_listener.local_addr().map_err(|e| {
+        anyhow::anyhow!("shared bridge: failed to read local address for {bridge_listen}: {e}")
+    })?;
     // Phase 1 bridge only supports loopback — guard in case the resolved
     // address is somehow non-loopback (shouldn't happen with 127.0.0.1, but
     // be defensive).
@@ -80,12 +80,22 @@ pub async fn run(
     // file — abort hard so we don't silently steal its agents' routing.
     // Other errors (permissions, disk) warn-and-continue so the bridge still
     // runs for same-process agents.
-    match chorus::bridge::discovery::write_bridge_info(&chorus::bridge::discovery::BridgeInfo {
-        port: actual_bridge_port,
-        pid: std::process::id(),
-        started_at: chrono::Utc::now().to_rfc3339(),
-    }) {
-        Ok(()) => {}
+    let _discovery_guard = match chorus::bridge::discovery::write_bridge_info(
+        &chorus::bridge::discovery::BridgeInfo {
+            port: actual_bridge_port,
+            pid: std::process::id(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        },
+    ) {
+        Ok(()) => {
+            // RAII guard removes the discovery file on every exit path —
+            // normal shutdown, `?` propagation, or a panic during the
+            // auto-restart loop below. Without this, a panic between here
+            // and the bridge task actually serving HTTP would leave a stale
+            // file that the next `chorus serve` reads as "another chorus
+            // is alive," permanently blocking startup.
+            Some(chorus::bridge::discovery::DiscoveryGuard)
+        }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
             anyhow::bail!(
                 "shared bridge: {e}. Stop the other chorus server (or wait for it to exit) \
@@ -94,8 +104,9 @@ pub async fn run(
         }
         Err(e) => {
             tracing::warn!(err = %e, "shared bridge: failed to write discovery file; bridge will still run");
+            None
         }
-    }
+    };
 
     tracing::info!(port = actual_bridge_port, "shared bridge listening");
 
@@ -118,8 +129,9 @@ pub async fn run(
         {
             tracing::error!(err = %e, "shared bridge exited with error");
         }
-        // Clean up discovery file when bridge shuts down.
-        chorus::bridge::discovery::remove_bridge_info();
+        // Note: the discovery file is removed by DiscoveryGuard held in the
+        // outer scope on drop; don't remove it here or we double-up and
+        // could race with a second serve that already stomp-checked.
         tracing::info!("shared bridge stopped");
     });
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -46,6 +46,5 @@ pub async fn run(
         });
     }
 
-    // `start` never activates the shared bridge — that is opt-in via `serve --shared-bridge`.
-    serve::run(port, data_dir_str, template_dir, false, 4321).await
+    serve::run(port, data_dir_str, template_dir, 4321).await
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -11,6 +11,7 @@ pub async fn run(
     data_dir: Option<String>,
     no_open: bool,
     template_dir: Option<String>,
+    bridge_port: u16,
 ) -> anyhow::Result<()> {
     let data_dir_str = data_dir.unwrap_or_else(default_data_dir);
     let template_dir = resolve_template_dir(&data_dir_str, template_dir);
@@ -46,5 +47,5 @@ pub async fn run(
         });
     }
 
-    serve::run(port, data_dir_str, template_dir, 4321).await
+    serve::run(port, data_dir_str, template_dir, bridge_port).await
 }

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -260,9 +260,8 @@ async fn opencode_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         run_id: None,
     })?;
 
-    // 5. Build AgentSpec with bridge_endpoint set — this is the code path
-    //    we're validating. bridge_binary/server_url are unused when
-    //    bridge_endpoint is Some.
+    // 5. Build AgentSpec pointing at the shared bridge — the code path we're
+    //    validating.
     let tmpdir = tempfile::tempdir()?;
     let spec = AgentSpec {
         display_name: "OpenCode Live Bot".to_string(),
@@ -272,9 +271,7 @@ async fn opencode_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         reasoning_effort: None,
         env_vars: vec![],
         working_directory: tmpdir.path().to_path_buf(),
-        bridge_binary: "chorus".to_string(),
-        server_url: server_url.clone(),
-        bridge_endpoint: Some(bridge_url.clone()),
+        bridge_endpoint: bridge_url.clone(),
     };
 
     // 6. Attach + start the runtime, deferring the first prompt so it's
@@ -398,9 +395,7 @@ async fn claude_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         reasoning_effort: None,
         env_vars: vec![],
         working_directory: tmpdir.path().to_path_buf(),
-        bridge_binary: "chorus".to_string(),
-        server_url: server_url.clone(),
-        bridge_endpoint: Some(bridge_url.clone()),
+        bridge_endpoint: bridge_url.clone(),
     };
 
     // 6. Attach + start the runtime with initial prompt.
@@ -526,9 +521,7 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         reasoning_effort: None,
         env_vars: vec![],
         working_directory: tmpdir.path().to_path_buf(),
-        bridge_binary: "chorus".to_string(),
-        server_url: server_url.clone(),
-        bridge_endpoint: Some(bridge_url.clone()),
+        bridge_endpoint: bridge_url.clone(),
     };
 
     // 6. Attach + start the runtime with initial prompt.
@@ -653,9 +646,7 @@ async fn kimi_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         reasoning_effort: None,
         env_vars: vec![],
         working_directory: tmpdir.path().to_path_buf(),
-        bridge_binary: "chorus".to_string(),
-        server_url: server_url.clone(),
-        bridge_endpoint: Some(bridge_url.clone()),
+        bridge_endpoint: bridge_url.clone(),
     };
 
     // 6. Attach + start the runtime with initial prompt.

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -46,26 +46,23 @@
 //! Use `--nocapture` to see runtime stderr piped through our tracing setup.
 //! If a test hangs, check whether the runtime has valid auth in its config dir.
 //!
-//! # Coverage matrix: `chorus serve --shared-bridge` (A1 + A2)
+//! # Coverage matrix
 //!
-//! The full `chorus serve --shared-bridge` flow is covered by the combination
-//! of three test layers — a dedicated A3 end-to-end test would be redundant:
+//! The shared-bridge runtime path is covered by four test layers:
 //!
 //! | Layer | Test location | What it proves |
 //! |-------|--------------|----------------|
-//! | Bridge HTTP layer (A1) | `tests/bridge_serve_tests.rs` | In-process bridge starts, health, sessions, token pairing, `send_message` → store |
-//! | Discovery file I/O | `src/bridge/discovery.rs` (unit tests) | `write_bridge_info_to` / `read_bridge_info_from` roundtrip, stale PID, corrupt file |
-//! | A2 URL formatting | `src/agent/manager.rs` (`bridge_endpoint_from_info_formats_url`, `bridge_endpoint_from_none_is_none`) | `BridgeInfo { port }` → `"http://127.0.0.1:{port}"` |
-//! | Driver + bridge round-trip | This file (4 `#[ignore]` live tests) | Real runtime binary with `bridge_endpoint: Some(url)` → message lands in store |
+//! | Bridge HTTP layer | `tests/bridge_serve_tests.rs` | In-process bridge starts, health, sessions, token pairing, `send_message` → store |
+//! | Discovery file I/O | `src/bridge/discovery.rs` (unit tests) | `write_bridge_info_to` / `read_bridge_info_from` roundtrip, stale PID, corrupt file, live-PID stomp guard |
+//! | `resolve_bridge_endpoint` | `src/agent/manager.rs` (`resolve_bridge_endpoint_returns_override_when_set`, `resolve_bridge_endpoint_fails_loudly_without_bridge`) | Override path Ok, no-bridge path Err with user-visible message |
+//! | Driver + bridge round-trip | This file (4 `#[ignore]` live tests) | Real runtime binary wired to `bridge_endpoint: String` → message lands in store |
 //!
-//! The one composition NOT tested by automation: `AgentManager::start_agent`
-//! calling `read_bridge_info()` when a discovery file is present (the `Some`
-//! branch of the auto-discover block in manager.rs). This is three mechanical
-//! lines that wire the above individually-tested functions together. The risk
-//! of a silent bug here is low, and exercising it requires either writing to
-//! `~/.chorus/bridge.json` (global, unsafe in CI) or adding a path-override
-//! seam to `AgentManager`. The trade-off favors trusting the unit tests over
-//! introducing test-only indirection into production code.
+//! The one composition that is not tested by automation is the
+//! `AgentManager::start_agent` → `read_bridge_info()` path when a real
+//! discovery file is present on the developer's machine. That path would
+//! require writing to `~/.chorus/bridge.json` (global, unsafe in CI); the
+//! combination of discovery unit tests + `resolve_bridge_endpoint` override
+//! tests covers everything that doesn't require a real bridge process.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -257,27 +254,52 @@ const DIAGNOSTIC_LOG_TAIL_BYTES: u64 = 256 * 1024;
 /// How many trailing lines of that tail we actually print.
 const DIAGNOSTIC_LOG_TAIL_LINES: usize = 200;
 
+/// Redact `/token/{token}/mcp` URL segments so pairing bearer tokens don't
+/// leak into CI-archived test logs. Replaces the `{token}` with `[REDACTED]`
+/// while leaving the surrounding URL visible so operators can still see the
+/// port / path shape when debugging. Non-URL occurrences of `token` are left
+/// alone.
+fn redact_pairing_tokens(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(idx) = rest.find("/token/") {
+        out.push_str(&rest[..idx]);
+        out.push_str("/token/[REDACTED]");
+        rest = &rest[idx + "/token/".len()..];
+        // Skip past the token itself up to the next `/` or line terminator.
+        let end = rest.find(['/', '\n', '"']).unwrap_or(rest.len());
+        rest = &rest[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Read the trailing `max_bytes` of a file without loading the whole thing.
-/// Returns an empty string (never errors) if the file can't be opened.
-/// If the requested slice lands mid-multibyte-sequence the first partial
-/// character is trimmed at the nearest UTF-8 boundary.
+/// Returns `io::Error` if the file can't be opened or read.
+/// If a seek was performed (file larger than cap), trims up to the first
+/// newline so the output starts on a clean line. Files smaller than the cap
+/// are returned in full — trimming them would silently drop the first line.
+/// Any invalid UTF-8 bytes are replaced via lossy conversion.
 fn read_log_tail(path: &std::path::Path, max_bytes: u64) -> std::io::Result<String> {
     use std::io::{Read, Seek, SeekFrom};
     let mut f = std::fs::File::open(path)?;
     let len = f.metadata()?.len();
     let to_read = std::cmp::min(len, max_bytes);
-    if to_read < len {
+    let seeked = to_read < len;
+    if seeked {
         f.seek(SeekFrom::End(-(to_read as i64)))?;
     }
     let mut buf = Vec::with_capacity(to_read as usize);
     f.take(to_read).read_to_end(&mut buf)?;
-    // The seek likely landed mid-line; trim up to the first newline so the
-    // output always starts on a clean line.
-    let start = buf
-        .iter()
-        .position(|&b| b == b'\n')
-        .map(|i| i + 1)
-        .unwrap_or(0);
+    let start = if seeked {
+        // Seek likely landed mid-line; trim up to the first newline.
+        buf.iter()
+            .position(|&b| b == b'\n')
+            .map(|i| i + 1)
+            .unwrap_or(0)
+    } else {
+        0
+    };
     Ok(String::from_utf8_lossy(&buf[start..]).into_owned())
 }
 
@@ -350,7 +372,11 @@ fn collect_failure_diagnostics(
                 out.push_str(&format!("\n  {}:\n", entry.path().display()));
                 match std::fs::read_to_string(entry.path()) {
                     Ok(contents) => {
-                        for line in contents.lines() {
+                        // Redact the pairing token in MCP URLs. These are
+                        // bearer credentials — even with a 5-min TTL, dumping
+                        // them into CI-archived logs is sloppy.
+                        let redacted = redact_pairing_tokens(&contents);
+                        for line in redacted.lines() {
                             out.push_str("    ");
                             out.push_str(line);
                             out.push('\n');
@@ -937,4 +963,64 @@ async fn kimi_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic-helper unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod diagnostic_helper_tests {
+    use super::*;
+
+    #[test]
+    fn redact_pairing_tokens_masks_token_segment() {
+        let input = r#"{"url": "http://127.0.0.1:4321/token/abc123xyz/mcp"}"#;
+        let out = redact_pairing_tokens(input);
+        assert!(out.contains("/token/[REDACTED]/mcp"));
+        assert!(!out.contains("abc123xyz"));
+    }
+
+    #[test]
+    fn redact_pairing_tokens_leaves_non_url_text_alone() {
+        let input = "normal text with no URL";
+        assert_eq!(redact_pairing_tokens(input), input);
+    }
+
+    #[test]
+    fn redact_pairing_tokens_handles_multiple_tokens() {
+        let input = "A=/token/tok1/mcp B=/token/tok2/mcp";
+        let out = redact_pairing_tokens(input);
+        assert_eq!(out, "A=/token/[REDACTED]/mcp B=/token/[REDACTED]/mcp");
+    }
+
+    #[test]
+    fn read_log_tail_returns_full_file_when_smaller_than_cap() {
+        let tmp =
+            std::env::temp_dir().join(format!("chorus_log_tail_small_{}.log", std::process::id()));
+        std::fs::write(&tmp, b"line one\nline two\n").unwrap();
+        let got = read_log_tail(&tmp, 1024).unwrap();
+        assert_eq!(got, "line one\nline two\n");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn read_log_tail_trims_to_newline_when_seeking() {
+        let tmp =
+            std::env::temp_dir().join(format!("chorus_log_tail_big_{}.log", std::process::id()));
+        let mut contents = String::new();
+        for i in 0..500 {
+            contents.push_str(&format!("line number {i:04}\n"));
+        }
+        std::fs::write(&tmp, contents.as_bytes()).unwrap();
+        let got = read_log_tail(&tmp, 128).unwrap();
+        assert!(got.len() <= 128);
+        // First char must be the start of a line (either the original line
+        // we landed on, or the start of the next).
+        assert!(
+            !got.starts_with("umber"),
+            "must not start mid-line: {got:?}"
+        );
+        let _ = std::fs::remove_file(&tmp);
+    }
 }

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -195,6 +195,152 @@ fn binary_on_path(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Return the path of the newest `.log` file in `dir`, or `None` if the
+/// directory does not exist or contains no log files.
+fn newest_log_in(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().map(|t| t.is_file()).unwrap_or(false)
+                && e.path().extension().map_or(false, |x| x == "log")
+        })
+        .max_by_key(|e| {
+            e.metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        })
+        .map(|e| e.path())
+}
+
+/// Return the well-known log path for a given runtime, or `None` if the path
+/// does not exist on this machine.
+fn runtime_log_path(runtime_name: &str) -> Option<std::path::PathBuf> {
+    let home = dirs::home_dir()?;
+    match runtime_name {
+        "claude" => {
+            // Claude Code log directory — newest file.
+            let log_dir = home.join(".claude").join("logs");
+            newest_log_in(&log_dir)
+        }
+        "codex" => {
+            // Codex TUI log (may or may not apply to app-server mode).
+            let path = home.join(".codex").join("log").join("codex-tui.log");
+            if path.exists() { Some(path) } else { None }
+        }
+        "kimi" => {
+            // Kimi writes to ~/.kimi/logs/kimi.log — the most common signal source.
+            let path = home.join(".kimi").join("logs").join("kimi.log");
+            if path.exists() { Some(path) } else { None }
+        }
+        "opencode" => {
+            let log_dir = home.join(".opencode").join("logs");
+            newest_log_in(&log_dir)
+        }
+        _ => None,
+    }
+}
+
+/// Dump all available diagnostic signals before an `Err` is returned from a
+/// live runtime test.  Returns a `String` suitable for appending to the
+/// anyhow error message.
+///
+/// Collects (best-effort, never panics):
+/// 1. Last 200 lines of the runtime's log file (if path provided and readable)
+/// 2. Contents of any MCP config files the driver wrote in `working_dir`
+/// 3. Observable state (channel history, captured by caller)
+/// 4. Hint for surfacing runtime stderr via RUST_LOG on re-run
+///
+/// Note on runtime stderr: the drivers spawn async tasks that consume stderr
+/// and re-emit it via `tracing::warn!`.  Re-capturing it here would require
+/// invasive driver changes.  The RUST_LOG hint below is the lowest-friction
+/// workaround — it surfaces the stderr on the next explicit re-run.
+fn collect_failure_diagnostics(
+    runtime_name: &str,
+    runtime_log_path: Option<&std::path::Path>,
+    working_dir: &std::path::Path,
+    channel_history: &str,
+) -> String {
+    let mut out = String::new();
+    out.push_str("\n\n=== FAILURE DIAGNOSTICS ===\n");
+
+    // 1. Runtime log file (last 200 lines).
+    out.push_str(&format!("\n--- {} log file ---\n", runtime_name));
+    if let Some(log_path) = runtime_log_path {
+        out.push_str(&format!("Path: {}\n", log_path.display()));
+        match std::fs::read_to_string(log_path) {
+            Ok(contents) => {
+                let lines: Vec<&str> = contents.lines().collect();
+                let start = lines.len().saturating_sub(200);
+                for line in &lines[start..] {
+                    out.push_str(line);
+                    out.push('\n');
+                }
+            }
+            Err(e) => {
+                out.push_str(&format!("(not readable: {})\n", e));
+            }
+        }
+    } else {
+        out.push_str("(no log path documented for this runtime)\n");
+    }
+
+    // 2. MCP config files in working_dir.
+    out.push_str(&format!(
+        "\n--- MCP config files in {} ---\n",
+        working_dir.display()
+    ));
+    if let Ok(entries) = std::fs::read_dir(working_dir) {
+        let mut found = false;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            // MCP config files follow known naming patterns used by the drivers.
+            if name_str.contains("mcp") || name_str.ends_with(".json") {
+                found = true;
+                out.push_str(&format!("\n  {}:\n", entry.path().display()));
+                match std::fs::read_to_string(entry.path()) {
+                    Ok(contents) => {
+                        for line in contents.lines() {
+                            out.push_str("    ");
+                            out.push_str(line);
+                            out.push('\n');
+                        }
+                    }
+                    Err(e) => {
+                        out.push_str(&format!("    (not readable: {})\n", e));
+                    }
+                }
+            }
+        }
+        if !found {
+            out.push_str("(no MCP config files found)\n");
+        }
+    } else {
+        out.push_str("(working dir not readable)\n");
+    }
+
+    // 3. Observable channel state.
+    out.push_str("\n--- Channel state at failure ---\n");
+    out.push_str(channel_history);
+
+    // 4. Hint for surfacing runtime stderr on re-run.
+    out.push_str("\n\n--- Runtime stderr ---\n");
+    out.push_str(
+        "Not captured directly by this helper (captured by driver's internal tokio task \
+        and emitted via tracing::warn!). To see runtime stderr, re-run with:\n",
+    );
+    out.push_str(&format!(
+        "  RUST_LOG=chorus::agent::drivers::v2::{}=debug \
+        cargo test --test live_runtime_tests {}_agent_replies_through_shared_bridge \
+        -- --ignored --nocapture\n",
+        runtime_name, runtime_name
+    ));
+
+    out.push_str("\n=== END DIAGNOSTICS ===\n");
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -312,15 +458,23 @@ async fn opencode_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
     bridge_ct.cancel();
 
     if !found {
-        // Print the final history so the failure message is actionable.
         let (messages, _) = store.get_history("general", None, 100, None, None)?;
-        anyhow::bail!(
-            "agent did not send a reply containing 'hello world' within 60s; \
-             channel history was: {:?}",
+        let history_str = format!(
+            "{:#?}",
             messages
                 .iter()
                 .map(|m| (&m.sender_name, &m.content))
                 .collect::<Vec<_>>()
+        );
+        let diagnostics = collect_failure_diagnostics(
+            "opencode",
+            runtime_log_path("opencode").as_deref(),
+            tmpdir.path(),
+            &history_str,
+        );
+        anyhow::bail!(
+            "agent did not send a reply containing 'hello world' within 60s{}",
+            diagnostics
         );
     }
 
@@ -436,13 +590,22 @@ async fn claude_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
 
     if !found {
         let (messages, _) = store.get_history("general", None, 100, None, None)?;
-        anyhow::bail!(
-            "agent did not send a reply containing 'hello world' within 60s; \
-             channel history was: {:?}",
+        let history_str = format!(
+            "{:#?}",
             messages
                 .iter()
                 .map(|m| (&m.sender_name, &m.content))
                 .collect::<Vec<_>>()
+        );
+        let diagnostics = collect_failure_diagnostics(
+            "claude",
+            runtime_log_path("claude").as_deref(),
+            tmpdir.path(),
+            &history_str,
+        );
+        anyhow::bail!(
+            "agent did not send a reply containing 'hello world' within 60s{}",
+            diagnostics
         );
     }
 
@@ -564,13 +727,22 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
 
     if !found {
         let (messages, _) = store.get_history("general", None, 100, None, None)?;
-        anyhow::bail!(
-            "agent did not send a reply containing 'hello world' within 60s; \
-             channel history was: {:?}",
+        let history_str = format!(
+            "{:#?}",
             messages
                 .iter()
                 .map(|m| (&m.sender_name, &m.content))
                 .collect::<Vec<_>>()
+        );
+        let diagnostics = collect_failure_diagnostics(
+            "codex",
+            runtime_log_path("codex").as_deref(),
+            tmpdir.path(),
+            &history_str,
+        );
+        anyhow::bail!(
+            "agent did not send a reply containing 'hello world' within 60s{}",
+            diagnostics
         );
     }
 
@@ -690,13 +862,22 @@ async fn kimi_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
 
     if !found {
         let (messages, _) = store.get_history("general", None, 100, None, None)?;
-        anyhow::bail!(
-            "agent did not send a reply containing 'hello world' within 60s; \
-             channel history was: {:?}",
+        let history_str = format!(
+            "{:#?}",
             messages
                 .iter()
                 .map(|m| (&m.sender_name, &m.content))
                 .collect::<Vec<_>>()
+        );
+        let diagnostics = collect_failure_diagnostics(
+            "kimi",
+            runtime_log_path("kimi").as_deref(),
+            tmpdir.path(),
+            &history_str,
+        );
+        anyhow::bail!(
+            "agent did not send a reply containing 'hello world' within 60s{}",
+            diagnostics
         );
     }
 

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -203,7 +203,7 @@ fn newest_log_in(dir: &std::path::Path) -> Option<std::path::PathBuf> {
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.file_type().map(|t| t.is_file()).unwrap_or(false)
-                && e.path().extension().map_or(false, |x| x == "log")
+                && e.path().extension().is_some_and(|x| x == "log")
         })
         .max_by_key(|e| {
             e.metadata()
@@ -226,12 +226,20 @@ fn runtime_log_path(runtime_name: &str) -> Option<std::path::PathBuf> {
         "codex" => {
             // Codex TUI log (may or may not apply to app-server mode).
             let path = home.join(".codex").join("log").join("codex-tui.log");
-            if path.exists() { Some(path) } else { None }
+            if path.exists() {
+                Some(path)
+            } else {
+                None
+            }
         }
         "kimi" => {
             // Kimi writes to ~/.kimi/logs/kimi.log — the most common signal source.
             let path = home.join(".kimi").join("logs").join("kimi.log");
-            if path.exists() { Some(path) } else { None }
+            if path.exists() {
+                Some(path)
+            } else {
+                None
+            }
         }
         "opencode" => {
             let log_dir = home.join(".opencode").join("logs");
@@ -241,12 +249,45 @@ fn runtime_log_path(runtime_name: &str) -> Option<std::path::PathBuf> {
     }
 }
 
+/// Hard cap on how many trailing bytes of a runtime log we slurp into memory
+/// for the diagnostic dump. Set to 256 KiB — enough to hold well over 200
+/// lines of typical runtime log output without ever reading a multi-GB log.
+const DIAGNOSTIC_LOG_TAIL_BYTES: u64 = 256 * 1024;
+
+/// How many trailing lines of that tail we actually print.
+const DIAGNOSTIC_LOG_TAIL_LINES: usize = 200;
+
+/// Read the trailing `max_bytes` of a file without loading the whole thing.
+/// Returns an empty string (never errors) if the file can't be opened.
+/// If the requested slice lands mid-multibyte-sequence the first partial
+/// character is trimmed at the nearest UTF-8 boundary.
+fn read_log_tail(path: &std::path::Path, max_bytes: u64) -> std::io::Result<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(path)?;
+    let len = f.metadata()?.len();
+    let to_read = std::cmp::min(len, max_bytes);
+    if to_read < len {
+        f.seek(SeekFrom::End(-(to_read as i64)))?;
+    }
+    let mut buf = Vec::with_capacity(to_read as usize);
+    f.take(to_read).read_to_end(&mut buf)?;
+    // The seek likely landed mid-line; trim up to the first newline so the
+    // output always starts on a clean line.
+    let start = buf
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    Ok(String::from_utf8_lossy(&buf[start..]).into_owned())
+}
+
 /// Dump all available diagnostic signals before an `Err` is returned from a
 /// live runtime test.  Returns a `String` suitable for appending to the
 /// anyhow error message.
 ///
 /// Collects (best-effort, never panics):
-/// 1. Last 200 lines of the runtime's log file (if path provided and readable)
+/// 1. Last `DIAGNOSTIC_LOG_TAIL_LINES` lines (≤ `DIAGNOSTIC_LOG_TAIL_BYTES`)
+///    of the runtime's log file (if path provided and readable)
 /// 2. Contents of any MCP config files the driver wrote in `working_dir`
 /// 3. Observable state (channel history, captured by caller)
 /// 4. Hint for surfacing runtime stderr via RUST_LOG on re-run
@@ -264,14 +305,14 @@ fn collect_failure_diagnostics(
     let mut out = String::new();
     out.push_str("\n\n=== FAILURE DIAGNOSTICS ===\n");
 
-    // 1. Runtime log file (last 200 lines).
+    // 1. Runtime log file — tail only; large logs would otherwise blow memory.
     out.push_str(&format!("\n--- {} log file ---\n", runtime_name));
     if let Some(log_path) = runtime_log_path {
         out.push_str(&format!("Path: {}\n", log_path.display()));
-        match std::fs::read_to_string(log_path) {
-            Ok(contents) => {
-                let lines: Vec<&str> = contents.lines().collect();
-                let start = lines.len().saturating_sub(200);
+        match read_log_tail(log_path, DIAGNOSTIC_LOG_TAIL_BYTES) {
+            Ok(tail) => {
+                let lines: Vec<&str> = tail.lines().collect();
+                let start = lines.len().saturating_sub(DIAGNOSTIC_LOG_TAIL_LINES);
                 for line in &lines[start..] {
                     out.push_str(line);
                     out.push('\n');
@@ -295,8 +336,16 @@ fn collect_failure_diagnostics(
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            // MCP config files follow known naming patterns used by the drivers.
-            if name_str.contains("mcp") || name_str.ends_with(".json") {
+            // Only dump files the drivers actually write — matching every
+            // `.json` would sweep in unrelated config and risk leaking
+            // user secrets that happen to live in working_dir.
+            //   - `.chorus-claude-mcp.json`  (ClaudeDriver)
+            //   - `.chorus-kimi-mcp.json`    (KimiDriver)
+            //   - `opencode.json`            (OpencodeDriver)
+            //   - Codex configures via `-c` flags, no file on disk.
+            let is_driver_mcp_config =
+                name_str.contains("-mcp.json") || name_str == "opencode.json";
+            if is_driver_mcp_config {
                 found = true;
                 out.push_str(&format!("\n  {}:\n", entry.path().display()));
                 match std::fs::read_to_string(entry.path()) {

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -690,6 +690,8 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
     // 6. Attach + start the runtime with initial prompt.
     //    Codex uses the `app-server` native protocol; the driver passes
     //    `-c mcp_servers.chat.url=…` flags to wire up the HTTP bridge.
+    //    (Codex app-server doesn't write a log file — its only signal is
+    //    stdout JSON-RPC. The Iron Rule helper will note this on failure.)
     let driver = CodexDriver;
     let attach_result = driver.attach(agent_key.to_string(), spec).await?;
     let mut handle = attach_result.handle;
@@ -706,8 +708,11 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
 
     handle.start(StartOpts::default(), Some(prompt)).await?;
 
-    // 7. Poll the store for up to 60 seconds waiting for the agent's reply.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    // 7. Poll the store for up to 120s waiting for the agent's reply.
+    //    Codex on gpt-5.4 via WebSocket + MCP tool round-trip can exceed 60s
+    //    on a cold cache — extending keeps this test reliable.
+    let codex_deadline_secs = 120u64;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(codex_deadline_secs);
     let mut found = false;
     while tokio::time::Instant::now() < deadline {
         let (messages, _) = store.get_history("general", None, 100, None, None)?;
@@ -741,7 +746,8 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
             &history_str,
         );
         anyhow::bail!(
-            "agent did not send a reply containing 'hello world' within 60s{}",
+            "agent did not send a reply containing 'hello world' within {}s{}",
+            codex_deadline_secs,
             diagnostics
         );
     }


### PR DESCRIPTION
## Summary

Phase 1/2 follow-up work completing the shared-bridge migration. Four commits, net -701 lines.

- **Remove legacy stdio bridge.** `bridge::run_bridge` and the `chorus bridge` subcommand are gone; the shared HTTP bridge is now the only agent↔Chorus transport. `chorus serve` always starts it in-process. Drivers' `build_mcp_config` helpers lose the stdio fallback arm; `AgentSpec.bridge_endpoint` is now `String` (not `Option`), and `AgentManager` fails loudly if no bridge is running instead of silently falling back.
- **Retrofit Iron Rule into live runtime tests.** Each of the four `#[ignore]` live-runtime tests (Claude, Codex, Kimi, OpenCode) now emits a structured diagnostic dump on failure: last 200 log-tail lines, MCP config file contents, channel state at timeout, and a `RUST_LOG` hint for re-running with driver tracing. Codified in `qa/cases/bridge.md` (BRG/LRT/INT catalog) and `qa/README.md` ("Subprocess and External Runtime Tests").
- **Codex timeout bumped to 120s** for cold-cache WebSocket warmup runs.
- **Ship-review fixes** addressing findings from a multi-reviewer pass:
  - F10: shared shutdown token now cascades into the bridge's internal `CancellationToken` so in-flight MCP sessions drain on Ctrl-C.
  - F1 / Codex P0: `write_bridge_info` refuses to stomp a discovery file pointing to a live PID belonging to a different process. Two concurrent `chorus serve` instances abort loudly instead of silently stealing each other's routing.
  - Perf: `collect_failure_diagnostics` tails logs via seek-to-end (256 KiB cap) instead of `read_to_string` on arbitrarily large files.
  - MCP-config filter tightened to the three filenames drivers actually write (no more sweeping every `.json` in working_dir).
  - F6: `--shared-bridge` re-added as hidden deprecated no-op so pre-existing scripts don't hit clap parse errors.
  - Drive-by: clippy `is_some_and` cleanup + `cargo fmt` drift absorbed.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — 361 passing, 4 ignored (live-runtime gates)
- [x] 2 new unit tests in `src/bridge/discovery.rs` pin the live-PID guard: `refuses_to_stomp_live_pid`, `overwrites_stale_pid`
- [x] 10/10 `bridge_serve_tests` green (end-to-end pairing + send_message flow unchanged)
- [ ] Live-runtime: requires installed binaries + auth. Re-run locally with `cargo test --test live_runtime_tests -- --ignored --nocapture` before merge if credentials available.
- [ ] Manual: start two `chorus serve` instances concurrently → second should abort with "another chorus bridge is already running" instead of stealing discovery.