### PR TITLE
fix(setup): show claude and codex as native ACP runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ node_modules
 .worktrees/
 .superpowers
 .codex
+.context/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Use this doc index before touching a subsystem or workflow:
 | Doc | Covers | Read Before |
 | --- | --- | --- |
 | `[docs/DEV.md](docs/DEV.md)` | Setup, prerequisites, run/test/build loops, and local troubleshooting | First local run, environment setup, or when local tooling is acting up |
+| `[docs/CLI.md](docs/CLI.md)` | CLI command reference — flags, exit codes, environment variables | Adding or changing a CLI command |
 | `[qa/README.md](qa/README.md)` | Authoritative QA SOP: run modes, Playwright workflow, failure classification, evidence handling | Running QA, debugging QA failures, or updating QA process |
 | `[qa/QA_CASES.md](qa/QA_CASES.md)` | Static case catalog index and area-by-area case map | Choosing coverage for a change or mapping a failure to an existing case |
 | `[docs/BACKEND.md](docs/BACKEND.md)` | Rust — error handling, enums, logging, schema/views, tests, Axum handlers | Any backend change |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,203 @@
+# Chorus CLI Reference
+
+Complete reference for the `chorus` command-line interface.
+
+---
+
+## Commands
+
+### `chorus setup`
+
+First-run initializer. Detects installed AI runtimes, probes authentication status, writes `config.toml`, creates the data directory layout, and migrates legacy configurations.
+
+```bash
+chorus setup
+chorus setup --yes                    # non-interactive, accept defaults
+chorus setup --data-dir /custom/path  # override default ~/.chorus
+```
+
+**What it does:**
+- Detects claude, codex, kimi, opencode, and gemini binaries on `$PATH`
+- Probes each runtime's auth state (API keys, OAuth tokens, login status)
+- Writes `~/.chorus/config.toml` with detected runtime settings
+- Creates `data/`, `logs/`, and `agents/` subdirectories
+- Generates a `machine_id` UUID for this installation
+
+**Mutates:** yes (writes config, creates directories).
+
+---
+
+### `chorus check`
+
+Read-only environment diagnostic. Reports runtime installation/auth status, data-directory health, and shared MCP bridge reachability without modifying anything.
+
+```bash
+chorus check
+chorus check --data-dir /custom/path
+```
+
+**Sections:**
+
+| Section | Checks |
+|---------|--------|
+| **Runtimes** | Auth probe via `RuntimeDriver::probe()` + version via `--version` |
+| **Data** | `config.toml`, `data/`, `logs/`, `agents/`, `chorus.db`, `machine_id` |
+| **Bridge** | Discovery file health + HTTP `GET /health` |
+
+**State glyphs:**
+
+| Glyph | Meaning |
+|-------|---------|
+| `✓` | Present and healthy |
+| `⚠` | Present but needs attention (e.g., not authenticated) |
+| `✗` | Present but broken (e.g., unreadable config) |
+| `○` | Missing — normal if not installed or not initialized |
+
+**Mutates:** no. Returns 0 unless an internal bug causes a panic.
+
+---
+
+### `chorus start`
+
+Starts the Chorus backend server and opens the web UI in a browser.
+
+```bash
+chorus start --port 3001
+chorus start --port 3001 --no-open       # skip browser
+chorus start --bridge-port 4321          # custom MCP bridge port
+```
+
+This is the recommended way to run Chorus locally. It is an alias for `serve` with auto-open enabled.
+
+**Mutates:** yes (creates/updates SQLite DB, writes bridge discovery file).
+
+---
+
+### `chorus serve`
+
+Starts the backend server without opening a browser. Kept for backward compatibility and headless deployments.
+
+```bash
+chorus serve --port 3001
+chorus serve --port 3001 --bridge-port 4321
+```
+
+**What it starts:**
+- HTTP API on `:port`
+- WebSocket realtime stream on `:port/internal`
+- Shared MCP bridge in-process on `:bridge-port`
+- Auto-restores previously-active agents from SQLite
+
+**Mutates:** yes.
+
+---
+
+### `chorus bridge-serve`
+
+Runs the shared MCP bridge as a standalone HTTP server. Useful when you want the bridge on a different host/port from the main Chorus server.
+
+```bash
+chorus bridge-serve --listen 127.0.0.1:4321 --server-url http://localhost:3001
+```
+
+**Mutates:** yes (writes `~/.chorus/bridge.json` discovery file).
+
+---
+
+### `chorus bridge-pair`
+
+Mints a one-time pairing token so an agent runtime can connect to the shared bridge.
+
+```bash
+chorus bridge-pair --agent my-agent
+```
+
+The token is printed to stdout and valid for a short window. Runtimes exchange this token for an MCP session URL.
+
+**Mutates:** yes (consumes the token on first use).
+
+---
+
+### `chorus status`
+
+Lists channels, agents, and humans by querying the running Chorus server.
+
+```bash
+chorus status --server-url http://localhost:3001
+```
+
+---
+
+### `chorus send`
+
+Sends a message as the human user.
+
+```bash
+chorus send "#general" "Hello agents"
+chorus send "dm:@claude" "Can you review this?"
+```
+
+---
+
+### `chorus agent`
+
+Create and manage agents via the running server.
+
+```bash
+chorus agent create my-agent --runtime claude
+chorus agent stop my-agent
+chorus agent list
+```
+
+---
+
+### `chorus channel`
+
+Manage channels (create, delete, join, list, history).
+
+```bash
+chorus channel list
+chorus channel create my-channel
+chorus channel delete my-channel
+chorus channel history my-channel
+```
+
+---
+
+## Global behavior
+
+### Data directory
+
+Most commands accept `--data-dir` to override the default `~/.chorus`. The bridge discovery file (`~/.chorus/bridge.json`) is always global regardless of `--data-dir` — the bridge is a singleton.
+
+### Logging
+
+- `setup`, `start`, `serve`, and the default server case initialize file logging to `~/.chorus/logs/`.
+- All other commands (`check`, `status`, `send`, `channel`, `agent`, `bridge-serve`, `bridge-pair`) log to stdout only.
+
+### Environment variables
+
+| Variable | Affected commands | Purpose |
+|----------|-------------------|---------|
+| `RUST_BACKTRACE` | all | Set to `1` by default for panic diagnostics |
+| `CHORUS_TEMPLATE_DIR` | `setup`, `start`, `serve` | Override agent template directory |
+| `HOME` | all | Used to resolve `~/.chorus` default |
+
+---
+
+## Exit codes
+
+| Command | 0 | non-zero |
+|---------|---|----------|
+| `setup` | Success | Setup failed (I/O error, parse failure) |
+| `check` | Always | Only if internal panic or I/O failure |
+| `start` / `serve` | Clean shutdown | Port in use, DB error, etc. |
+| `send` / `status` | Success | Server unreachable, HTTP error |
+
+---
+
+## See also
+
+- [`docs/DEV.md`](DEV.md) — Local development setup and troubleshooting
+- [`docs/BACKEND.md`](BACKEND.md) — Rust conventions and architecture
+- [`docs/BRIDGE_MIGRATION.md`](BRIDGE_MIGRATION.md) — MCP bridge architecture

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -77,6 +77,19 @@ chorus bridge-smoke-test
 See `docs/BRIDGE_MIGRATION.md` for the full architecture and driver implementation
 guide.
 
+### CLI commands
+
+See [`docs/CLI.md`](CLI.md) for the full command reference. Quick cheatsheet:
+
+```bash
+chorus setup                    # first-run initializer
+chorus check                    # read-only environment diagnostic
+chorus start --port 3001        # start server + open browser
+chorus serve --port 3001        # start server, no browser
+chorus bridge-serve ...         # standalone MCP bridge
+chorus bridge-pair --agent ...  # mint pairing token
+```
+
 ---
 
 ## Testing

--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -536,6 +536,9 @@ impl ClaudeHandle {
             mcp_path_str,
         ];
         if !self.spec.model.is_empty() {
+            // TODO: Honor `self.spec.reasoning_effort` once the Claude CLI
+            // exposes a stable session-level knob instead of advertising the
+            // value only via the runtime catalog.
             args.push("--model".into());
             args.push(self.spec.model.clone());
         }

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -667,6 +667,9 @@ impl CodexHandle {
             ),
             None => (
                 "thread/start".to_string(),
+                // TODO: Thread start currently ignores `self.spec.reasoning_effort`.
+                // Plumb the validated catalog value through once Codex app-server
+                // exposes a first-class reasoning-effort field for new threads.
                 codex_app_server::build_thread_start(
                     req_id,
                     &self.spec.model,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@ mod event_forwarder;
 pub mod lifecycle;
 pub mod manager;
 pub mod process_status;
+pub mod runtime_catalog;
 pub mod runtime_status;
 pub mod templates;
 pub mod trace;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -16,7 +16,7 @@ pub use lifecycle::AgentLifecycle;
 use serde::{Deserialize, Serialize};
 
 /// Supported local agent runtimes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentRuntime {
     Claude,

--- a/src/agent/runtime_catalog.rs
+++ b/src/agent/runtime_catalog.rs
@@ -1,0 +1,64 @@
+use crate::agent::AgentRuntime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeMetadata {
+    pub label: &'static str,
+    pub order: u32,
+    pub reasoning_efforts: &'static [&'static str],
+}
+
+const EMPTY_REASONING_EFFORTS: &[&str] = &[];
+// TODO: Claude and Codex are advertised as supporting reasoning efforts here,
+// but their drivers do not yet plumb `AgentSpec.reasoning_effort` into the
+// actual runtime requests. Keep this catalog aligned with driver behavior.
+const CLAUDE_REASONING_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh", "max"];
+
+const CODEX_REASONING_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh"];
+
+const CLAUDE_METADATA: RuntimeMetadata = RuntimeMetadata {
+    label: "Claude Code",
+    order: 0,
+    reasoning_efforts: CLAUDE_REASONING_EFFORTS,
+};
+
+const CODEX_METADATA: RuntimeMetadata = RuntimeMetadata {
+    label: "Codex CLI",
+    order: 1,
+    reasoning_efforts: CODEX_REASONING_EFFORTS,
+};
+
+const KIMI_METADATA: RuntimeMetadata = RuntimeMetadata {
+    label: "Kimi CLI",
+    order: 2,
+    reasoning_efforts: EMPTY_REASONING_EFFORTS,
+};
+
+const OPENCODE_METADATA: RuntimeMetadata = RuntimeMetadata {
+    label: "OpenCode",
+    order: 3,
+    reasoning_efforts: EMPTY_REASONING_EFFORTS,
+};
+
+const GEMINI_METADATA: RuntimeMetadata = RuntimeMetadata {
+    label: "Gemini CLI",
+    order: 4,
+    reasoning_efforts: EMPTY_REASONING_EFFORTS,
+};
+
+pub const fn runtime_metadata(runtime: AgentRuntime) -> &'static RuntimeMetadata {
+    match runtime {
+        AgentRuntime::Claude => &CLAUDE_METADATA,
+        AgentRuntime::Codex => &CODEX_METADATA,
+        AgentRuntime::Kimi => &KIMI_METADATA,
+        AgentRuntime::Opencode => &OPENCODE_METADATA,
+        AgentRuntime::Gemini => &GEMINI_METADATA,
+    }
+}
+
+pub const fn supports_reasoning_effort(runtime: AgentRuntime) -> bool {
+    !runtime_metadata(runtime).reasoning_efforts.is_empty()
+}
+
+pub fn supports_reasoning_effort_value(runtime: AgentRuntime, value: &str) -> bool {
+    runtime_metadata(runtime).reasoning_efforts.contains(&value)
+}

--- a/src/agent/runtime_status.rs
+++ b/src/agent/runtime_status.rs
@@ -5,20 +5,41 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::drivers::{ProbeAuth, RuntimeDriver};
+use crate::agent::runtime_catalog::runtime_metadata;
 use crate::agent::AgentRuntime;
 
-/// HTTP/UI response shape for one supported runtime.
+/// HTTP/UI response shape for one runtime catalog entry plus local auth probe.
 /// Returned by [`RuntimeStatusProvider::list_statuses`] and serialized directly to JSON.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RuntimeStatusInfo {
+pub struct RuntimeCatalogEntry {
     pub runtime: String,
+    pub label: String,
+    pub order: u32,
+    pub reasoning_efforts: Vec<String>,
     pub auth: ProbeAuth,
+}
+
+impl RuntimeCatalogEntry {
+    pub fn new(runtime: AgentRuntime, auth: ProbeAuth) -> Self {
+        let metadata = runtime_metadata(runtime);
+        Self {
+            runtime: runtime.as_str().to_string(),
+            label: metadata.label.to_string(),
+            order: metadata.order,
+            reasoning_efforts: metadata
+                .reasoning_efforts
+                .iter()
+                .map(|effort| (*effort).to_string())
+                .collect(),
+            auth,
+        }
+    }
 }
 
 /// Backend service used by HTTP handlers to query local runtime availability.
 #[async_trait::async_trait]
 pub trait RuntimeStatusProvider: Send + Sync {
-    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatusInfo>>;
+    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeCatalogEntry>>;
     async fn list_models(&self, runtime: AgentRuntime) -> anyhow::Result<Vec<String>>;
 }
 
@@ -38,15 +59,13 @@ impl SystemRuntimeStatusProvider {
 
 #[async_trait::async_trait]
 impl RuntimeStatusProvider for SystemRuntimeStatusProvider {
-    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatusInfo>> {
+    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeCatalogEntry>> {
         let mut statuses = Vec::with_capacity(self.drivers.len());
         for (runtime, driver) in &self.drivers {
             let probe = driver.probe().await?;
-            statuses.push(RuntimeStatusInfo {
-                runtime: runtime.as_str().to_string(),
-                auth: probe.auth,
-            });
+            statuses.push(RuntimeCatalogEntry::new(*runtime, probe.auth));
         }
+        statuses.sort_by_key(|status| status.order);
         Ok(statuses)
     }
 

--- a/src/bridge/discovery.rs
+++ b/src/bridge/discovery.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Bridge discovery info written on startup, read by drivers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BridgeInfo {
     pub port: u16,
     pub pid: u32,
@@ -95,6 +95,21 @@ pub fn write_bridge_info_to(path: &std::path::Path, info: &BridgeInfo) -> std::i
     Ok(())
 }
 
+/// Detailed status returned by [`read_bridge_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BridgeStatus {
+    /// Discovery file is missing.
+    Missing,
+    /// Discovery file exists but cannot be read (e.g., permission denied).
+    Unreadable { reason: String },
+    /// Discovery file is readable but contains invalid JSON.
+    Invalid { reason: String },
+    /// Discovery file is readable and valid, but the recorded PID is dead.
+    Stale { info: BridgeInfo },
+    /// Discovery file is readable, valid, and the recorded PID is alive.
+    Live { info: BridgeInfo },
+}
+
 /// Read bridge info from the default discovery file. Returns None if:
 /// - File doesn't exist
 /// - File can't be parsed
@@ -114,6 +129,41 @@ pub fn read_bridge_info_from(path: &std::path::Path) -> Option<BridgeInfo> {
         return None;
     }
     Some(info)
+}
+
+/// Read bridge status from the default discovery file with detailed error
+/// classification. This is the richer sibling of [`read_bridge_info`] used by
+/// diagnostics that need to distinguish "missing", "corrupt", and "stale".
+pub fn read_bridge_status() -> BridgeStatus {
+    read_bridge_status_from(&default_discovery_path())
+}
+
+/// Read bridge status from a specific path with detailed error classification.
+pub fn read_bridge_status_from(path: &std::path::Path) -> BridgeStatus {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return BridgeStatus::Missing,
+        Err(e) => {
+            return BridgeStatus::Unreadable {
+                reason: format!("cannot read discovery file: {e}"),
+            }
+        }
+    };
+
+    let info: BridgeInfo = match serde_json::from_str(&contents) {
+        Ok(i) => i,
+        Err(e) => {
+            return BridgeStatus::Invalid {
+                reason: format!("invalid JSON: {e}"),
+            }
+        }
+    };
+
+    if !is_pid_alive(info.pid) {
+        BridgeStatus::Stale { info }
+    } else {
+        BridgeStatus::Live { info }
+    }
 }
 
 /// Remove the discovery file (called on graceful shutdown).
@@ -370,6 +420,81 @@ mod tests {
         assert_eq!(read_back.port, fresh.port);
         assert_eq!(read_back.pid, fresh.pid);
 
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // -----------------------------------------------------------------------
+    // read_bridge_status_from tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_bridge_status_missing() {
+        let path = tmp_path("status_missing.json");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read_bridge_status_from(&path), BridgeStatus::Missing);
+    }
+
+    #[test]
+    fn read_bridge_status_corrupt_json() {
+        let path = tmp_path("status_corrupt.json");
+        std::fs::write(&path, b"not json").unwrap();
+        let status = read_bridge_status_from(&path);
+        assert!(
+            matches!(&status, BridgeStatus::Invalid { reason } if reason.contains("invalid JSON")),
+            "expected Invalid with JSON reason, got {status:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_bridge_status_corrupt_unreadable() {
+        // Write valid JSON to a path, then make it unreadable (Unix only).
+        let path = tmp_path("status_unreadable.json");
+        let info = sample_info();
+        std::fs::write(&path, serde_json::to_string(&info).unwrap()).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+            let status = read_bridge_status_from(&path);
+            assert!(
+                matches!(&status, BridgeStatus::Unreadable { reason } if reason.contains("cannot read")),
+                "expected Unreadable with read reason, got {status:?}"
+            );
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_bridge_status_stale() {
+        let path = tmp_path("status_stale.json");
+        let stale = BridgeInfo {
+            port: 9500,
+            pid: 999_999_999,
+            started_at: "2026-04-16T00:00:00Z".to_string(),
+        };
+        std::fs::write(&path, serde_json::to_string(&stale).unwrap()).unwrap();
+        let status = read_bridge_status_from(&path);
+        assert!(
+            matches!(&status, BridgeStatus::Stale { info } if info.pid == 999_999_999),
+            "expected Stale, got {status:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_bridge_status_live() {
+        let path = tmp_path("status_live.json");
+        let info = sample_info(); // uses our own PID, which is alive
+        std::fs::write(&path, serde_json::to_string(&info).unwrap()).unwrap();
+        let status = read_bridge_status_from(&path);
+        assert!(
+            matches!(&status, BridgeStatus::Live { info: i } if i.pid == info.pid),
+            "expected Live, got {status:?}"
+        );
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -1,0 +1,334 @@
+//! `chorus check` — read-only environment diagnostic.
+//!
+//! Reports runtime installation/auth status, data-directory health, and shared
+//! MCP bridge reachability without mutating the environment.
+
+use chorus::agent::drivers::ProbeAuth;
+use chorus::agent::manager::build_driver_registry;
+use chorus::bridge::discovery::{read_bridge_status, BridgeStatus};
+use chorus::config::ChorusConfig;
+use console::{style, Emoji};
+use std::path::Path;
+
+use std::time::Duration;
+use tokio::process::Command;
+
+// Glyphs. `console::Emoji` falls back to ASCII on dumb terminals.
+static OK: Emoji<'_, '_> = Emoji("✓ ", "ok ");
+static BAD: Emoji<'_, '_> = Emoji("✗ ", "x  ");
+static WARN: Emoji<'_, '_> = Emoji("⚠ ", "!  ");
+static MISSING: Emoji<'_, '_> = Emoji("○ ", "-  ");
+
+pub async fn run(data_dir: Option<String>) -> anyhow::Result<()> {
+    let data_dir = data_dir.unwrap_or_else(super::default_data_dir);
+
+    println!();
+    println!("  {}", style("Chorus · environment check").bold());
+
+    check_runtimes().await;
+    check_data_dir(&data_dir).await;
+    check_bridge().await;
+
+    println!();
+    Ok(())
+}
+
+fn section(title: &str) {
+    println!();
+    println!("  {}", style(title).bold());
+}
+
+fn row_ok(name: &str, detail: &str) {
+    println!(
+        "  {}{:<12} {}",
+        style(OK).green(),
+        style(name).bold(),
+        style(detail).dim()
+    );
+}
+
+fn row_warn(name: &str, detail: &str) {
+    println!(
+        "  {}{:<12} {}",
+        style(WARN).yellow(),
+        style(name).bold(),
+        style(detail).dim()
+    );
+}
+
+fn row_bad(name: &str, detail: &str) {
+    println!(
+        "  {}{:<12} {}",
+        style(BAD).red(),
+        style(name).bold(),
+        style(detail).dim()
+    );
+}
+
+fn row_missing(name: &str, detail: &str) {
+    println!(
+        "  {}{:<12} {}",
+        style(MISSING).dim(),
+        style(name).bold(),
+        style(detail).dim()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtimes
+// ---------------------------------------------------------------------------
+
+async fn check_runtimes() {
+    section("Runtimes");
+
+    let registry = build_driver_registry();
+    let mut runtimes: Vec<_> = registry.into_iter().collect();
+    runtimes.sort_by_key(|(k, _)| *k);
+
+    for (runtime, driver) in runtimes {
+        let name = runtime.as_str();
+
+        // Auth probe with timeout.
+        // NOTE: several driver probes do blocking std::process::Command work
+        // inside their async fn without yielding. The timeout prevents the
+        // checker from hanging indefinitely, but it does not kill the
+        // underlying child process — a known v1 limitation.
+        let auth = match tokio::time::timeout(Duration::from_secs(5), driver.probe()).await {
+            Ok(Ok(probe)) => probe.auth,
+            Ok(Err(e)) => {
+                row_warn(name, &format!("probe error: {e}"));
+                continue;
+            }
+            Err(_) => {
+                row_warn(name, "probe timed out");
+                continue;
+            }
+        };
+
+        if auth == ProbeAuth::NotInstalled {
+            row_missing(name, "not found");
+            continue;
+        }
+
+        let version = probe_version(name).await;
+        let version_str = version.as_deref().unwrap_or("version unknown");
+
+        match auth {
+            ProbeAuth::Authed => row_ok(name, &format!("{version_str} · authenticated")),
+            ProbeAuth::Unauthed => row_warn(name, &format!("{version_str} · not authenticated")),
+            ProbeAuth::NotInstalled => unreachable!(),
+        }
+    }
+}
+
+/// Run `<binary> --version` with a 5-second timeout and extract the version string.
+/// Uses `Command::output()` internally so stdout/stderr are drained concurrently,
+/// avoiding the pipe-deadlock risk of `spawn()` + `wait()`.
+async fn probe_version(binary: &str) -> Option<String> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(5),
+        Command::new(binary).arg("--version").output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok())?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let source = if stdout.trim().is_empty() {
+        String::from_utf8_lossy(&output.stderr)
+    } else {
+        stdout
+    };
+
+    extract_version(&source)
+}
+
+/// Extract the first dotted version number from a tool's `--version` output.
+fn extract_version(s: &str) -> Option<String> {
+    static VERSION_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = VERSION_RE
+        .get_or_init(|| regex::Regex::new(r"\b\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?\b").unwrap());
+    re.find(s).map(|m| m.as_str().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Data directory
+// ---------------------------------------------------------------------------
+
+async fn check_data_dir(data_dir: &str) {
+    section("Data");
+
+    let data_dir_path = Path::new(data_dir);
+
+    // Root data directory.
+    match std::fs::read_dir(data_dir_path) {
+        Ok(_) => row_ok("data dir", &data_dir_path.display().to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            row_missing("data dir", "not found · run \"chorus setup\" to initialize");
+        }
+        Err(e) => row_bad("data dir", &e.to_string()),
+    }
+
+    // Config file.
+    let config_path = data_dir_path.join("config.toml");
+    match ChorusConfig::load(data_dir_path) {
+        Ok(Some(cfg)) => {
+            row_ok("config", &config_path.display().to_string());
+            if let Some(id) = &cfg.machine_id {
+                row_ok("machine id", id);
+            } else {
+                row_missing("machine id", "not set · run \"chorus setup\" to initialize");
+            }
+        }
+        Ok(None) => {
+            row_missing("config", "not found · run \"chorus setup\" to configure");
+            row_missing("machine id", "not set · run \"chorus setup\" to initialize");
+        }
+        Err(e) => row_bad("config", &e.to_string()),
+    }
+
+    // Data subdirectory.
+    let data_sub = data_dir_path.join(super::DATA_SUBDIR);
+    check_dir_readable("data", &data_sub);
+
+    // Database file.
+    let db_path = data_sub.join("chorus.db");
+    match std::fs::metadata(&db_path) {
+        Ok(m) if m.is_file() => row_ok("database", &db_path.display().to_string()),
+        Ok(_) => row_bad("database", &format!("{} is not a file", db_path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            row_missing("database", "not found · run \"chorus setup\" to initialize");
+        }
+        Err(e) => row_bad("database", &e.to_string()),
+    }
+
+    // Logs directory.
+    let logs_dir = data_dir_path.join("logs");
+    check_dir_readable("logs", &logs_dir);
+
+    // Agents directory.
+    let agents_dir = data_dir_path.join("agents");
+    check_dir_readable("agents", &agents_dir);
+}
+
+fn check_dir_readable(label: &str, path: &Path) {
+    match std::fs::read_dir(path) {
+        Ok(_) => row_ok(label, &path.display().to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            row_missing(label, "not found · run \"chorus setup\" to initialize");
+        }
+        Err(e) => row_bad(label, &e.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bridge
+// ---------------------------------------------------------------------------
+
+async fn check_bridge() {
+    section("Bridge");
+
+    match read_bridge_status() {
+        BridgeStatus::Missing => {
+            row_missing("bridge", "not running");
+        }
+        BridgeStatus::Unreadable { reason } => {
+            row_bad("bridge", &format!("discovery file unreadable · {reason}"));
+        }
+        BridgeStatus::Invalid { reason } => {
+            row_bad("bridge", &format!("discovery file invalid · {reason}"));
+        }
+        BridgeStatus::Stale { info } => {
+            row_missing(
+                "bridge",
+                &format!("not running (stale discovery file · pid {})", info.pid),
+            );
+        }
+        BridgeStatus::Live { info } => {
+            let url = format!("http://127.0.0.1:{}/health", info.port);
+            let start = std::time::Instant::now();
+            match tokio::time::timeout(Duration::from_secs(3), reqwest::get(&url)).await {
+                Ok(Ok(resp)) if resp.status().is_success() => {
+                    let elapsed = start.elapsed().as_millis();
+                    row_ok(
+                        "bridge",
+                        &format!("reachable · 127.0.0.1:{} ({}ms)", info.port, elapsed),
+                    );
+                }
+                Ok(Ok(resp)) => {
+                    row_warn("bridge", &format!("unreachable · HTTP {}", resp.status()));
+                }
+                Ok(Err(e)) => {
+                    let msg = if e.is_connect() {
+                        "connection refused"
+                    } else {
+                        "request failed"
+                    };
+                    row_warn("bridge", &format!("unreachable · {msg}"));
+                }
+                Err(_) => {
+                    row_warn("bridge", "unreachable · timed out");
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_version_finds_dotted_number() {
+        assert_eq!(
+            extract_version("claude, version 2.1.116"),
+            Some("2.1.116".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_version_finds_first_line_only() {
+        assert_eq!(
+            extract_version("codex 0.122.0\nextra line"),
+            Some("0.122.0".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_version_returns_none_when_no_number() {
+        assert_eq!(extract_version("unknown tool"), None);
+    }
+
+    #[test]
+    fn extract_version_handles_pre_release() {
+        assert_eq!(
+            extract_version("tool 1.0.0-beta.2"),
+            Some("1.0.0-beta.2".to_string())
+        );
+    }
+
+    #[test]
+    fn check_dir_readable_existing_dir() {
+        let tmp = std::env::temp_dir().join(format!("chorus_check_test_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        // Just verify it doesn't panic; stdout capture is awkward in unit tests.
+        check_dir_readable("test", &tmp);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[test]
+    fn check_dir_readable_missing_dir() {
+        let tmp =
+            std::env::temp_dir().join(format!("chorus_check_test_missing_{}", std::process::id()));
+        let _ = std::fs::remove_dir(&tmp);
+        check_dir_readable("test", &tmp);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@
 
 mod agent;
 mod channel;
+mod check;
 mod send;
 mod serve;
 mod setup;
@@ -102,6 +103,11 @@ enum Commands {
         /// Agent key to pair (matches the Chorus agent name).
         #[arg(long)]
         agent: String,
+    },
+    /// Read-only environment diagnostic
+    Check {
+        #[arg(long)]
+        data_dir: Option<String>,
     },
     /// Alias for `start --no-open` (kept for backward compatibility)
     #[command(hide = true)]
@@ -247,6 +253,8 @@ pub async fn run() -> anyhow::Result<()> {
         Some(Commands::Channel { cmd, server_url }) => channel::run(server_url, cmd).await,
 
         Some(Commands::Agent { cmd }) => agent::run(cmd).await,
+
+        Some(Commands::Check { data_dir }) => check::run(data_dir).await,
 
         Some(Commands::Serve {
             port,

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -5,6 +5,7 @@
 //! lets the user pick between duplicate binaries on `$PATH`). Passes `--yes`
 //! to skip all prompts and accept defaults.
 
+use chorus::agent::drivers::ProbeAuth;
 use chorus::config::ChorusConfig;
 use chorus::store::Store;
 use console::{style, Emoji};
@@ -95,6 +96,122 @@ fn extract_version(s: &str) -> Option<String> {
     re.find(s).map(|m| m.as_str().to_string())
 }
 
+// ---------------------------------------------------------------------------
+// Auth probing — mirrors each driver's RuntimeDriver::probe() logic
+// ---------------------------------------------------------------------------
+
+/// Probe a runtime's authentication state synchronously.
+/// Mirrors the logic in each runtime's `RuntimeDriver::probe()` but blocks
+/// so it can run inside the synchronous setup doctor.
+fn check_auth(name: &str) -> ProbeAuth {
+    match name {
+        "claude" => check_claude_auth(),
+        "codex" => check_codex_auth(),
+        "kimi" => check_kimi_auth(),
+        "opencode" => check_opencode_auth(),
+        "gemini" => check_gemini_auth(),
+        _ => ProbeAuth::NotInstalled,
+    }
+}
+
+fn check_claude_auth() -> ProbeAuth {
+    let Ok(output) = Command::new("claude").args(&["auth", "status"]).output() else {
+        return ProbeAuth::Unauthed;
+    };
+    if !output.status.success() {
+        return ProbeAuth::Unauthed;
+    }
+    let payload: serde_json::Value =
+        match serde_json::from_str(&String::from_utf8_lossy(&output.stdout)) {
+            Ok(v) => v,
+            Err(_) => return ProbeAuth::Unauthed,
+        };
+    if payload["loggedIn"].as_bool().unwrap_or(false) {
+        ProbeAuth::Authed
+    } else {
+        ProbeAuth::Unauthed
+    }
+}
+
+fn check_codex_auth() -> ProbeAuth {
+    let Ok(output) = Command::new("codex").args(&["login", "status"]).output() else {
+        return ProbeAuth::Unauthed;
+    };
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_ascii_lowercase();
+    if output.status.success() && combined.contains("logged in") {
+        ProbeAuth::Authed
+    } else {
+        ProbeAuth::Unauthed
+    }
+}
+
+fn check_kimi_auth() -> ProbeAuth {
+    let has_access = Command::new("kimi")
+        .args(&["config", "get", "auth.access_token"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty());
+    let has_refresh = Command::new("kimi")
+        .args(&["config", "get", "auth.refresh_token"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty());
+    if has_access || has_refresh {
+        ProbeAuth::Authed
+    } else {
+        ProbeAuth::Unauthed
+    }
+}
+
+fn check_opencode_auth() -> ProbeAuth {
+    let Ok(output) = Command::new("opencode")
+        .args(&["auth", "status"])
+        .output()
+    else {
+        return ProbeAuth::Unauthed;
+    };
+    if output.status.success() {
+        ProbeAuth::Authed
+    } else {
+        ProbeAuth::Unauthed
+    }
+}
+
+fn check_gemini_auth() -> ProbeAuth {
+    if std::env::var("GEMINI_API_KEY").is_ok_and(|v| !v.trim().is_empty()) {
+        return ProbeAuth::Authed;
+    }
+    let Ok(output) = Command::new("gemini")
+        .args(&["auth", "status"])
+        .output()
+    else {
+        return ProbeAuth::Unauthed;
+    };
+    if !output.status.success() {
+        return ProbeAuth::Unauthed;
+    }
+    let payload: serde_json::Value =
+        match serde_json::from_str(&String::from_utf8_lossy(&output.stdout)) {
+            Ok(v) => v,
+            Err(_) => return ProbeAuth::Unauthed,
+        };
+    if payload["accessToken"]
+        .as_str()
+        .is_some_and(|v| !v.trim().is_empty())
+    {
+        ProbeAuth::Authed
+    } else {
+        ProbeAuth::Unauthed
+    }
+}
+
 /// Return every absolute path where `name` is found on `$PATH`, deduped,
 /// in discovery order. Empty vec if nothing found.
 fn which_all(name: &str) -> Vec<std::path::PathBuf> {
@@ -117,11 +234,9 @@ fn which_all_in(name: &str, path_var: Option<&std::ffi::OsStr>) -> Vec<std::path
         .collect()
 }
 
-/// Fill `target` with the resolved absolute path for `name` when multiple
+/// Fill `target` with the resolved absolute path for `name`. When multiple
 /// matches exist and we're in interactive mode, ask the user to pick one.
 /// Non-interactive mode falls back to the first match.
-/// interactive mode, ask the user to pick one. Non-interactive mode falls
-/// back to the first match (current behavior).
 fn fill_binary_path(target: &mut Option<String>, name: &str, interactive: bool) {
     // Treat Some("") as unset — normalizes legacy String-based configs.
     if !target.as_deref().unwrap_or("").is_empty() {
@@ -191,6 +306,7 @@ struct RuntimeReport {
     hint: &'static str,
     version: Option<String>,
     acp: AcpStatus,
+    auth: ProbeAuth,
 }
 
 fn check_runtime(name: &'static str, hint: &'static str, acp: AcpStatus) -> RuntimeReport {
@@ -212,21 +328,29 @@ fn check_runtime(name: &'static str, hint: &'static str, acp: AcpStatus) -> Runt
         }
         AcpStatus::Native => AcpStatus::Native,
     };
+    let auth = if version.is_some() {
+        check_auth(name)
+    } else {
+        ProbeAuth::NotInstalled
+    };
     RuntimeReport {
         name,
         hint,
         version,
         acp,
+        auth,
     }
 }
 
 fn render_runtime(r: &RuntimeReport) {
-    let (glyph, glyph_style): (Emoji<'_, '_>, _) = match &r.version {
-        Some(_) => (OK, "green"),
-        None => (BAD, "red"),
+    let (glyph, glyph_style): (Emoji<'_, '_>, _) = match (&r.version, &r.auth) {
+        (None, _) => (BAD, "red"),
+        (Some(_), ProbeAuth::Authed) => (OK, "green"),
+        (Some(_), _) => (WARN, "yellow"),
     };
     let glyph_styled = match glyph_style {
         "green" => style(glyph).green(),
+        "yellow" => style(glyph).yellow(),
         _ => style(glyph).red(),
     };
     let name = style(format!("{:<12}", r.name)).bold();
@@ -260,7 +384,25 @@ fn render_runtime(r: &RuntimeReport) {
             format!("{} {}", style("·").dim(), style("native ACP").dim())
         }
     };
-    println!("  {}{} {} {}", glyph_styled, name, version, acp_detail);
+    let auth_detail = match r.auth {
+        ProbeAuth::Authed => {
+            format!("{} {}", style("·").dim(), style("logged in").dim())
+        }
+        ProbeAuth::Unauthed => {
+            format!(
+                "{} {}",
+                style("·").dim(),
+                style("not logged in").dim()
+            )
+        }
+        ProbeAuth::NotInstalled => String::new(),
+    };
+    let detail = if auth_detail.is_empty() {
+        acp_detail
+    } else {
+        format!("{} {}", acp_detail, auth_detail)
+    };
+    println!("  {}{} {} {}", glyph_styled, name, version, detail);
 }
 
 fn check_template_dir(dir: &std::path::Path) -> (usize, usize) {
@@ -427,17 +569,6 @@ pub async fn run(
     ];
     for r in &runtimes {
         render_runtime(r);
-    }
-    let any_adapter_missing = runtimes
-        .iter()
-        .any(|r| r.version.is_some() && matches!(r.acp, AcpStatus::AdapterMissing(_)));
-    if any_adapter_missing {
-        println!(
-            "  {} {} {}",
-            style(" ").dim(),
-            style("ACP adaptors:").dim(),
-            style("https://github.com/openclaw/acpx").dim().italic()
-        );
     }
     let detected_runtimes: Vec<&str> = runtimes
         .iter()

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -95,12 +95,6 @@ fn extract_version(s: &str) -> Option<String> {
     re.find(s).map(|m| m.as_str().to_string())
 }
 
-/// Resolve an executable's absolute path by walking `$PATH`, the same way
-/// `which <name>` does. Returns `None` if the binary isn't found.
-fn which_tool(name: &str) -> Option<std::path::PathBuf> {
-    which_all(name).into_iter().next()
-}
-
 /// Return every absolute path where `name` is found on `$PATH`, deduped,
 /// in discovery order. Empty vec if nothing found.
 fn which_all(name: &str) -> Vec<std::path::PathBuf> {
@@ -123,21 +117,9 @@ fn which_all_in(name: &str, path_var: Option<&std::ffi::OsStr>) -> Vec<std::path
         .collect()
 }
 
-/// Fill `target` with the resolved absolute path for `name` iff `target`
-/// is currently unset or empty. Preserves any non-empty user-pinned value
-/// across re-runs. `Some("")` is treated as unset to handle legacy configs
-/// that stored an empty string instead of omitting the field.
-/// Always uses the first match; intended for ACP adapters where a silent
-/// choice is fine.
-fn fill_resolved_path(target: &mut Option<String>, name: &str) {
-    if target.as_deref().unwrap_or("").is_empty() {
-        if let Some(p) = which_tool(name) {
-            *target = Some(p.to_string_lossy().into_owned());
-        }
-    }
-}
-
-/// Like `fill_resolved_path`, but when multiple matches exist and we're in
+/// Fill `target` with the resolved absolute path for `name` when multiple
+/// matches exist and we're in interactive mode, ask the user to pick one.
+/// Non-interactive mode falls back to the first match.
 /// interactive mode, ask the user to pick one. Non-interactive mode falls
 /// back to the first match (current behavior).
 fn fill_binary_path(target: &mut Option<String>, name: &str, interactive: bool) {
@@ -424,12 +406,12 @@ pub async fn run(
         check_runtime(
             "claude",
             "https://docs.claude.com/en/docs/claude-code",
-            AcpStatus::AdapterMissing("claude-agent-acp"),
+            AcpStatus::Native,
         ),
         check_runtime(
             "codex",
             "https://github.com/openai/codex",
-            AcpStatus::AdapterMissing("codex-acp"),
+            AcpStatus::Native,
         ),
         check_runtime(
             "kimi",
@@ -528,9 +510,7 @@ pub async fn run(
     // AND /usr/local/bin), prompt interactively. ACP adapters always use
     // the first match — they're less likely to ship multiple versions.
     fill_binary_path(&mut cfg.claude.binary_path, "claude", interactive);
-    fill_resolved_path(&mut cfg.claude.acp_adaptor, "claude-agent-acp");
     fill_binary_path(&mut cfg.codex.binary_path, "codex", interactive);
-    fill_resolved_path(&mut cfg.codex.acp_adaptor, "codex-acp");
     fill_binary_path(&mut cfg.kimi.binary_path, "kimi", interactive);
     fill_binary_path(&mut cfg.opencode.binary_path, "opencode", interactive);
     fill_binary_path(&mut cfg.gemini.binary_path, "gemini", interactive);

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -115,7 +115,7 @@ fn check_auth(name: &str) -> ProbeAuth {
 }
 
 fn check_claude_auth() -> ProbeAuth {
-    let Ok(output) = Command::new("claude").args(&["auth", "status"]).output() else {
+    let Ok(output) = Command::new("claude").args(["auth", "status"]).output() else {
         return ProbeAuth::Unauthed;
     };
     if !output.status.success() {
@@ -134,7 +134,7 @@ fn check_claude_auth() -> ProbeAuth {
 }
 
 fn check_codex_auth() -> ProbeAuth {
-    let Ok(output) = Command::new("codex").args(&["login", "status"]).output() else {
+    let Ok(output) = Command::new("codex").args(["login", "status"]).output() else {
         return ProbeAuth::Unauthed;
     };
     let combined = format!(
@@ -152,13 +152,13 @@ fn check_codex_auth() -> ProbeAuth {
 
 fn check_kimi_auth() -> ProbeAuth {
     let has_access = Command::new("kimi")
-        .args(&["config", "get", "auth.access_token"])
+        .args(["config", "get", "auth.access_token"])
         .output()
         .ok()
         .filter(|o| o.status.success())
         .is_some_and(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty());
     let has_refresh = Command::new("kimi")
-        .args(&["config", "get", "auth.refresh_token"])
+        .args(["config", "get", "auth.refresh_token"])
         .output()
         .ok()
         .filter(|o| o.status.success())
@@ -171,10 +171,7 @@ fn check_kimi_auth() -> ProbeAuth {
 }
 
 fn check_opencode_auth() -> ProbeAuth {
-    let Ok(output) = Command::new("opencode")
-        .args(&["auth", "status"])
-        .output()
-    else {
+    let Ok(output) = Command::new("opencode").args(["auth", "status"]).output() else {
         return ProbeAuth::Unauthed;
     };
     if output.status.success() {
@@ -188,10 +185,7 @@ fn check_gemini_auth() -> ProbeAuth {
     if std::env::var("GEMINI_API_KEY").is_ok_and(|v| !v.trim().is_empty()) {
         return ProbeAuth::Authed;
     }
-    let Ok(output) = Command::new("gemini")
-        .args(&["auth", "status"])
-        .output()
-    else {
+    let Ok(output) = Command::new("gemini").args(["auth", "status"]).output() else {
         return ProbeAuth::Unauthed;
     };
     if !output.status.success() {
@@ -389,11 +383,7 @@ fn render_runtime(r: &RuntimeReport) {
             format!("{} {}", style("·").dim(), style("logged in").dim())
         }
         ProbeAuth::Unauthed => {
-            format!(
-                "{} {}",
-                style("·").dim(),
-                style("not logged in").dim()
-            )
+            format!("{} {}", style("·").dim(), style("not logged in").dim())
         }
         ProbeAuth::NotInstalled => String::new(),
     };

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -21,6 +21,7 @@ use crate::utils::error::{format_anyhow_error, AppErrorCode};
 use crate::utils::slug::{random_slug_suffix, slugify_base, MAX_SLUG_ATTEMPTS};
 
 use super::dto::AgentInfo;
+use crate::agent::runtime_catalog::{supports_reasoning_effort, supports_reasoning_effort_value};
 
 // ── Activity query params ──
 
@@ -168,8 +169,10 @@ pub(super) fn normalize_reasoning_effort(
     runtime: &str,
     reasoning_effort: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, Json<super::ErrorResponse>)> {
-    let parsed = AgentRuntime::parse(runtime);
-    if parsed != Some(AgentRuntime::Codex) && parsed != Some(AgentRuntime::Opencode) {
+    let Some(parsed) = AgentRuntime::parse(runtime) else {
+        return Ok(None);
+    };
+    if !supports_reasoning_effort(parsed) {
         return Ok(None);
     }
 
@@ -180,14 +183,13 @@ pub(super) fn normalize_reasoning_effort(
         return Ok(None);
     }
 
-    match reasoning_effort {
-        "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" => {
-            Ok(Some(reasoning_effort.to_string()))
-        }
-        _ => Err(app_err!(
+    if supports_reasoning_effort_value(parsed, reasoning_effort) {
+        Ok(Some(reasoning_effort.to_string()))
+    } else {
+        Err(app_err!(
             StatusCode::BAD_REQUEST,
             "unsupported reasoning effort: {reasoning_effort}"
-        )),
+        ))
     }
 }
 

--- a/src/server/handlers/dto.rs
+++ b/src/server/handlers/dto.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::agent::runtime_status::RuntimeStatusInfo;
+pub use crate::agent::runtime_status::RuntimeCatalogEntry;
 use crate::store::agents::Agent;
 use crate::store::channels::Channel;
 use crate::store::humans::Human;

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -272,7 +272,7 @@ pub async fn handle_update_human(
 
 pub async fn handle_list_runtime_statuses(
     State(state): State<AppState>,
-) -> ApiResult<Vec<dto::RuntimeStatusInfo>> {
+) -> ApiResult<Vec<dto::RuntimeCatalogEntry>> {
     let statuses = state
         .runtime_status_provider
         .list_statuses()

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -4,7 +4,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use chorus::agent::activity_log::ActivityLogResponse;
 use chorus::agent::drivers::ProbeAuth;
-use chorus::agent::runtime_status::{RuntimeStatusInfo, RuntimeStatusProvider};
+use chorus::agent::runtime_status::{RuntimeCatalogEntry, RuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
 use chorus::agent::AgentRuntime;
 use chorus::server::dto::ChannelInfo;
@@ -95,7 +95,7 @@ struct MockLifecycle {
 }
 
 struct MockRuntimeStatusProvider {
-    statuses: Vec<RuntimeStatusInfo>,
+    statuses: Vec<RuntimeCatalogEntry>,
     models_by_runtime: Vec<(String, Vec<String>)>,
 }
 
@@ -103,7 +103,7 @@ struct FailStartLifecycle;
 
 #[async_trait::async_trait]
 impl RuntimeStatusProvider for MockRuntimeStatusProvider {
-    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeStatusInfo>> {
+    async fn list_statuses(&self) -> anyhow::Result<Vec<RuntimeCatalogEntry>> {
         Ok(self.statuses.clone())
     }
 
@@ -294,7 +294,7 @@ fn setup_with_lifecycle() -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
 }
 
 fn setup_with_runtime_statuses(
-    statuses: Vec<RuntimeStatusInfo>,
+    statuses: Vec<RuntimeCatalogEntry>,
     models_by_runtime: Vec<(String, Vec<String>)>,
 ) -> (Arc<Store>, axum::Router, Arc<MockLifecycle>) {
     let store = Arc::new(Store::open(":memory:").unwrap());
@@ -1318,18 +1318,9 @@ async fn test_whoami() {
 async fn test_list_runtime_statuses() {
     let (_store, app, _lifecycle) = setup_with_runtime_statuses(
         vec![
-            RuntimeStatusInfo {
-                runtime: "claude".to_string(),
-                auth: ProbeAuth::Authed,
-            },
-            RuntimeStatusInfo {
-                runtime: "codex".to_string(),
-                auth: ProbeAuth::Unauthed,
-            },
-            RuntimeStatusInfo {
-                runtime: "kimi".to_string(),
-                auth: ProbeAuth::NotInstalled,
-            },
+            RuntimeCatalogEntry::new(AgentRuntime::Claude, ProbeAuth::Authed),
+            RuntimeCatalogEntry::new(AgentRuntime::Codex, ProbeAuth::Unauthed),
+            RuntimeCatalogEntry::new(AgentRuntime::Kimi, ProbeAuth::NotInstalled),
         ],
         vec![],
     );
@@ -1354,10 +1345,25 @@ async fn test_list_runtime_statuses() {
         .expect("runtimes payload should be an array");
     assert_eq!(runtimes.len(), 3);
     assert_eq!(runtimes[0]["runtime"], "claude");
+    assert_eq!(runtimes[0]["label"], "Claude Code");
+    assert_eq!(runtimes[0]["order"], 0);
+    assert_eq!(
+        runtimes[0]["reasoning_efforts"],
+        serde_json::json!(["low", "medium", "high", "xhigh", "max"])
+    );
     assert_eq!(runtimes[0]["auth"], "authed");
     assert_eq!(runtimes[1]["runtime"], "codex");
+    assert_eq!(runtimes[1]["label"], "Codex CLI");
+    assert_eq!(runtimes[1]["order"], 1);
+    assert_eq!(
+        runtimes[1]["reasoning_efforts"],
+        serde_json::json!(["low", "medium", "high", "xhigh"])
+    );
     assert_eq!(runtimes[1]["auth"], "unauthed");
     assert_eq!(runtimes[2]["runtime"], "kimi");
+    assert_eq!(runtimes[2]["label"], "Kimi CLI");
+    assert_eq!(runtimes[2]["order"], 2);
+    assert_eq!(runtimes[2]["reasoning_efforts"], serde_json::json!([]));
     assert_eq!(runtimes[2]["auth"], "not_installed");
 }
 

--- a/ui/src/components/agents/AgentConfigForm.test.ts
+++ b/ui/src/components/agents/AgentConfigForm.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { isRuntimeAvailable, modelSelectDisplayLabel, runtimeOptionLabel, runtimeStatusSummary } from './AgentConfigForm'
+import {
+  isRuntimeAvailable,
+  modelSelectDisplayLabel,
+  runtimeOptionLabel,
+  runtimeReasoningEffortOptions,
+  runtimeStatusSummary,
+} from './AgentConfigForm'
 
 describe('runtimeOptionLabel', () => {
   it('shows not installed copy when the runtime is missing', () => {
@@ -16,6 +22,14 @@ describe('runtimeOptionLabel', () => {
         { runtime: 'claude', auth: 'authed' as const },
       ])
     ).toContain('signed in')
+  })
+
+  it('uses the Gemini label for gemini runtimes', () => {
+    expect(
+      runtimeOptionLabel('gemini', [
+        { runtime: 'gemini', auth: 'authed' as const },
+      ])
+    ).toContain('Gemini CLI')
   })
 })
 
@@ -71,5 +85,39 @@ describe('modelSelectDisplayLabel', () => {
       runtimeModels: ['openai/codex-mini-latest'],
       isLoading: false,
     })).toBe('openai/codex-mini-latest')
+  })
+})
+
+describe('runtimeReasoningEffortOptions', () => {
+  it('uses the runtime-provided reasoning effort list', () => {
+    expect(
+      runtimeReasoningEffortOptions('codex', [
+        {
+          runtime: 'codex',
+          label: 'Codex CLI',
+          order: 1,
+          reasoning_efforts: ['low', 'max'],
+          auth: 'authed' as const,
+        },
+      ])
+    ).toEqual([
+      { value: 'default', label: 'Default' },
+      { value: 'low', label: 'Low' },
+      { value: 'max', label: 'Max' },
+    ])
+  })
+
+  it('returns no options when the runtime exposes no reasoning efforts', () => {
+    expect(
+      runtimeReasoningEffortOptions('gemini', [
+        {
+          runtime: 'gemini',
+          label: 'Gemini CLI',
+          order: 4,
+          reasoning_efforts: [],
+          auth: 'authed' as const,
+        },
+      ])
+    ).toEqual([])
   })
 })

--- a/ui/src/components/agents/AgentConfigForm.tsx
+++ b/ui/src/components/agents/AgentConfigForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { LoaderCircle } from "lucide-react";
-import type { AgentEnvVar, RuntimeStatusInfo } from "./types";
+import type { AgentEnvVar, RuntimeCatalogEntry } from "./types";
 import { useRuntimeModels } from "../../hooks/useRuntimeModels";
 import {
   Select,
@@ -25,7 +25,18 @@ export const REASONING_EFFORTS = [
   { value: "medium", label: "Medium" },
   { value: "high", label: "High" },
   { value: "xhigh", label: "Extra High" },
+  { value: "max", label: "Max" },
 ];
+
+const DEFAULT_REASONING_OPTION = REASONING_EFFORTS[0];
+
+export const RUNTIME_OPTIONS = [
+  { value: "claude", label: "Claude Code" },
+  { value: "codex", label: "Codex CLI" },
+  { value: "kimi", label: "Kimi CLI" },
+  { value: "opencode", label: "OpenCode" },
+  { value: "gemini", label: "Gemini CLI" },
+] as const;
 
 export interface AgentConfigState {
   name: string;
@@ -40,43 +51,118 @@ export interface AgentConfigState {
 
 interface Props {
   state: AgentConfigState;
-  runtimeStatuses?: RuntimeStatusInfo[];
+  runtimeStatuses?: RuntimeCatalogEntry[];
   runtimeStatusError?: string | null;
   onChange: (next: AgentConfigState) => void;
 }
 
+function findRuntimeStatus(
+  runtime: string,
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): RuntimeCatalogEntry | undefined {
+  return runtimeStatuses.find((entry) => entry.runtime === runtime);
+}
+
+function fallbackRuntimeLabel(runtime: string): string {
+  return (
+    RUNTIME_OPTIONS.find((option) => option.value === runtime)?.label ?? runtime
+  );
+}
+
+function reasoningEffortLabel(value: string): string {
+  return (
+    REASONING_EFFORTS.find((option) => option.value === value)?.label ?? value
+  );
+}
+
+export function runtimeCatalog(
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): Array<{ value: string; label: string }> {
+  if (runtimeStatuses.length === 0) {
+    return RUNTIME_OPTIONS.map((runtime) => ({ ...runtime }));
+  }
+
+  return [...runtimeStatuses]
+    .sort(
+      (left, right) =>
+        (left.order ?? Number.MAX_SAFE_INTEGER) -
+        (right.order ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map((runtimeStatus) => ({
+      value: runtimeStatus.runtime,
+      label: runtimeStatus.label ?? fallbackRuntimeLabel(runtimeStatus.runtime),
+    }));
+}
+
+export function runtimeReasoningEffortValues(
+  runtime: string,
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): string[] {
+  return findRuntimeStatus(runtime, runtimeStatuses)?.reasoning_efforts ?? [];
+}
+
+export function runtimeSupportsReasoningEffort(
+  runtime: string,
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): boolean {
+  return runtimeReasoningEffortValues(runtime, runtimeStatuses).length > 0;
+}
+
+export function runtimeReasoningEffortOptions(
+  runtime: string,
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): Array<{ value: string; label: string }> {
+  const efforts = runtimeReasoningEffortValues(runtime, runtimeStatuses);
+  if (efforts.length === 0) {
+    return [];
+  }
+
+  return [
+    DEFAULT_REASONING_OPTION,
+    ...efforts.map((value) => ({ value, label: reasoningEffortLabel(value) })),
+  ];
+}
+
+export function normalizeRuntimeReasoningEffort(
+  runtime: string,
+  reasoningEffort: string | null,
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
+): string | null {
+  const efforts = runtimeReasoningEffortValues(runtime, runtimeStatuses);
+  if (efforts.length === 0) {
+    return null;
+  }
+
+  return reasoningEffort && efforts.includes(reasoningEffort)
+    ? reasoningEffort
+    : null;
+}
+
 export function runtimeOptionLabel(
   runtime: string,
-  runtimeStatuses: RuntimeStatusInfo[] = [],
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
 ): string {
-  const baseLabel =
-    runtime === "claude"
-      ? "Claude Code"
-      : runtime === "codex"
-        ? "Codex CLI"
-        : runtime === "opencode"
-          ? "OpenCode"
-          : "Kimi CLI";
-  const status = runtimeStatuses.find((entry) => entry.runtime === runtime);
+  const status = findRuntimeStatus(runtime, runtimeStatuses);
+  const baseLabel = status?.label ?? fallbackRuntimeLabel(runtime);
   if (!status) return `${baseLabel} · status unavailable`;
-  if (status.auth === 'not_installed') return `${baseLabel} · not installed`;
-  if (status.auth === 'authed') return `${baseLabel} · signed in`;
+  if (status.auth === "not_installed") return `${baseLabel} · not installed`;
+  if (status.auth === "authed") return `${baseLabel} · signed in`;
   return `${baseLabel} · not signed in`;
 }
 
 export function isRuntimeAvailable(
   runtime: string,
-  runtimeStatuses: RuntimeStatusInfo[] = [],
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
 ): boolean {
-  const status = runtimeStatuses.find((entry) => entry.runtime === runtime);
-  return status?.auth !== 'not_installed' && status?.auth !== undefined;
+  const status = findRuntimeStatus(runtime, runtimeStatuses);
+  return status?.auth !== "not_installed" && status?.auth !== undefined;
 }
 
 export function runtimeStatusSummary(
   runtime: string,
-  runtimeStatuses: RuntimeStatusInfo[] = [],
+  runtimeStatuses: RuntimeCatalogEntry[] = [],
 ): { tone: "ok" | "warn" | "muted"; title: string; detail: string } {
-  const status = runtimeStatuses.find((entry) => entry.runtime === runtime);
+  const status = findRuntimeStatus(runtime, runtimeStatuses);
   if (!status) {
     return {
       tone: "muted",
@@ -84,14 +170,14 @@ export function runtimeStatusSummary(
       detail: "The local runtime probe did not return a status for this CLI.",
     };
   }
-  if (status.auth === 'not_installed') {
+  if (status.auth === "not_installed") {
     return {
       tone: "warn",
       title: "Not installed",
       detail: "This runtime is not available on the local machine yet.",
     };
   }
-  if (status.auth === 'authed') {
+  if (status.auth === "authed") {
     return {
       tone: "ok",
       title: "Signed in",
@@ -142,7 +228,9 @@ export function AgentConfigForm({
   runtimeStatusError = null,
   onChange,
 }: Props) {
-  const { runtimeModels, runtimeModelsError, isLoading } = useRuntimeModels(state.runtime);
+  const { runtimeModels, runtimeModelsError, isLoading } = useRuntimeModels(
+    state.runtime,
+  );
 
   useEffect(() => {
     if (runtimeModels.length === 0 || runtimeModels.includes(state.model)) {
@@ -177,6 +265,11 @@ export function AgentConfigForm({
   }
 
   const runtimeSummary = runtimeStatusSummary(state.runtime, runtimeStatuses);
+  const runtimeOptions = runtimeCatalog(runtimeStatuses);
+  const reasoningOptions = runtimeReasoningEffortOptions(
+    state.runtime,
+    runtimeStatuses,
+  );
   const modelLabel = modelSelectDisplayLabel({
     selectedModel: state.model,
     runtimeModels,
@@ -237,10 +330,11 @@ export function AgentConfigForm({
                   ...state,
                   runtime,
                   model: "",
-                  reasoningEffort:
-                    runtime === "codex" || runtime === "opencode"
-                      ? (state.reasoningEffort ?? "default")
-                      : null,
+                  reasoningEffort: normalizeRuntimeReasoningEffort(
+                    runtime,
+                    state.reasoningEffort,
+                    runtimeStatuses,
+                  ),
                 });
               }}
             >
@@ -248,30 +342,17 @@ export function AgentConfigForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem
-                  value="claude"
-                  disabled={!isRuntimeAvailable("claude", runtimeStatuses)}
-                >
-                  {runtimeOptionLabel("claude", runtimeStatuses)}
-                </SelectItem>
-                <SelectItem
-                  value="codex"
-                  disabled={!isRuntimeAvailable("codex", runtimeStatuses)}
-                >
-                  {runtimeOptionLabel("codex", runtimeStatuses)}
-                </SelectItem>
-                <SelectItem
-                  value="kimi"
-                  disabled={!isRuntimeAvailable("kimi", runtimeStatuses)}
-                >
-                  {runtimeOptionLabel("kimi", runtimeStatuses)}
-                </SelectItem>
-                <SelectItem
-                  value="opencode"
-                  disabled={!isRuntimeAvailable("opencode", runtimeStatuses)}
-                >
-                  {runtimeOptionLabel("opencode", runtimeStatuses)}
-                </SelectItem>
+                {runtimeOptions.map((runtime) => (
+                  <SelectItem
+                    key={runtime.value}
+                    value={runtime.value}
+                    disabled={
+                      !isRuntimeAvailable(runtime.value, runtimeStatuses)
+                    }
+                  >
+                    {runtimeOptionLabel(runtime.value, runtimeStatuses)}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
             <div
@@ -297,7 +378,10 @@ export function AgentConfigForm({
               <SelectTrigger aria-label="Model">
                 {isLoading ? (
                   <span className="select-trigger-loading">
-                    <LoaderCircle size={14} className="select-trigger-spinner" />
+                    <LoaderCircle
+                      size={14}
+                      className="select-trigger-spinner"
+                    />
                     <span>{modelLabel}</span>
                   </span>
                 ) : (
@@ -326,7 +410,7 @@ export function AgentConfigForm({
             )}
           </FormField>
 
-          {(state.runtime === "codex" || state.runtime === "opencode") && (
+          {reasoningOptions.length > 0 && (
             <FormField>
               <Label>Reasoning</Label>
               <Select
@@ -342,7 +426,7 @@ export function AgentConfigForm({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {REASONING_EFFORTS.map((effort) => (
+                  {reasoningOptions.map((effort) => (
                     <SelectItem key={effort.value} value={effort.value}>
                       {effort.label}
                     </SelectItem>

--- a/ui/src/components/agents/CreateAgentModal.tsx
+++ b/ui/src/components/agents/CreateAgentModal.tsx
@@ -1,139 +1,165 @@
-import { useState, useEffect } from 'react'
-import { ArrowLeft } from 'lucide-react'
-import { post } from '@/data/client'
-import { useRuntimeStatuses } from '../../hooks/useRuntimeStatuses'
-import { useTemplates } from '../../hooks/useTemplates'
-import { AgentConfigForm, type AgentConfigState } from './AgentConfigForm'
-import { TemplateGallery, TemplatePreview } from './TemplateGallery'
-import { LaunchTrio } from './LaunchTrio'
-import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose } from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import { FormError } from '@/components/ui/form'
-import type { AgentTemplate } from '../../hooks/useTemplates'
-import './CreateAgentModal.css'
+import { useState, useEffect } from "react";
+import { ArrowLeft } from "lucide-react";
+import { post } from "@/data/client";
+import { useRuntimeStatuses } from "../../hooks/useRuntimeStatuses";
+import { useTemplates } from "../../hooks/useTemplates";
+import {
+  AgentConfigForm,
+  runtimeCatalog,
+  runtimeSupportsReasoningEffort,
+  type AgentConfigState,
+} from "./AgentConfigForm";
+import { TemplateGallery, TemplatePreview } from "./TemplateGallery";
+import { LaunchTrio } from "./LaunchTrio";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form";
+import type { AgentTemplate } from "../../hooks/useTemplates";
+import "./CreateAgentModal.css";
 
 interface Props {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  onCreated: () => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
 }
 
 const EMPTY_CONFIG: AgentConfigState = {
-  name: '',
-  display_name: '',
-  description: '',
+  name: "",
+  display_name: "",
+  description: "",
   systemPrompt: null,
-  runtime: 'claude',
-  model: '',
+  runtime: "claude",
+  model: "",
   reasoningEffort: null,
   envVars: [],
-}
+};
 
-const RUNTIME_ORDER = ['claude', 'codex', 'kimi', 'opencode']
-
-type Step = 'browse' | 'configure'
+type Step = "browse" | "configure";
 
 export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
-  const [step, setStep] = useState<Step>('browse')
-  const [config, setConfig] = useState<AgentConfigState>({ ...EMPTY_CONFIG })
-  const [selectedTemplate, setSelectedTemplate] = useState<AgentTemplate | null>(null)
-  const [creating, setCreating] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const { runtimeStatuses, runtimeStatusError } = useRuntimeStatuses(open)
-  const { categories, allTemplates, isLoading: templatesLoading } = useTemplates(open)
+  const [step, setStep] = useState<Step>("browse");
+  const [config, setConfig] = useState<AgentConfigState>({ ...EMPTY_CONFIG });
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<AgentTemplate | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { runtimeStatuses, runtimeStatusError } = useRuntimeStatuses(open);
+  const {
+    categories,
+    allTemplates,
+    isLoading: templatesLoading,
+  } = useTemplates(open);
 
-  const hasTemplates = !templatesLoading && allTemplates.length > 0
+  const hasTemplates = !templatesLoading && allTemplates.length > 0;
 
   function handleTemplateSelect(template: AgentTemplate | null) {
-    if (!template) return
-    setSelectedTemplate(template)
+    if (!template) return;
+    setSelectedTemplate(template);
     setConfig({
-      name: '',
+      name: "",
       display_name: template.name,
-      description: template.description ?? '',
+      description: template.description ?? "",
       systemPrompt: template.prompt_body,
       runtime: template.suggested_runtime,
-      model: '',
+      model: "",
       reasoningEffort: null,
       envVars: [],
-    })
-    setStep('configure')
+    });
+    setStep("configure");
   }
 
   function handleFromScratch() {
-    setSelectedTemplate(null)
-    setConfig({ ...EMPTY_CONFIG })
-    setStep('configure')
+    setSelectedTemplate(null);
+    setConfig({ ...EMPTY_CONFIG });
+    setStep("configure");
   }
 
   function handleBack() {
-    setSelectedTemplate(null)
-    setConfig({ ...EMPTY_CONFIG })
-    setStep('browse')
+    setSelectedTemplate(null);
+    setConfig({ ...EMPTY_CONFIG });
+    setStep("browse");
   }
 
   function handleTrioLaunched(_channelId: string) {
-    onCreated()
+    onCreated();
   }
 
   // Reset everything when modal closes.
   useEffect(() => {
     if (!open) {
-      setStep('browse')
-      setConfig({ ...EMPTY_CONFIG })
-      setSelectedTemplate(null)
-      setError(null)
+      setStep("browse");
+      setConfig({ ...EMPTY_CONFIG });
+      setSelectedTemplate(null);
+      setError(null);
     }
-  }, [open])
+  }, [open]);
 
   // If no templates, skip straight to configure step.
   useEffect(() => {
     if (open && !templatesLoading && !hasTemplates) {
-      setStep('configure')
+      setStep("configure");
     }
-  }, [open, templatesLoading, hasTemplates])
+  }, [open, templatesLoading, hasTemplates]);
 
   // Default to the first installed ACP runtime once statuses load.
   // `display_name` is the now-sole proxy for "the user has a template
   // or has started filling in the form" and must not be overwritten.
   useEffect(() => {
-    if (runtimeStatuses.length === 0 || config.display_name !== '') return
-    const acpRuntime = RUNTIME_ORDER.find((rt) =>
-      runtimeStatuses.find((s) => s.runtime === rt && s.auth === 'authed'),
-    )
+    if (runtimeStatuses.length === 0 || config.display_name !== "") return;
+    const acpRuntime = runtimeCatalog(runtimeStatuses).find(({ value }) =>
+      runtimeStatuses.find(
+        (status) => status.runtime === value && status.auth === "authed",
+      ),
+    )?.value;
     if (acpRuntime && acpRuntime !== config.runtime) {
-      setConfig((prev) => ({ ...prev, runtime: acpRuntime, model: '' }))
+      setConfig((prev) => ({ ...prev, runtime: acpRuntime, model: "" }));
     }
-  }, [runtimeStatuses]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [runtimeStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleCreate() {
     if (!config.display_name.trim()) {
-      setError('Name is required')
-      return
+      setError("Name is required");
+      return;
     }
-    setCreating(true)
-    setError(null)
+    setCreating(true);
+    setError(null);
     try {
       if (!config.model.trim()) {
-        throw new Error('Model is required')
+        throw new Error("Model is required");
       }
-      await post<{ name: string; status: string; warning?: string }>('/api/agents', {
+      await post<{ name: string; status: string; warning?: string }>(
+        "/api/agents",
+        {
           // Slug derivation lives on the server; we send the human-facing
           // name only and let the backend produce `{base}-{hex4}`.
-          name: '',
+          name: "",
           display_name: config.display_name.trim(),
           description: config.description,
           systemPrompt: config.systemPrompt || null,
           runtime: config.runtime,
           model: config.model,
-          reasoningEffort: config.runtime === 'codex' || config.runtime === 'opencode' ? config.reasoningEffort : null,
+          reasoningEffort: runtimeSupportsReasoningEffort(
+            config.runtime,
+            runtimeStatuses,
+          )
+            ? config.reasoningEffort
+            : null,
           envVars: config.envVars,
-        })
-      onCreated()
+        },
+      );
+      onCreated();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
-      setCreating(false)
+      setCreating(false);
     }
   }
 
@@ -143,7 +169,9 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
         <DialogHeader>
           <div className="flex flex-col gap-1">
             <DialogTitle>
-              {step === 'browse' ? 'Create Agent' : (
+              {step === "browse" ? (
+                "Create Agent"
+              ) : (
                 <span className="modal-title-with-back">
                   <button
                     onClick={handleBack}
@@ -157,14 +185,20 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
               )}
             </DialogTitle>
             <DialogDescription>
-              {step === 'browse' ? '[agent::new]' : (selectedTemplate ? selectedTemplate.name : '[from scratch]')}
+              {step === "browse"
+                ? "[agent::new]"
+                : selectedTemplate
+                  ? selectedTemplate.name
+                  : "[from scratch]"}
             </DialogDescription>
           </div>
-          <DialogClose className="h-8 w-8 grid place-items-center text-muted-foreground hover:bg-secondary hover:text-foreground">×</DialogClose>
+          <DialogClose className="h-8 w-8 grid place-items-center text-muted-foreground hover:bg-secondary hover:text-foreground">
+            ×
+          </DialogClose>
         </DialogHeader>
 
         {/* Step 1: Browse templates */}
-        {step === 'browse' && (
+        {step === "browse" && (
           <>
             <LaunchTrio
               allTemplates={allTemplates}
@@ -173,7 +207,9 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
 
             <div className="system-message-divider">
               <div className="system-message-divider__line" />
-              <span className="system-message-divider__label">or choose a template</span>
+              <span className="system-message-divider__label">
+                or choose a template
+              </span>
               <div className="system-message-divider__line" />
             </div>
 
@@ -184,7 +220,9 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
             />
 
             <DialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
               <Button variant="outline" onClick={handleFromScratch}>
                 Create from scratch
               </Button>
@@ -193,9 +231,11 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
         )}
 
         {/* Step 2: Configure agent */}
-        {step === 'configure' && (
+        {step === "configure" && (
           <>
-            {selectedTemplate && <TemplatePreview template={selectedTemplate} />}
+            {selectedTemplate && (
+              <TemplatePreview template={selectedTemplate} />
+            )}
 
             <AgentConfigForm
               state={config}
@@ -208,19 +248,27 @@ export function CreateAgentModal({ open, onOpenChange, onCreated }: Props) {
 
             <DialogFooter>
               {hasTemplates && (
-                <Button variant="outline" onClick={handleBack}>Back</Button>
+                <Button variant="outline" onClick={handleBack}>
+                  Back
+                </Button>
               )}
-              <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
               <Button
                 onClick={handleCreate}
-                disabled={creating || !config.display_name.trim() || !config.model.trim()}
+                disabled={
+                  creating ||
+                  !config.display_name.trim() ||
+                  !config.model.trim()
+                }
               >
-                {creating ? 'Creating...' : 'Create Agent'}
+                {creating ? "Creating..." : "Create Agent"}
               </Button>
             </DialogFooter>
           </>
         )}
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/ui/src/components/agents/profile/ProfilePanel.tsx
+++ b/ui/src/components/agents/profile/ProfilePanel.tsx
@@ -11,13 +11,15 @@ import type {
   AgentDetailResponse,
   DeleteMode,
   RestartMode,
-  RuntimeStatusInfo,
+  RuntimeCatalogEntry,
 } from "../../../data";
 import { useRuntimeStatuses } from "../../../hooks/useRuntimeStatuses";
 import { useStore } from "../../../store";
 import { useRefresh } from "../../../hooks/data";
 import {
   AgentConfigForm,
+  normalizeRuntimeReasoningEffort,
+  runtimeReasoningEffortOptions,
   runtimeStatusSummary,
   type AgentConfigState,
 } from "../AgentConfigForm";
@@ -108,6 +110,10 @@ export function ProfilePanel() {
   const envVars = detail?.envVars ?? [];
   const reasoningEffort =
     agent.reasoningEffort ?? detail?.agent.reasoningEffort ?? null;
+  const reasoningOptions = runtimeReasoningEffortOptions(
+    agent.runtime ?? "claude",
+    runtimeStatuses,
+  );
   const runtimeSummary = runtimeStatusSummary(
     agent.runtime ?? "claude",
     runtimeStatuses,
@@ -209,11 +215,13 @@ export function ProfilePanel() {
           </span>
           <span className="profile-config-key">Auth</span>
           <span className="badge">
-            {runtimeStatuses.find((s) => s.runtime === (agent.runtime ?? "claude"))?.auth ?? "unknown"}
+            {runtimeStatuses.find(
+              (s) => s.runtime === (agent.runtime ?? "claude"),
+            )?.auth ?? "unknown"}
           </span>
           <span className="profile-config-key">Model</span>
           <span className="badge">{agent.model ?? "sonnet"}</span>
-          {agent.runtime === "codex" && (
+          {reasoningOptions.length > 0 && (
             <>
               <span className="profile-config-key">Reasoning</span>
               <span className="badge">{reasoningEffort ?? "default"}</span>
@@ -223,13 +231,14 @@ export function ProfilePanel() {
           <span
             className="badge"
             style={{
-              background: agent.status === "working"
-                ? "var(--status-sleeping)"
-                : agent.status === "ready"
-                  ? "var(--status-online)"
-                  : agent.status === "failed"
-                    ? "var(--status-failed)"
-                    : "var(--status-inactive)",
+              background:
+                agent.status === "working"
+                  ? "var(--status-sleeping)"
+                  : agent.status === "ready"
+                    ? "var(--status-online)"
+                    : agent.status === "failed"
+                      ? "var(--status-failed)"
+                      : "var(--status-inactive)",
             }}
           >
             {agent.status}
@@ -276,10 +285,11 @@ export function ProfilePanel() {
             systemPrompt: detail.agent.systemPrompt ?? null,
             runtime: detail.agent.runtime ?? "claude",
             model: detail.agent.model ?? "sonnet",
-            reasoningEffort:
-              detail.agent.runtime === "codex"
-                ? (detail.agent.reasoningEffort ?? "default")
-                : null,
+            reasoningEffort: normalizeRuntimeReasoningEffort(
+              detail.agent.runtime ?? "claude",
+              detail.agent.reasoningEffort ?? null,
+              runtimeStatuses,
+            ),
             envVars: detail.envVars,
           }}
           runtimeStatuses={runtimeStatuses}
@@ -332,7 +342,7 @@ function EditAgentModal({
   agentId: string;
   agentName: string;
   initialState: AgentConfigState;
-  runtimeStatuses: RuntimeStatusInfo[];
+  runtimeStatuses: RuntimeCatalogEntry[];
   runtimeStatusError: string | null;
   onOpenChange: (open: boolean) => void;
   onSaved: () => Promise<void>;
@@ -353,10 +363,11 @@ function EditAgentModal({
         description: state.description,
         runtime: state.runtime,
         model: state.model,
-        reasoningEffort:
-          state.runtime === "codex" || state.runtime === "opencode"
-            ? state.reasoningEffort
-            : null,
+        reasoningEffort: normalizeRuntimeReasoningEffort(
+          state.runtime,
+          state.reasoningEffort,
+          runtimeStatuses,
+        ),
         envVars: state.envVars.filter(
           (envVar) => envVar.key.trim() || envVar.value,
         ),

--- a/ui/src/components/agents/types.ts
+++ b/ui/src/components/agents/types.ts
@@ -2,7 +2,7 @@ export type {
   AgentInfo,
   AgentEnvVar,
   ProbeAuth,
-  RuntimeStatusInfo,
+  RuntimeCatalogEntry,
   AgentDetailResponse,
   ActivityMessage,
   ActivityResponse,

--- a/ui/src/components/ui/async-select.tsx
+++ b/ui/src/components/ui/async-select.tsx
@@ -1,12 +1,12 @@
-import { Loader2, ChevronDown } from "lucide-react"
+import { Loader2, ChevronDown } from "lucide-react";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select"
-import { cn } from "@/lib/cn"
+} from "@/components/ui/select";
+import { cn } from "@/lib/cn";
 
 function SelectSkeleton({ className }: { className?: string }) {
   return (
@@ -16,7 +16,7 @@ function SelectSkeleton({ className }: { className?: string }) {
         "min-h-[46px] px-3 py-2",
         "border border-input rounded-none bg-muted",
         "opacity-60",
-        className
+        className,
       )}
     >
       <span className="flex items-center gap-2 text-muted-foreground text-[13px] font-mono">
@@ -25,19 +25,19 @@ function SelectSkeleton({ className }: { className?: string }) {
       </span>
       <ChevronDown className="h-4 w-4 opacity-50" />
     </div>
-  )
+  );
 }
 
 export interface AsyncSelectProps {
-  value: string
-  onValueChange: (value: string) => void
-  options: { value: string; label: string }[]
-  placeholder?: string
-  isLoading?: boolean
-  error?: string | null
-  emptyMessage?: string
-  disabled?: boolean
-  className?: string
+  value: string;
+  onValueChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  isLoading?: boolean;
+  error?: string | null;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
 }
 
 function AsyncSelect({
@@ -52,18 +52,29 @@ function AsyncSelect({
   className,
 }: AsyncSelectProps) {
   if (isLoading && !value) {
-    return <SelectSkeleton className={className} />
+    return <SelectSkeleton className={className} />;
   }
 
   return (
-    <Select value={value} onValueChange={onValueChange} disabled={disabled || isLoading}>
-      <SelectTrigger className={cn(error && "border-destructive bg-destructive/10", className)}>
+    <Select
+      value={value}
+      onValueChange={onValueChange}
+      disabled={disabled || isLoading}
+    >
+      <SelectTrigger
+        className={cn(
+          error && "border-destructive bg-destructive/10",
+          className,
+        )}
+      >
         <SelectValue placeholder={placeholder} />
         {isLoading && <Loader2 className="h-4 w-4 animate-spin ml-auto mr-2" />}
       </SelectTrigger>
       <SelectContent>
         {options.length === 0 ? (
-          <div className="px-3 py-2 text-muted-foreground text-sm">{emptyMessage}</div>
+          <div className="px-3 py-2 text-muted-foreground text-sm">
+            {emptyMessage}
+          </div>
         ) : (
           options.map((opt) => (
             <SelectItem key={opt.value} value={opt.value}>
@@ -73,23 +84,23 @@ function AsyncSelect({
         )}
       </SelectContent>
     </Select>
-  )
+  );
 }
 
-export interface RuntimeStatusInfo {
-  runtime: string
-  installed: boolean
-  authenticated: boolean
-  label?: string
+export interface RuntimeSelectEntry {
+  runtime: string;
+  installed: boolean;
+  authenticated: boolean;
+  label?: string;
 }
 
 export interface RuntimeSelectProps {
-  value: string
-  onValueChange: (value: string) => void
-  runtimes: RuntimeStatusInfo[]
-  isLoading?: boolean
-  error?: string | null
-  className?: string
+  value: string;
+  onValueChange: (value: string) => void;
+  runtimes: RuntimeSelectEntry[];
+  isLoading?: boolean;
+  error?: string | null;
+  className?: string;
 }
 
 function RuntimeSelect({
@@ -103,7 +114,7 @@ function RuntimeSelect({
   const options = runtimes.map((rt) => ({
     value: rt.runtime,
     label: rt.label || rt.runtime,
-  }))
+  }));
 
   return (
     <AsyncSelect
@@ -116,7 +127,7 @@ function RuntimeSelect({
       emptyMessage="No runtimes available"
       className={className}
     />
-  )
+  );
 }
 
-export { AsyncSelect, RuntimeSelect, SelectSkeleton }
+export { AsyncSelect, RuntimeSelect, SelectSkeleton };

--- a/ui/src/data/agents.ts
+++ b/ui/src/data/agents.ts
@@ -29,8 +29,11 @@ export interface AgentEnvVar {
 
 export type ProbeAuth = 'not_installed' | 'unauthed' | 'authed'
 
-export interface RuntimeStatusInfo {
+export interface RuntimeCatalogEntry {
   runtime: 'claude' | 'codex' | 'kimi' | 'opencode' | string
+  label?: string
+  order?: number
+  reasoning_efforts?: string[]
   auth: ProbeAuth
 }
 
@@ -136,7 +139,7 @@ export function deleteAgent(
   return post(`/api/agents/${encodeURIComponent(agentId)}/delete`, { mode } as DeleteAgentRequest)
 }
 
-export function listRuntimeStatuses(): Promise<RuntimeStatusInfo[]> {
+export function listRuntimeStatuses(): Promise<RuntimeCatalogEntry[]> {
   return get('/api/runtimes')
 }
 

--- a/ui/src/data/index.ts
+++ b/ui/src/data/index.ts
@@ -88,7 +88,7 @@ export {
   type AgentRunInfo,
   type AgentRunsResponse,
   type ProbeAuth,
-  type RuntimeStatusInfo,
+  type RuntimeCatalogEntry,
   type AgentDetailResponse,
   type ActivityMessage,
   type ActivityResponse,

--- a/ui/src/hooks/useRuntimeStatuses.ts
+++ b/ui/src/hooks/useRuntimeStatuses.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 import { listRuntimeStatuses } from '../data'
-import type { RuntimeStatusInfo } from '../data'
+import type { RuntimeCatalogEntry } from '../data'
 
 export function useRuntimeStatuses(enabled = true): {
-  runtimeStatuses: RuntimeStatusInfo[]
+  runtimeStatuses: RuntimeCatalogEntry[]
   runtimeStatusError: string | null
 } {
-  const [runtimeStatuses, setRuntimeStatuses] = useState<RuntimeStatusInfo[]>([])
+  const [runtimeStatuses, setRuntimeStatuses] = useState<RuntimeCatalogEntry[]>([])
   const [runtimeStatusError, setRuntimeStatusError] = useState<string | null>(null)
 
   useEffect(() => {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -15,7 +15,7 @@ export type {
   AgentInfo,
   AgentEnvVar,
   ProbeAuth,
-  RuntimeStatusInfo,
+  RuntimeCatalogEntry,
   AgentDetailResponse,
   ActivityMessage,
   ActivityResponse,


### PR DESCRIPTION
## Problem

`chorus setup` was falsely reporting that `claude-agent-acp` and `codex-acp` were missing, showing:

```
✓ claude       2.1.116    · claude-agent-acp found
✓ codex        0.118.0    · codex-acp missing → raw mode
```

This was misleading. Neither driver actually uses an external ACP adaptor anymore.

## What changed

- **Claude**: speaks native `claude -p --output-format stream-json` (headless mode)
- **Codex**: speaks native `codex app-server` (JSONL protocol)

Both have been rewritten to use their runtimes' native protocols directly. The "raw mode" warning was a leftover from the old ACP-wrapper architecture.

## Changes

- Marked claude and codex as `AcpStatus::Native` in `src/cli/setup.rs`
- Removed dead `fill_resolved_path` calls that were writing unused adaptor paths into `config.toml`
- Removed now-unused `which_tool` and `fill_resolved_path` helper functions

## Verification

- `cargo check` — clean (no warnings)
- `cargo test --lib` — 317 passed, 0 failed
