### PR TITLE
feat: channel task-event feed (living card ↔ pill)

### DIFF
--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -95,6 +95,20 @@ They are intentionally kept in sync but exist for different call paths.
 
 **Task sub-channels.** Every task owns a child channel (`ChannelType::Task`, `parent_channel_id` FK). Created when the task is created; the creator is its first member. Claim/unclaim syncs membership. Transitioning to `Done` archives the sub-channel. Task sub-channels are excluded from default channel listings; reach them via the parent task board and the task detail view (a full-panel view backed by Zustand's `currentTaskDetail` state). Legacy tasks from before 2026-04-22 are backfilled on migration.
 
+### Task event system messages
+
+Task mutations in `src/store/tasks/mod.rs` post a `sender_type = 'system'`
+message to the parent channel for every successful `create` / `claim` /
+`unclaim` / status change. The `content` column carries a JSON payload with
+`kind: "task_event"` and a camelCase schema (`taskNumber`, `prevStatus`,
+`nextStatus`, `claimedBy`, ...). The frontend renders these via
+`TaskEventMessage` in the chat feed; the bridge layer formats them as a
+one-line human sentence before handing them to agents (see
+`src/bridge/format.rs::format_message_for_agent`).
+
+The task-row write and the event-message insert share the same `tx`, so a
+failure on either rolls both back.
+
 ### Sender Type Resolution (Security Boundary)
 
 **Never allow clients to forge `sender_type='system'` messages.**
@@ -108,7 +122,7 @@ sender_type_for_actor()
 
 - `lookup_sender_type` only queries `agents` and `humans` tables
 - `System` is never returned from this lookup
-- `create_system_message` is only callable internally (templates.rs)
+- `create_system_message` is internal-only. Current callers: channel-kickoff in `templates.rs` and the task mutation hooks in `src/store/tasks/mod.rs` (create / claim / unclaim / status change). Clients cannot forge `sender_type = 'system'` — the HTTP surface has no endpoint that accepts it.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -191,6 +191,14 @@ Inter 400 / 500 / 600 / 700, IBM Plex Mono 400 / 500 / 600.
   this recipe.
 - **Display text uses negative tracking.** Only at 24px+. Below that, use
   default or positive tracking.
+- **Ambient system markers break the case and sans rules on purpose.**
+  Task-event cards in the chat feed (`ui/src/components/chat/TaskEventMessage.*`)
+  use *lowercase* mono for the task-number and status badges (letter-spacing
+  0.07em) and *sans* for the 14px title. The card is a quiet state indicator,
+  not a content label or chat message — shouting "IN PROGRESS" next to a
+  pressable card reads like a warning. Mono + muted still applies to the
+  meta row and the inline timeline. If you add a new ambient marker (not a
+  content message, not a badge on a control), follow this pattern.
 
 ---
 
@@ -430,6 +438,18 @@ Used by: `.chat-header-btn`, `.chat-header-member-btn`, `.mention-pill-clickable
 `.message-input-btn`, `.new-message-badge`, `.message-action-btn`. When you add a
 new interactive element, this is the default hover treatment.
 
+### Large-surface hover: accent tint, not primary-invert
+
+Large clickable surfaces — whole card rows, feed items — use a quieter hover
+(`background: var(--color-accent)`) instead of the full primary-invert.
+Color-inversion at card scale is visually loud next to the feed's natural
+hover rhythm and competes with the content. Reserve primary-invert for
+buttons, pills, and small controls.
+
+Used by: `.message-item` (via translucent white, historical), `.task-event-card`,
+`.task-event-done-row`. When you add a new card-scale click target, follow
+this pattern, not the primary-invert above.
+
 ### Active / selected
 
 Same as hover — primary fill, white text. There is no separate "active" style.
@@ -508,10 +528,34 @@ consolidated but have not been.
 
 ### Motion rules
 
-- **Color transitions only.** 120-150ms ease on background, color, border.
+- **Color transitions only *on hover*.** 120-150ms ease on background, color,
+  border. Never on `transform`, `scale`, or `box-shadow`.
 - **Never scale on hover.** Never translate. Never rotate on hover.
 - **Loaders spin linearly, statuses pulse in ease-in-out.** Keep it that way.
 - **No spring physics, no overshoot, no stagger.**
+- **`prefers-reduced-motion` is honored.** Any transition added must drop to
+  `transition: none !important` inside `@media (prefers-reduced-motion: reduce)`.
+
+### State-machine transitions
+
+The "color transitions only" rule above governs **hover**. State-machine
+components — where a data attribute flips an element between distinct,
+named states — may also transition the properties listed below. These are
+*not* hover animations; they express a persistent data change.
+
+Allowed properties:
+
+- `max-height` + `opacity` for reveal / collapse of stacked views (e.g. the
+  `.task-event-card-view` ↔ `.task-event-pill-view` swap when a task reaches
+  `done`). 200-260ms on `cubic-bezier(0.2, 0.8, 0.2, 1)`.
+- `transform: translateX` (small, under 8px) + `opacity` for list-item entry
+  into a live feed (`.task-event-ev.is-show`). 180ms.
+- `border-left-color` + `color` for status-pill color changes
+  (`.task-event-status[data-status=...]`). 220ms on the same ease curve.
+
+See `ui/src/components/chat/TaskEventMessage.css` for the canonical recipe.
+Reach for this *only* when the element is driven by a data-attribute state
+flip. If the trigger is the user's pointer, re-read the motion rules above.
 
 ---
 

--- a/qa/cases/playwright/TSK-004.spec.ts
+++ b/qa/cases/playwright/TSK-004.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from './helpers/fixtures'
+import {
+  gotoApp,
+  createUserChannelViaUi,
+  clickSidebarChannel,
+} from './helpers/ui'
+
+/**
+ * Catalog: `qa/cases/tasks.md` — TSK-004 Channel Task-Event Feed
+ *
+ * Verifies the channel chat tab shows task activity as a living card that
+ * mutates through the lifecycle and collapses on done:
+ *   - creating a task surfaces a card in the parent channel chat
+ *   - claim / advance / done each update the SAME card in place
+ *   - terminal done collapses to the compact done-pill
+ */
+test.describe('TSK-004', () => {
+  test('Channel Task-Event Feed @case TSK-004', async ({ page }) => {
+    const slug = `qa-task-feed-${Date.now()}`
+    const title = `TSK-004 ${Date.now()}`
+
+    const failed: string[] = []
+    page.on('response', (res) => {
+      const url = res.url()
+      if (
+        (url.includes('/tasks') || url.includes('/channels')) &&
+        res.status() >= 400
+      ) {
+        failed.push(`${res.status()} ${url}`)
+      }
+    })
+
+    await gotoApp(page)
+
+    await test.step('Step 1: Create a channel', async () => {
+      await createUserChannelViaUi(page, slug, 'playwright TSK-004')
+      await clickSidebarChannel(page, slug)
+    })
+
+    await test.step('Step 2: Create a task via the kanban tab', async () => {
+      await page.getByRole('button', { name: 'Tasks', exact: true }).click()
+      await page.locator('.new-task-input').fill(title)
+      await page.locator('.new-task-submit').click()
+      await expect(
+        page
+          .locator('.task-column[data-status="todo"] .task-card-title')
+          .filter({ hasText: title }),
+      ).toBeVisible()
+    })
+
+    await test.step('Step 3: Parent channel chat shows a task card in todo', async () => {
+      await page.getByRole('button', { name: 'Chat', exact: true }).click()
+      const thread = page.locator('[data-testid^="task-thread-"]').first()
+      await expect(thread).toBeVisible()
+      await expect(thread).toHaveAttribute('data-state', 'todo')
+      await expect(thread).toContainText(title)
+    })
+
+    const thread = page.locator('[data-testid^="task-thread-"]').first()
+
+    await test.step('Step 4: Start the task (todo → in_progress) — card mutates in place', async () => {
+      await thread.click()
+      await page.getByRole('button', { name: /start/i }).click()
+      await page.getByRole('button', { name: /back to channel/i }).click()
+      await expect(thread).toHaveAttribute('data-state', 'in_progress')
+    })
+
+    await test.step('Step 5: Submit for review — status pill updates', async () => {
+      await thread.click()
+      await page.getByRole('button', { name: /submit for review/i }).click()
+      await page.getByRole('button', { name: /back to channel/i }).click()
+      await expect(thread).toHaveAttribute('data-state', 'in_review')
+    })
+
+    await test.step('Step 6: Mark done — card collapses to done pill', async () => {
+      await thread.click()
+      await page.getByRole('button', { name: /mark done/i }).click()
+      await page.getByRole('button', { name: /back to channel/i }).click()
+      await expect(thread).toHaveAttribute('data-state', 'done')
+      await expect(thread.locator('.task-event-done-row')).toBeVisible()
+      await expect(thread.locator('.task-event-done-row')).toContainText(title)
+    })
+
+    expect(failed, 'no 4xx/5xx responses during the lifecycle').toEqual([])
+  })
+})

--- a/qa/cases/tasks.md
+++ b/qa/cases/tasks.md
@@ -44,3 +44,17 @@
   7. Verify the task lands in `Done` on the board.
   8. Reopen the task detail after Done and verify the posted message is still visible.
 - Expected: sub-channel is never shown in the sidebar; status transitions succeed; archival preserves message history
+
+### TSK-004 Channel Task-Event Feed
+
+- Suite: smoke
+- Goal: verify task lifecycle events surface as a single living card in the parent channel chat and collapse to a done pill when terminal
+- Script: [`playwright/TSK-004.spec.ts`](./playwright/TSK-004.spec.ts)
+- Steps:
+  1. Create a channel.
+  2. Create a task via the kanban tab.
+  3. Open the parent channel chat and verify the task card renders in the `todo` state.
+  4. Click through to the task, `Start` it, return to chat, and verify the card's `data-state` is now `in_progress`.
+  5. `Submit for review` and verify the card's `data-state` flips to `in_review` in place.
+  6. `Mark done` and verify the card collapses to the done pill (`task-event-done-row` visible, `data-state="done"`).
+- Expected: one task → one card; state transitions update the same card without duplication; terminal done swaps to the compact pill view

--- a/src/bridge/backend.rs
+++ b/src/bridge/backend.rs
@@ -272,15 +272,20 @@ impl Backend for ChorusBackend {
                     .and_then(|v| v.as_str())
                     .map(to_local_time)
                     .unwrap_or_else(|| "-".into());
-                let sender_type = match m.get("sender_type").and_then(|v| v.as_str()) {
-                    Some("agent") => " type=agent",
+                let sender_type_raw = m.get("sender_type").and_then(|v| v.as_str()).unwrap_or("");
+                let sender_type = match sender_type_raw {
+                    "agent" => " type=agent",
                     _ => "",
                 };
                 let sender = m
                     .get("sender_name")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                let content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                let raw_content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                let content = crate::bridge::format::format_message_for_agent(
+                    sender_type_raw,
+                    raw_content,
+                );
                 let attach_suffix = format_attachments(m.get("attachments"));
                 format!(
                     "[target={} msg={} time={}{}] @{}: {}{}",
@@ -358,8 +363,9 @@ impl Backend for ChorusBackend {
         let formatted: Vec<String> = messages
             .iter()
             .map(|m| {
-                let sender_type = match m.get("senderType").and_then(|v| v.as_str()) {
-                    Some("agent") => " type=agent",
+                let sender_type_raw = m.get("senderType").and_then(|v| v.as_str()).unwrap_or("");
+                let sender_type = match sender_type_raw {
+                    "agent" => " type=agent",
                     _ => "",
                 };
                 let time = m
@@ -381,7 +387,11 @@ impl Backend for ChorusBackend {
                     .get("senderName")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                let content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                let raw_content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                let content = crate::bridge::format::format_message_for_agent(
+                    sender_type_raw,
+                    raw_content,
+                );
                 let attach_suffix = format_attachments(m.get("attachments"));
                 format!(
                     "[seq={} msg={} time={}{}] @{}: {}{}",

--- a/src/bridge/backend.rs
+++ b/src/bridge/backend.rs
@@ -282,10 +282,8 @@ impl Backend for ChorusBackend {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 let raw_content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
-                let content = crate::bridge::format::format_message_for_agent(
-                    sender_type_raw,
-                    raw_content,
-                );
+                let content =
+                    crate::bridge::format::format_message_for_agent(sender_type_raw, raw_content);
                 let attach_suffix = format_attachments(m.get("attachments"));
                 format!(
                     "[target={} msg={} time={}{}] @{}: {}{}",
@@ -388,10 +386,8 @@ impl Backend for ChorusBackend {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 let raw_content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
-                let content = crate::bridge::format::format_message_for_agent(
-                    sender_type_raw,
-                    raw_content,
-                );
+                let content =
+                    crate::bridge::format::format_message_for_agent(sender_type_raw, raw_content);
                 let attach_suffix = format_attachments(m.get("attachments"));
                 format!(
                     "[seq={} msg={} time={}{}] @{}: {}{}",

--- a/src/bridge/format.rs
+++ b/src/bridge/format.rs
@@ -1,5 +1,8 @@
 use serde_json::Value;
 
+use crate::store::tasks::events::{TaskEventAction, TaskEventPayload};
+use crate::store::tasks::TaskStatus;
+
 pub(super) fn to_local_time(iso: &str) -> String {
     chrono::DateTime::parse_from_rfc3339(iso)
         .map(|dt| {
@@ -42,4 +45,68 @@ pub(super) fn format_attachments(attachments: Option<&Value>) -> String {
         }
         _ => String::new(),
     }
+}
+
+/// Format a message `content` string for agent consumption. Task-event messages
+/// (`sender_type = "system"` + JSON payload tagged `kind: "task_event"`) are
+/// rendered as a one-line human sentence so agents don't see raw JSON in their
+/// context. All other sender types pass through unchanged. Non-task system
+/// messages (e.g. legacy channel kickoff) also pass through.
+///
+/// Any malformed or partially-malformed task_event payload falls back to the
+/// raw string so agents are never starved of content — consistency with the
+/// frontend parser is a nicety, not an invariant here.
+pub fn format_message_for_agent(sender_type: &str, content: &str) -> String {
+    if sender_type != "system" {
+        return content.to_string();
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return content.to_string();
+    };
+    if value.get("kind").and_then(|k| k.as_str()) != Some("task_event") {
+        return content.to_string();
+    }
+    match parse_task_event_from_value(&value) {
+        Some(payload) => payload.as_agent_sentence(),
+        None => content.to_string(),
+    }
+}
+
+fn parse_task_event_from_value(value: &serde_json::Value) -> Option<TaskEventPayload> {
+    let action = match value.get("action")?.as_str()? {
+        "created" => TaskEventAction::Created,
+        "claimed" => TaskEventAction::Claimed,
+        "unclaimed" => TaskEventAction::Unclaimed,
+        "status_changed" => TaskEventAction::StatusChanged,
+        _ => return None,
+    };
+    let next_status = TaskStatus::from_status_str(value.get("nextStatus")?.as_str()?)?;
+    // prevStatus: mirror the frontend contract — present-but-invalid means
+    // producer is broken, so fail the parse and fall back to raw content.
+    let prev_status = match value.get("prevStatus") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => match TaskStatus::from_status_str(s) {
+            Some(status) => Some(status),
+            None => return None,
+        },
+        Some(_) => return None,
+    };
+    let task_number = value.get("taskNumber")?.as_i64()?;
+    // claimedBy: same contract — if present and not null, it must be a string.
+    let claimed_by = match value.get("claimedBy") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(_) => return None,
+    };
+
+    Some(TaskEventPayload {
+        action,
+        task_number,
+        title: value.get("title")?.as_str()?.to_string(),
+        sub_channel_id: value.get("subChannelId")?.as_str()?.to_string(),
+        actor: value.get("actor")?.as_str()?.to_string(),
+        prev_status,
+        next_status,
+        claimed_by,
+    })
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -6,7 +6,7 @@ use rmcp::{tool, tool_handler, tool_router, ServerHandler};
 pub mod backend;
 pub mod discovery;
 pub mod error;
-mod format;
+pub mod format;
 pub mod pairing;
 pub mod serve;
 mod types;

--- a/src/store/inbox.rs
+++ b/src/store/inbox.rs
@@ -200,9 +200,16 @@ impl Store {
     pub fn get_unread_summary(&self, member_name: &str) -> Result<HashMap<String, i64>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT conversation_name, unread_count
-             FROM inbox_conversation_state_view
-             WHERE member_name = ?1 AND unread_count > 0",
+            // Archived task sub-channels are terminal work; the agent's start
+            // prompt should not list them as unread — they're hidden from the
+            // active UI, so the agent has no way to clear them. Mirrors the
+            // filter on `get_inbox_conversation_notifications`.
+            "SELECT view.conversation_name, view.unread_count
+             FROM inbox_conversation_state_view view
+             JOIN channels c ON c.id = view.conversation_id
+             WHERE view.member_name = ?1
+               AND view.unread_count > 0
+               AND NOT (c.archived = 1 AND c.channel_type = 'task')",
         )?;
         let rows = stmt
             .query_map(params![member_name], |row| {

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -113,17 +113,17 @@ impl Store {
     /// Returns the [`InsertedMessage`] so callers can emit the stream event
     /// after the outer transaction commits.
     pub(crate) fn create_system_message_tx(
-        tx: &rusqlite::Transaction<'_>,
+        tx: &Transaction<'_>,
         channel_id: &str,
         content: &str,
-    ) -> anyhow::Result<crate::store::messages::types::InsertedMessage> {
+    ) -> Result<InsertedMessage> {
         let channel = Self::get_channel_by_id_inner(tx, channel_id)?
-            .ok_or_else(|| anyhow::anyhow!("channel not found by id"))?;
+            .ok_or_else(|| anyhow!("channel not found by id"))?;
         Self::insert_message_tx(
             tx,
             &channel,
             "system",
-            crate::store::messages::types::SenderType::System,
+            SenderType::System,
             content,
             &[],
             None,
@@ -138,18 +138,18 @@ impl Store {
     /// the DB rows are the source of truth.
     pub(crate) fn emit_system_stream_events(
         &self,
-        channel: &crate::store::channels::Channel,
-        pending: Vec<(crate::store::messages::types::InsertedMessage, String)>,
-    ) -> anyhow::Result<()> {
+        channel: &Channel,
+        pending: Vec<(InsertedMessage, String)>,
+    ) -> Result<()> {
         for (inserted, content) in pending {
             let payload = inserted.to_event_payload(
                 channel.id.as_str(),
                 channel.channel_type.as_api_str(),
                 "system",
-                crate::store::messages::types::SenderType::System.as_str(),
+                SenderType::System.as_str(),
                 &content,
             );
-            let stream_event = crate::store::stream::StreamEvent::new(
+            let stream_event = StreamEvent::new(
                 channel.id.clone(),
                 inserted.seq,
                 serde_json::to_value(payload)?,
@@ -245,14 +245,49 @@ mod tests {
             inserted.id
         };
 
-        let content: String = store
+        // Verify ALL invariants the helper owns, not just content.
+        let (content, sender_type, sender_name, seq): (String, String, String, i64) = store
             .conn_for_test()
             .query_row(
-                "SELECT content FROM messages WHERE id = ?1",
+                "SELECT content, sender_type, sender_name, seq FROM messages WHERE id = ?1",
                 params![msg_id],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
             )
             .unwrap();
         assert_eq!(content, "hello");
+        assert_eq!(sender_type, "system");
+        assert_eq!(sender_name, "system");
+        assert_eq!(seq, 1);
+    }
+
+    #[test]
+    fn create_system_message_tx_respects_caller_rollback() {
+        // The whole point of a tx-scoped API: if the caller rolls back, the
+        // insert must not persist. Pins the "no inner transaction" invariant.
+        use rusqlite::OptionalExtension;
+
+        let store = make_store();
+        let channel_id = store
+            .create_channel("eng", None, ChannelType::Channel, None)
+            .unwrap();
+
+        let msg_id = {
+            let mut conn = store.conn_for_test();
+            let tx = conn.transaction().unwrap();
+            let inserted = Store::create_system_message_tx(&tx, &channel_id, "discard me").unwrap();
+            // Drop the tx without committing — implicit rollback.
+            drop(tx);
+            inserted.id
+        };
+
+        let row: Option<String> = store
+            .conn_for_test()
+            .query_row("SELECT id FROM messages WHERE id = ?1", params![msg_id], |r| r.get(0))
+            .optional()
+            .unwrap();
+        assert!(
+            row.is_none(),
+            "tx-scoped insert must not persist when caller rolls back"
+        );
     }
 }

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -282,8 +282,7 @@ mod tests {
             let channel = Store::get_channel_by_id_inner(&tx, &channel_id)
                 .unwrap()
                 .unwrap();
-            let inserted =
-                Store::create_system_message_tx(&tx, &channel, "discard me").unwrap();
+            let inserted = Store::create_system_message_tx(&tx, &channel, "discard me").unwrap();
             // Drop the tx without committing — implicit rollback.
             drop(tx);
             inserted.id

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -110,18 +110,20 @@ impl Store {
     /// call this helper. Use the public [`Store::create_system_message`] for
     /// standalone posts.
     ///
+    /// Takes `&Channel` directly so batched callers (e.g. `create_tasks`
+    /// looping over N tasks in one tx) don't re-query the channel row for
+    /// every event they emit.
+    ///
     /// Returns the [`InsertedMessage`] so callers can emit the stream event
     /// after the outer transaction commits.
     pub(crate) fn create_system_message_tx(
         tx: &Transaction<'_>,
-        channel_id: &str,
+        channel: &Channel,
         content: &str,
     ) -> Result<InsertedMessage> {
-        let channel = Self::get_channel_by_id_inner(tx, channel_id)?
-            .ok_or_else(|| anyhow!("channel not found by id"))?;
         Self::insert_message_tx(
             tx,
-            &channel,
+            channel,
             "system",
             SenderType::System,
             content,
@@ -165,7 +167,7 @@ impl Store {
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
             .ok_or_else(|| anyhow!("channel not found by id"))?;
-        let inserted = Self::create_system_message_tx(&tx, channel_id, content)?;
+        let inserted = Self::create_system_message_tx(&tx, &channel, content)?;
         let message_id = inserted.id.clone();
         tx.commit()?;
         drop(conn); // release the guard before fanout to avoid holding the mutex
@@ -240,7 +242,10 @@ mod tests {
         let msg_id = {
             let mut conn = store.conn_for_test();
             let tx = conn.transaction().unwrap();
-            let inserted = Store::create_system_message_tx(&tx, &channel_id, "hello").unwrap();
+            let channel = Store::get_channel_by_id_inner(&tx, &channel_id)
+                .unwrap()
+                .unwrap();
+            let inserted = Store::create_system_message_tx(&tx, &channel, "hello").unwrap();
             tx.commit().unwrap();
             inserted.id
         };
@@ -274,7 +279,11 @@ mod tests {
         let msg_id = {
             let mut conn = store.conn_for_test();
             let tx = conn.transaction().unwrap();
-            let inserted = Store::create_system_message_tx(&tx, &channel_id, "discard me").unwrap();
+            let channel = Store::get_channel_by_id_inner(&tx, &channel_id)
+                .unwrap()
+                .unwrap();
+            let inserted =
+                Store::create_system_message_tx(&tx, &channel, "discard me").unwrap();
             // Drop the tx without committing — implicit rollback.
             drop(tx);
             inserted.id

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -282,7 +282,11 @@ mod tests {
 
         let row: Option<String> = store
             .conn_for_test()
-            .query_row("SELECT id FROM messages WHERE id = ?1", params![msg_id], |r| r.get(0))
+            .query_row(
+                "SELECT id FROM messages WHERE id = ?1",
+                params![msg_id],
+                |r| r.get(0),
+            )
             .optional()
             .unwrap();
         assert!(

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -104,38 +104,74 @@ impl Store {
         Ok(inserted.id)
     }
 
+    /// Insert a `sender_type = 'system'` message inside an existing transaction.
+    /// Callers doing multi-statement mutations (e.g. task claim → status flip
+    /// → event message) wrap the whole sequence in their own transaction and
+    /// call this helper. Use the public [`Store::create_system_message`] for
+    /// standalone posts.
+    ///
+    /// Returns the [`InsertedMessage`] so callers can emit the stream event
+    /// after the outer transaction commits.
+    pub(crate) fn create_system_message_tx(
+        tx: &rusqlite::Transaction<'_>,
+        channel_id: &str,
+        content: &str,
+    ) -> anyhow::Result<crate::store::messages::types::InsertedMessage> {
+        let channel = Self::get_channel_by_id_inner(tx, channel_id)?
+            .ok_or_else(|| anyhow::anyhow!("channel not found by id"))?;
+        Self::insert_message_tx(
+            tx,
+            &channel,
+            "system",
+            crate::store::messages::types::SenderType::System,
+            content,
+            &[],
+            None,
+            None,
+        )
+    }
+
+    /// Emit `message.created` stream events for system messages that were
+    /// inserted via `create_system_message_tx` and committed by the caller.
+    /// Each `(inserted, content)` tuple produced inside the transaction maps
+    /// to one WebSocket event. Best-effort: send errors are dropped because
+    /// the DB rows are the source of truth.
+    pub(crate) fn emit_system_stream_events(
+        &self,
+        channel: &crate::store::channels::Channel,
+        pending: Vec<(crate::store::messages::types::InsertedMessage, String)>,
+    ) -> anyhow::Result<()> {
+        for (inserted, content) in pending {
+            let payload = inserted.to_event_payload(
+                channel.id.as_str(),
+                channel.channel_type.as_api_str(),
+                "system",
+                crate::store::messages::types::SenderType::System.as_str(),
+                &content,
+            );
+            let stream_event = crate::store::stream::StreamEvent::new(
+                channel.id.clone(),
+                inserted.seq,
+                serde_json::to_value(payload)?,
+            );
+            let _ = self.stream_tx.send(stream_event);
+        }
+        Ok(())
+    }
+
     /// Post a server-authored message into a channel.
     pub fn create_system_message(&self, channel_id: &str, content: &str) -> Result<String> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
             .ok_or_else(|| anyhow!("channel not found by id"))?;
-        let inserted = Self::insert_message_tx(
-            &tx,
-            &channel,
-            "system",
-            SenderType::System,
-            content,
-            &[],
-            None,
-            None,
-        )?;
+        let inserted = Self::create_system_message_tx(&tx, channel_id, content)?;
+        let message_id = inserted.id.clone();
         tx.commit()?;
+        drop(conn); // release the guard before fanout to avoid holding the mutex
 
-        let payload = inserted.to_event_payload(
-            channel.id.as_str(),
-            channel.channel_type.as_api_str(),
-            "system",
-            SenderType::System.as_str(),
-            content,
-        );
-        let stream_event = StreamEvent::new(
-            channel.id.clone(),
-            inserted.seq,
-            serde_json::to_value(payload)?,
-        );
-        let _ = self.stream_tx.send(stream_event);
-        Ok(inserted.id)
+        self.emit_system_stream_events(&channel, vec![(inserted, content.to_string())])?;
+        Ok(message_id)
     }
 
     pub fn create_message(&self, message: CreateMessage<'_>) -> Result<String> {
@@ -179,5 +215,44 @@ impl Store {
             let _ = self.stream_tx.send(stream_event);
         }
         Ok(inserted.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::store::channels::ChannelType;
+    use crate::store::Store;
+    use rusqlite::params;
+
+    fn make_store() -> Store {
+        // `Store::open` takes `&str`; in-memory matches what `tests/e2e_tests.rs`
+        // does for the test harness and avoids any path-to-string juggling.
+        Store::open(":memory:").unwrap()
+    }
+
+    #[test]
+    fn create_system_message_tx_inserts_within_caller_transaction() {
+        let store = make_store();
+        let channel_id = store
+            .create_channel("eng", None, ChannelType::Channel, None)
+            .unwrap();
+
+        let msg_id = {
+            let mut conn = store.conn_for_test();
+            let tx = conn.transaction().unwrap();
+            let inserted = Store::create_system_message_tx(&tx, &channel_id, "hello").unwrap();
+            tx.commit().unwrap();
+            inserted.id
+        };
+
+        let content: String = store
+            .conn_for_test()
+            .query_row(
+                "SELECT content FROM messages WHERE id = ?1",
+                params![msg_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "hello");
     }
 }

--- a/src/store/tasks/events.rs
+++ b/src/store/tasks/events.rs
@@ -75,15 +75,24 @@ impl TaskEventPayload {
             ),
             TaskEventAction::Claimed => format!(
                 "[task] {} claimed #{} \"{}\" (now {})",
-                self.actor, self.task_number, self.title, self.next_status.as_str()
+                self.actor,
+                self.task_number,
+                self.title,
+                self.next_status.as_str()
             ),
             TaskEventAction::Unclaimed => format!(
                 "[task] {} unclaimed #{} \"{}\" (now {})",
-                self.actor, self.task_number, self.title, self.next_status.as_str()
+                self.actor,
+                self.task_number,
+                self.title,
+                self.next_status.as_str()
             ),
             TaskEventAction::StatusChanged => format!(
                 "[task] {} → {} on #{} \"{}\"",
-                self.actor, self.next_status.as_str(), self.task_number, self.title
+                self.actor,
+                self.next_status.as_str(),
+                self.task_number,
+                self.title
             ),
         }
     }

--- a/src/store/tasks/events.rs
+++ b/src/store/tasks/events.rs
@@ -1,0 +1,90 @@
+//! Task-event system messages emitted on every task mutation.
+//!
+//! Every event becomes a `sender_type = 'system'` message in the parent channel
+//! with a JSON `content` payload. The frontend parses the JSON; agents receive
+//! a pre-formatted human sentence via the bridge adapter.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::store::tasks::TaskStatus;
+
+/// What happened to the task. Serialized as snake_case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskEventAction {
+    Created,
+    Claimed,
+    Unclaimed,
+    StatusChanged,
+}
+
+impl TaskEventAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Claimed => "claimed",
+            Self::Unclaimed => "unclaimed",
+            Self::StatusChanged => "status_changed",
+        }
+    }
+}
+
+/// Structured payload for one task-event message. Serialized to JSON and stored
+/// as the `messages.content` column for the parent channel's system messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskEventPayload {
+    pub action: TaskEventAction,
+    pub task_number: i64,
+    pub title: String,
+    pub sub_channel_id: String,
+    pub actor: String,
+    /// None on Created. Some() on Claimed / Unclaimed / StatusChanged.
+    pub prev_status: Option<TaskStatus>,
+    pub next_status: TaskStatus,
+    /// Current claimer after the event. None when task is unclaimed.
+    pub claimed_by: Option<String>,
+}
+
+impl TaskEventPayload {
+    /// Serialize to a JSON string suitable for `messages.content`. Emits
+    /// camelCase field names so the TypeScript frontend can read it without
+    /// mapping.
+    pub fn to_json_string(&self) -> Result<String, serde_json::Error> {
+        let value = json!({
+            "kind": "task_event",
+            "action": self.action.as_str(),
+            "taskNumber": self.task_number,
+            "title": self.title,
+            "subChannelId": self.sub_channel_id,
+            "actor": self.actor,
+            "prevStatus": self.prev_status.map(|s| s.as_str()),
+            "nextStatus": self.next_status.as_str(),
+            "claimedBy": self.claimed_by,
+        });
+        serde_json::to_string(&value)
+    }
+
+    /// Human-readable one-line summary used when serializing for agent
+    /// consumers in the bridge layer.
+    pub fn as_agent_sentence(&self) -> String {
+        match self.action {
+            TaskEventAction::Created => format!(
+                "[task] {} created #{} \"{}\"",
+                self.actor, self.task_number, self.title
+            ),
+            TaskEventAction::Claimed => format!(
+                "[task] {} claimed #{} \"{}\" (now {})",
+                self.actor, self.task_number, self.title, self.next_status.as_str()
+            ),
+            TaskEventAction::Unclaimed => format!(
+                "[task] {} unclaimed #{} \"{}\" (now {})",
+                self.actor, self.task_number, self.title, self.next_status.as_str()
+            ),
+            TaskEventAction::StatusChanged => format!(
+                "[task] {} → {} on #{} \"{}\"",
+                self.actor, self.next_status.as_str(), self.task_number, self.title
+            ),
+        }
+    }
+}

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -508,15 +508,16 @@ impl Store {
             .ok_or_else(|| anyhow!("channel not found: {}", channel_name))?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
-        let (current_status_str, claimed_by, sub_channel_id): (
+        let (current_status_str, claimed_by, sub_channel_id, title): (
             String,
             Option<String>,
             Option<String>,
+            String,
         ) = tx.query_row(
-            "SELECT status, claimed_by, sub_channel_id FROM tasks \
+            "SELECT status, claimed_by, sub_channel_id, title FROM tasks \
              WHERE channel_id = ?1 AND task_number = ?2",
             params![channel.id, task_number],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
 
         let current_status = TaskStatus::from_status_str(&current_status_str)
@@ -538,6 +539,21 @@ impl Store {
             params![new_status.as_str(), channel.id, task_number],
         )?;
 
+        // Emit the event inside the tx, BEFORE the optional archive below
+        // (which consumes `sub_channel_id`).
+        let payload = crate::store::tasks::events::TaskEventPayload {
+            action: crate::store::tasks::events::TaskEventAction::StatusChanged,
+            task_number,
+            title,
+            sub_channel_id: sub_channel_id.clone().unwrap_or_default(),
+            actor: requester_name.to_string(),
+            prev_status: Some(current_status),
+            next_status: new_status,
+            claimed_by: claimed_by.clone(),
+        };
+        let content = payload.to_json_string()?;
+        let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+
         // `Done` is terminal (`can_transition_to` has no outbound edges from
         // `Done`), so archiving here is safe — there is no path back that would
         // need to un-archive. Bypasses the `archive_channel` guard on purpose:
@@ -553,6 +569,8 @@ impl Store {
         }
 
         tx.commit()?;
+        drop(conn);
+        self.emit_system_stream_events(&channel, vec![(inserted, content)])?;
         Ok(())
     }
 }

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -211,7 +211,7 @@ impl Store {
                 claimed_by: None,
             };
             let content = payload.to_json_string()?;
-            let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+            let inserted = Self::create_system_message_tx(&tx, &channel, &content)?;
             pending_events.push((inserted, content));
 
             result.push(TaskInfo {
@@ -392,7 +392,7 @@ impl Store {
                         claimed_by: Some(claimer_name.to_string()),
                     };
                     let content = payload.to_json_string()?;
-                    let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+                    let inserted = Self::create_system_message_tx(&tx, &channel, &content)?;
                     pending_events.push((inserted, content));
                     results.push(ClaimResult {
                         task_number: tn,
@@ -485,7 +485,7 @@ impl Store {
             claimed_by: None,
         };
         let content = payload.to_json_string()?;
-        let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+        let inserted = Self::create_system_message_tx(&tx, &channel, &content)?;
         tx.commit()?;
         drop(conn);
         self.emit_system_stream_events(&channel, vec![(inserted, content)])?;
@@ -552,7 +552,7 @@ impl Store {
             claimed_by: claimed_by.clone(),
         };
         let content = payload.to_json_string()?;
-        let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+        let inserted = Self::create_system_message_tx(&tx, &channel, &content)?;
 
         // `Done` is terminal (`can_transition_to` has no outbound edges from
         // `Done`), so archiving here is safe — there is no path back that would

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -6,6 +6,7 @@ use rusqlite::{params, TransactionBehavior};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use self::events::{TaskEventAction, TaskEventPayload};
 use super::channels::ChannelType;
 use super::Store;
 
@@ -199,8 +200,8 @@ impl Store {
 
             // Emit task_event inside the same tx so the task row and its
             // visibility-in-chat commit atomically.
-            let payload = crate::store::tasks::events::TaskEventPayload {
-                action: crate::store::tasks::events::TaskEventAction::Created,
+            let payload = TaskEventPayload {
+                action: TaskEventAction::Created,
                 task_number,
                 title: title.to_string(),
                 sub_channel_id: sub_channel_id.clone(),
@@ -380,8 +381,8 @@ impl Store {
                             params![sub_id, claimer_name, claimer_type.as_str()],
                         )?;
                     }
-                    let payload = crate::store::tasks::events::TaskEventPayload {
-                        action: crate::store::tasks::events::TaskEventAction::Claimed,
+                    let payload = TaskEventPayload {
+                        action: TaskEventAction::Claimed,
                         task_number: tn,
                         title,
                         sub_channel_id: sub_channel_id.unwrap_or_default(),
@@ -473,8 +474,8 @@ impl Store {
         let prev_status = TaskStatus::from_status_str(&current_status_str)
             .ok_or_else(|| anyhow!("invalid task status: {}", current_status_str))?;
 
-        let payload = crate::store::tasks::events::TaskEventPayload {
-            action: crate::store::tasks::events::TaskEventAction::Unclaimed,
+        let payload = TaskEventPayload {
+            action: TaskEventAction::Unclaimed,
             task_number,
             title,
             sub_channel_id: sub_channel_id.unwrap_or_default(),
@@ -540,8 +541,8 @@ impl Store {
 
         // Emit the event inside the tx, BEFORE the optional archive below
         // (which consumes `sub_channel_id`).
-        let payload = crate::store::tasks::events::TaskEventPayload {
-            action: crate::store::tasks::events::TaskEventAction::StatusChanged,
+        let payload = TaskEventPayload {
+            action: TaskEventAction::StatusChanged,
             task_number,
             title,
             sub_channel_id: sub_channel_id.clone().unwrap_or_default(),

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -1,3 +1,5 @@
+pub mod events;
+
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, TransactionBehavior};

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -159,10 +159,8 @@ impl Store {
             params![channel.id],
             |row| row.get(0),
         )?;
-        let mut pending_events: Vec<(
-            crate::store::messages::types::InsertedMessage,
-            String,
-        )> = Vec::new();
+        let mut pending_events: Vec<(crate::store::messages::types::InsertedMessage, String)> =
+            Vec::new();
 
         let mut result = Vec::new();
         for (i, title) in titles.iter().enumerate() {
@@ -336,7 +334,8 @@ impl Store {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         let mut results = Vec::new();
-        let mut pending_events: Vec<(crate::store::messages::types::InsertedMessage, String)> = Vec::new();
+        let mut pending_events: Vec<(crate::store::messages::types::InsertedMessage, String)> =
+            Vec::new();
         // Batch semantics: all claims commit together or none do. A hard SQL
         // error on claim N rolls back successful claims 1..N-1. "Soft"
         // rejections (task already claimed / not in todo / stolen mid-flight)

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -336,22 +336,23 @@ impl Store {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         let mut results = Vec::new();
+        let mut pending_events: Vec<(crate::store::messages::types::InsertedMessage, String)> = Vec::new();
         // Batch semantics: all claims commit together or none do. A hard SQL
         // error on claim N rolls back successful claims 1..N-1. "Soft"
         // rejections (task already claimed / not in todo / stolen mid-flight)
         // push a `ClaimResult { success: false, .. }` and continue; they still
         // commit as a no-op batch.
         for &tn in task_numbers {
-            let task: Option<(String, Option<String>, Option<String>)> = tx
+            let task: Option<(String, Option<String>, Option<String>, String)> = tx
                 .query_row(
-                    "SELECT status, claimed_by, sub_channel_id FROM tasks WHERE channel_id = ?1 AND task_number = ?2",
+                    "SELECT status, claimed_by, sub_channel_id, title FROM tasks WHERE channel_id = ?1 AND task_number = ?2",
                     params![channel.id, tn],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )
                 .ok();
 
             match task {
-                Some((status, claimed_by, sub_channel_id))
+                Some((status, claimed_by, sub_channel_id, title))
                     if status == "todo" && claimed_by.is_none() =>
                 {
                     // Defense in depth: WHERE-guard on the precondition we
@@ -373,13 +374,26 @@ impl Store {
                     // Sync sub-channel membership: claimer joins. `INSERT OR
                     // IGNORE` keeps the operation idempotent when the claimer
                     // is already a member (e.g. they also created the task).
-                    if let Some(sub_id) = sub_channel_id {
+                    if let Some(ref sub_id) = sub_channel_id {
                         tx.execute(
                             "INSERT OR IGNORE INTO channel_members (channel_id, member_name, member_type, last_read_seq) \
                              VALUES (?1, ?2, ?3, 0)",
                             params![sub_id, claimer_name, claimer_type.as_str()],
                         )?;
                     }
+                    let payload = crate::store::tasks::events::TaskEventPayload {
+                        action: crate::store::tasks::events::TaskEventAction::Claimed,
+                        task_number: tn,
+                        title,
+                        sub_channel_id: sub_channel_id.unwrap_or_default(),
+                        actor: claimer_name.to_string(),
+                        prev_status: Some(TaskStatus::Todo),
+                        next_status: TaskStatus::InProgress,
+                        claimed_by: Some(claimer_name.to_string()),
+                    };
+                    let content = payload.to_json_string()?;
+                    let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+                    pending_events.push((inserted, content));
                     results.push(ClaimResult {
                         task_number: tn,
                         success: true,
@@ -403,6 +417,8 @@ impl Store {
             }
         }
         tx.commit()?;
+        drop(conn);
+        self.emit_system_stream_events(&channel, pending_events)?;
         Ok(results)
     }
 
@@ -423,10 +439,10 @@ impl Store {
 
         // tx-scoped read closes the TOCTOU window — another writer can't
         // reassign `claimed_by` between the check and the UPDATE.
-        let (claimed_by, sub_channel_id): (Option<String>, Option<String>) = tx.query_row(
-            "SELECT claimed_by, sub_channel_id FROM tasks WHERE channel_id = ?1 AND task_number = ?2",
+        let (claimed_by, sub_channel_id, current_status_str, title): (Option<String>, Option<String>, String, String) = tx.query_row(
+            "SELECT claimed_by, sub_channel_id, status, title FROM tasks WHERE channel_id = ?1 AND task_number = ?2",
             params![channel.id, task_number],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
 
         if claimed_by.as_deref() != Some(claimer_name) {
@@ -448,13 +464,31 @@ impl Store {
             ));
         }
 
-        if let Some(sub_id) = sub_channel_id {
+        if let Some(sub_id) = sub_channel_id.as_deref() {
             tx.execute(
                 "DELETE FROM channel_members WHERE channel_id = ?1 AND member_name = ?2",
                 params![sub_id, claimer_name],
             )?;
         }
+
+        let prev_status = TaskStatus::from_status_str(&current_status_str)
+            .ok_or_else(|| anyhow!("invalid task status: {}", current_status_str))?;
+
+        let payload = crate::store::tasks::events::TaskEventPayload {
+            action: crate::store::tasks::events::TaskEventAction::Unclaimed,
+            task_number,
+            title,
+            sub_channel_id: sub_channel_id.unwrap_or_default(),
+            actor: claimer_name.to_string(),
+            prev_status: Some(prev_status),
+            next_status: TaskStatus::Todo,
+            claimed_by: None,
+        };
+        let content = payload.to_json_string()?;
+        let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
         tx.commit()?;
+        drop(conn);
+        self.emit_system_stream_events(&channel, vec![(inserted, content)])?;
         Ok(())
     }
 

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -159,6 +159,11 @@ impl Store {
             params![channel.id],
             |row| row.get(0),
         )?;
+        let mut pending_events: Vec<(
+            crate::store::messages::types::InsertedMessage,
+            String,
+        )> = Vec::new();
+
         let mut result = Vec::new();
         for (i, title) in titles.iter().enumerate() {
             let task_id = Uuid::new_v4().to_string();
@@ -194,6 +199,22 @@ impl Store {
                 ],
             )?;
 
+            // Emit task_event inside the same tx so the task row and its
+            // visibility-in-chat commit atomically.
+            let payload = crate::store::tasks::events::TaskEventPayload {
+                action: crate::store::tasks::events::TaskEventAction::Created,
+                task_number,
+                title: title.to_string(),
+                sub_channel_id: sub_channel_id.clone(),
+                actor: creator_name.to_string(),
+                prev_status: None,
+                next_status: TaskStatus::Todo,
+                claimed_by: None,
+            };
+            let content = payload.to_json_string()?;
+            let inserted = Self::create_system_message_tx(&tx, &channel.id, &content)?;
+            pending_events.push((inserted, content));
+
             result.push(TaskInfo {
                 task_number,
                 title: title.to_string(),
@@ -205,6 +226,9 @@ impl Store {
             });
         }
         tx.commit()?;
+        drop(conn); // release the mutex guard before the stream fanout
+
+        self.emit_system_stream_events(&channel, pending_events)?;
         Ok(result)
     }
 

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -674,3 +674,176 @@ async fn pairing_token_end_to_end_sends_message() {
 
     bridge_ct.cancel();
 }
+
+// ---------------------------------------------------------------------------
+// Agent-readability adapter tests (Task 7)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bridge_formats_task_event_as_human_sentence_for_agents() {
+    use chorus::bridge::format::format_message_for_agent;
+    use chorus::store::tasks::events::{TaskEventAction, TaskEventPayload};
+    use chorus::store::tasks::TaskStatus;
+
+    let payload = TaskEventPayload {
+        action: TaskEventAction::Claimed,
+        task_number: 7,
+        title: "wire up the bridge".into(),
+        sub_channel_id: "sub-1".into(),
+        actor: "alice".into(),
+        prev_status: Some(TaskStatus::Todo),
+        next_status: TaskStatus::InProgress,
+        claimed_by: Some("alice".into()),
+    };
+    let content = payload.to_json_string().unwrap();
+
+    let formatted = format_message_for_agent("system", &content);
+    assert_eq!(
+        formatted,
+        "[task] alice claimed #7 \"wire up the bridge\" (now in_progress)"
+    );
+
+    // Regular messages pass through unchanged.
+    assert_eq!(
+        format_message_for_agent("human", "hello world"),
+        "hello world"
+    );
+
+    // Malformed system content falls back to the raw string.
+    assert_eq!(format_message_for_agent("system", "not json"), "not json");
+
+    // System content whose JSON parses but has the wrong `kind` also falls back.
+    assert_eq!(
+        format_message_for_agent("system", r#"{"kind":"other","msg":"hi"}"#),
+        r#"{"kind":"other","msg":"hi"}"#
+    );
+
+    // Malformed task_event (invalid prevStatus, wrong-type claimedBy) falls
+    // back to the raw content. Mirrors the frontend parser's "present-invalid
+    // is broken" contract.
+    let bad_prev = r#"{"kind":"task_event","action":"claimed","taskNumber":7,"title":"t","subChannelId":"s","actor":"a","prevStatus":"garbage","nextStatus":"in_progress"}"#;
+    assert_eq!(format_message_for_agent("system", bad_prev), bad_prev);
+
+    let bad_claimed = r#"{"kind":"task_event","action":"claimed","taskNumber":7,"title":"t","subChannelId":"s","actor":"a","nextStatus":"in_progress","claimedBy":42}"#;
+    assert_eq!(format_message_for_agent("system", bad_claimed), bad_claimed);
+}
+
+#[tokio::test]
+async fn bridge_read_history_formats_task_event_messages() {
+    use chorus::bridge::backend::{Backend, ChorusBackend};
+    use chorus::store::channels::ChannelType;
+
+    let (server_url, store) = start_chorus_server().await;
+
+    let channel_id = store
+        .create_channel("eng", None, ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store
+        .join_channel("eng", "alice", SenderType::Human)
+        .unwrap();
+    store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "agent-one",
+            display_name: "agent-one",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            env_vars: &[],
+        })
+        .unwrap();
+    store
+        .join_channel("eng", "agent-one", SenderType::Agent)
+        .unwrap();
+
+    let payload = r#"{"kind":"task_event","action":"claimed","taskNumber":7,"title":"wire up","subChannelId":"s-1","actor":"alice","prevStatus":"todo","nextStatus":"in_progress","claimedBy":"alice"}"#;
+    store.create_system_message(&channel_id, payload).unwrap();
+
+    let backend = ChorusBackend::new(server_url);
+    let history = backend
+        .read_history("agent-one", "eng", Some(20), None, None)
+        .await
+        .expect("read_history should succeed");
+
+    assert!(
+        history.contains(r#"[task] alice claimed #7 "wire up" (now in_progress)"#),
+        "expected formatted task-event sentence in history, got:\n{}",
+        history
+    );
+    assert!(
+        !history.contains(r#""kind":"task_event""#),
+        "raw JSON must NOT appear in agent-facing history; got:\n{}",
+        history
+    );
+}
+
+#[tokio::test]
+async fn bridge_receive_messages_formats_task_event_messages() {
+    use chorus::bridge::backend::{Backend, ChorusBackend};
+    use chorus::store::channels::ChannelType;
+
+    let (server_url, store) = start_chorus_server().await;
+
+    let channel_id = store
+        .create_channel("eng", None, ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store
+        .join_channel("eng", "alice", SenderType::Human)
+        .unwrap();
+    store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "agent-one",
+            display_name: "agent-one",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            env_vars: &[],
+        })
+        .unwrap();
+    store
+        .join_channel("eng", "agent-one", SenderType::Agent)
+        .unwrap();
+
+    let backend = ChorusBackend::new(server_url);
+
+    // Start a receive_messages call (blocking with short timeout) in parallel
+    // with seeding a task_event — the receive path should surface it with the
+    // formatted content.
+    let recv = tokio::spawn({
+        let backend = backend.clone();
+        async move {
+            backend
+                .receive_messages("agent-one", true, 2_000)
+                .await
+                .expect("receive_messages should succeed")
+        }
+    });
+
+    // Give the receive subscription a moment to register before the write
+    // races past it. TODO: replace with a subscription-registered signal once
+    // the store exposes one — a 100ms sleep is a race-deferral, not a sync
+    // primitive, and could flake on a loaded CI box. Matches the pattern at
+    // lines 38 / 61 / 170 / 568 in this file.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let payload = r#"{"kind":"task_event","action":"claimed","taskNumber":7,"title":"wire up","subChannelId":"s-1","actor":"alice","prevStatus":"todo","nextStatus":"in_progress","claimedBy":"alice"}"#;
+    store.create_system_message(&channel_id, payload).unwrap();
+
+    let received = recv.await.expect("recv task");
+
+    assert!(
+        received.contains(r#"[task] alice claimed #7 "wire up" (now in_progress)"#),
+        "expected formatted task-event sentence in receive payload, got:\n{}",
+        received
+    );
+    assert!(
+        !received.contains(r#""kind":"task_event""#),
+        "raw JSON must NOT appear in agent-facing receive; got:\n{}",
+        received
+    );
+}

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -498,3 +498,96 @@ async fn get_task_detail_returns_task_and_sub_channel() {
         .unwrap();
     assert_eq!(resp.status(), 404);
 }
+
+/// Task lifecycle: create → claim → in_review → done emits exactly 4 ordered
+/// system messages in the parent channel.
+#[tokio::test]
+async fn task_lifecycle_emits_four_events_in_parent_channel() {
+    use chorus::store::tasks::TaskStatus;
+
+    let (_url, store) = start_test_server().await;
+    let parent_id = store
+        .create_channel("eng", None, ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store
+        .join_channel("eng", "alice", SenderType::Human)
+        .unwrap();
+
+    // create → claim → in_review → done
+    store.create_tasks("eng", "alice", &["wire up"]).unwrap();
+    store.update_tasks_claim("eng", "alice", &[1]).unwrap();
+    store
+        .update_task_status("eng", 1, "alice", TaskStatus::InReview)
+        .unwrap();
+    store
+        .update_task_status("eng", 1, "alice", TaskStatus::Done)
+        .unwrap();
+
+    let events: Vec<serde_json::Value> = store
+        .conn_for_test()
+        .prepare(
+            "SELECT content FROM messages \
+             WHERE channel_id = ?1 AND sender_type = 'system' \
+             ORDER BY seq",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![parent_id], |r| r.get::<_, String>(0))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|s| serde_json::from_str(&s).unwrap())
+        .collect();
+
+    assert_eq!(events.len(), 4);
+    assert_eq!(events[0]["action"], "created");
+    assert_eq!(events[1]["action"], "claimed");
+    assert_eq!(events[2]["action"], "status_changed");
+    assert_eq!(events[2]["nextStatus"], "in_review");
+    assert_eq!(events[3]["action"], "status_changed");
+    assert_eq!(events[3]["nextStatus"], "done");
+}
+
+/// Batched create_tasks with 3 titles exercises the pending_events Vec with
+/// more than one entry and emits one `created` event per task.
+#[tokio::test]
+async fn batched_create_tasks_emits_one_event_per_task() {
+    let (_url, store) = start_test_server().await;
+    let parent_id = store
+        .create_channel("eng2", None, ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("bob").unwrap();
+    store
+        .join_channel("eng2", "bob", SenderType::Human)
+        .unwrap();
+
+    // Three tasks in one call exercises the pending_events Vec with > 1 entry.
+    let created = store
+        .create_tasks("eng2", "bob", &["a", "b", "c"])
+        .unwrap();
+    assert_eq!(created.len(), 3);
+
+    let events: Vec<serde_json::Value> = store
+        .conn_for_test()
+        .prepare(
+            "SELECT content FROM messages \
+             WHERE channel_id = ?1 AND sender_type = 'system' \
+             ORDER BY seq",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![parent_id], |r| r.get::<_, String>(0))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|s| serde_json::from_str(&s).unwrap())
+        .collect();
+
+    assert_eq!(events.len(), 3);
+    for (i, event) in events.iter().enumerate() {
+        assert_eq!(event["action"], "created");
+        assert_eq!(event["taskNumber"], (i + 1) as i64);
+        assert_eq!(event["actor"], "bob");
+    }
+    // Task numbers are distinct 1, 2, 3 in creation order.
+    assert_eq!(events[0]["title"], "a");
+    assert_eq!(events[1]["title"], "b");
+    assert_eq!(events[2]["title"], "c");
+}

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -561,9 +561,7 @@ async fn batched_create_tasks_emits_one_event_per_task() {
         .unwrap();
 
     // Three tasks in one call exercises the pending_events Vec with > 1 entry.
-    let created = store
-        .create_tasks("eng2", "bob", &["a", "b", "c"])
-        .unwrap();
+    let created = store.create_tasks("eng2", "bob", &["a", "b", "c"]).unwrap();
     assert_eq!(created.len(), 3);
 
     let events: Vec<serde_json::Value> = store

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1650,3 +1650,31 @@ fn test_lookup_sender_type_recovers_after_mutex_poison() {
 
     let _conn = store.conn_for_test();
 }
+
+#[test]
+fn task_event_payload_round_trips_through_json() {
+    use chorus::store::tasks::events::{TaskEventAction, TaskEventPayload};
+    use chorus::store::tasks::TaskStatus;
+
+    let original = TaskEventPayload {
+        action: TaskEventAction::Claimed,
+        task_number: 7,
+        title: "wire up the bridge".into(),
+        sub_channel_id: "22222222-2222-2222-2222-222222222222".into(),
+        actor: "alice".into(),
+        prev_status: Some(TaskStatus::Todo),
+        next_status: TaskStatus::InProgress,
+        claimed_by: Some("alice".into()),
+    };
+
+    let json = original.to_json_string().unwrap();
+    assert!(json.contains(r#""kind":"task_event""#));
+    assert!(json.contains(r#""action":"claimed""#));
+    assert!(json.contains(r#""nextStatus":"in_progress""#));
+    assert!(json.contains(r#""taskNumber":7"#));
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["kind"], "task_event");
+    assert_eq!(parsed["actor"], "alice");
+    assert_eq!(parsed["subChannelId"], "22222222-2222-2222-2222-222222222222");
+}

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1739,3 +1739,66 @@ fn create_tasks_emits_task_event_to_parent_channel() {
     assert_eq!(parsed["nextStatus"], "todo");
     assert_eq!(parsed["title"], "wire up the bridge");
 }
+
+#[test]
+fn claim_task_emits_claimed_event_to_parent_channel() {
+    let (store, _dir) = make_store();
+    let parent_id = store
+        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("bob").unwrap();
+    store.join_channel("eng", "bob", chorus::store::messages::types::SenderType::Human).unwrap();
+    store.create_human("alice").unwrap();
+    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+
+    store.create_tasks("eng", "bob", &["t"]).unwrap();
+    store.update_tasks_claim("eng", "alice", &[1]).unwrap();
+
+    let events: Vec<serde_json::Value> = store
+        .conn_for_test()
+        .prepare("SELECT content FROM messages WHERE channel_id = ?1 AND sender_type = 'system' ORDER BY seq")
+        .unwrap()
+        .query_map(rusqlite::params![parent_id], |r| r.get::<_, String>(0))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|s| serde_json::from_str(&s).unwrap())
+        .collect();
+
+    assert_eq!(events.len(), 2); // created + claimed
+    assert_eq!(events[1]["action"], "claimed");
+    assert_eq!(events[1]["actor"], "alice");
+    assert_eq!(events[1]["taskNumber"], 1);
+    assert_eq!(events[1]["prevStatus"], "todo");
+    assert_eq!(events[1]["nextStatus"], "in_progress");
+    assert_eq!(events[1]["claimedBy"], "alice");
+}
+
+#[test]
+fn unclaim_task_emits_unclaimed_event() {
+    let (store, _dir) = make_store();
+    store
+        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+    store.create_tasks("eng", "alice", &["t"]).unwrap();
+    store.update_tasks_claim("eng", "alice", &[1]).unwrap();
+
+    store.update_task_unclaim("eng", "alice", 1).unwrap();
+
+    let last_event: serde_json::Value = {
+        let content: String = store
+            .conn_for_test()
+            .query_row(
+                "SELECT content FROM messages WHERE sender_type = 'system' ORDER BY seq DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        serde_json::from_str(&content).unwrap()
+    };
+    assert_eq!(last_event["action"], "unclaimed");
+    assert_eq!(last_event["prevStatus"], "in_progress");
+    assert_eq!(last_event["nextStatus"], "todo");
+    assert_eq!(last_event["claimedBy"], serde_json::Value::Null);
+}

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1802,3 +1802,35 @@ fn unclaim_task_emits_unclaimed_event() {
     assert_eq!(last_event["nextStatus"], "todo");
     assert_eq!(last_event["claimedBy"], serde_json::Value::Null);
 }
+
+#[test]
+fn update_task_status_emits_status_changed_event() {
+    let (store, _dir) = make_store();
+    store
+        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+    store.create_tasks("eng", "alice", &["t"]).unwrap();
+    store.update_tasks_claim("eng", "alice", &[1]).unwrap();
+
+    store
+        .update_task_status("eng", 1, "alice", TaskStatus::InReview)
+        .unwrap();
+
+    let last_event: serde_json::Value = {
+        let content: String = store
+            .conn_for_test()
+            .query_row(
+                "SELECT content FROM messages WHERE sender_type = 'system' ORDER BY seq DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        serde_json::from_str(&content).unwrap()
+    };
+    assert_eq!(last_event["action"], "status_changed");
+    assert_eq!(last_event["actor"], "alice");
+    assert_eq!(last_event["prevStatus"], "in_progress");
+    assert_eq!(last_event["nextStatus"], "in_review");
+}

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1895,3 +1895,62 @@ fn update_task_status_emits_status_changed_event() {
     assert_eq!(last_event["prevStatus"], "in_progress");
     assert_eq!(last_event["nextStatus"], "in_review");
 }
+
+#[test]
+fn get_unread_summary_excludes_archived_task_sub_channels() {
+    // Archived task sub-channels are terminal work, hidden from the active UI.
+    // The agent start-prompt builder reads `get_unread_summary`; without this
+    // filter an agent resuming after a task hits `Done` gets told it has
+    // unread messages in a channel it can't navigate to. Mirrors the filter
+    // used by `get_inbox_conversation_notifications` for the sidebar.
+    let (store, _dir) = make_store();
+    let sub_id = store
+        .create_channel("eng__task-1", None, ChannelType::Task, None)
+        .unwrap();
+    store.create_human("alice").unwrap();
+    store.create_human("bob").unwrap();
+    store
+        .join_channel_by_id(&sub_id, "alice", SenderType::Human)
+        .unwrap();
+    store
+        .join_channel_by_id(&sub_id, "bob", SenderType::Human)
+        .unwrap();
+    // Bob's non-system message is unread for alice (the view excludes system
+    // messages, so only human/agent traffic can produce a leak).
+    store
+        .create_message(CreateMessage {
+            channel_name: "eng__task-1",
+            sender_name: "bob",
+            sender_type: SenderType::Human,
+            content: "hi alice",
+            attachment_ids: &[],
+            suppress_event: true,
+            run_id: None,
+        })
+        .unwrap();
+
+    let before = store.get_unread_summary("alice").unwrap();
+    assert_eq!(
+        before.get("eng__task-1"),
+        Some(&1),
+        "pre-archive: unread summary must include the sub-channel"
+    );
+
+    // Simulate the `Done` transition's archive step (direct UPDATE; the full
+    // lifecycle path is covered by `task_lifecycle_emits_four_events_in_parent_channel`).
+    store
+        .conn_for_test()
+        .execute(
+            "UPDATE channels SET archived = 1 WHERE id = ?1",
+            params![sub_id],
+        )
+        .unwrap();
+
+    let after = store.get_unread_summary("alice").unwrap();
+    assert!(
+        !after.contains_key("eng__task-1"),
+        "post-archive: unread summary must exclude archived task sub-channels, \
+         got {:?}",
+        after
+    );
+}

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1676,7 +1676,10 @@ fn task_event_payload_round_trips_through_json() {
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed["kind"], "task_event");
     assert_eq!(parsed["actor"], "alice");
-    assert_eq!(parsed["subChannelId"], "22222222-2222-2222-2222-222222222222");
+    assert_eq!(
+        parsed["subChannelId"],
+        "22222222-2222-2222-2222-222222222222"
+    );
 }
 
 #[test]
@@ -1699,8 +1702,16 @@ fn task_event_payload_serializes_none_fields_as_json_null() {
     };
     let parsed: serde_json::Value =
         serde_json::from_str(&created.to_json_string().unwrap()).unwrap();
-    assert!(parsed["prevStatus"].is_null(), "expected JSON null, got {:?}", parsed["prevStatus"]);
-    assert!(parsed["claimedBy"].is_null(), "expected JSON null, got {:?}", parsed["claimedBy"]);
+    assert!(
+        parsed["prevStatus"].is_null(),
+        "expected JSON null, got {:?}",
+        parsed["prevStatus"]
+    );
+    assert!(
+        parsed["claimedBy"].is_null(),
+        "expected JSON null, got {:?}",
+        parsed["claimedBy"]
+    );
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["nextStatus"], "todo");
 }
@@ -1709,10 +1720,21 @@ fn task_event_payload_serializes_none_fields_as_json_null() {
 fn create_tasks_emits_task_event_to_parent_channel() {
     let (store, _dir) = make_store();
     let parent_id = store
-        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .create_channel(
+            "eng",
+            None,
+            chorus::store::channels::ChannelType::Channel,
+            None,
+        )
         .unwrap();
     store.create_human("bob").unwrap();
-    store.join_channel("eng", "bob", chorus::store::messages::types::SenderType::Human).unwrap();
+    store
+        .join_channel(
+            "eng",
+            "bob",
+            chorus::store::messages::types::SenderType::Human,
+        )
+        .unwrap();
 
     let result = store
         .create_tasks("eng", "bob", &["wire up the bridge"])
@@ -1744,12 +1766,29 @@ fn create_tasks_emits_task_event_to_parent_channel() {
 fn claim_task_emits_claimed_event_to_parent_channel() {
     let (store, _dir) = make_store();
     let parent_id = store
-        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .create_channel(
+            "eng",
+            None,
+            chorus::store::channels::ChannelType::Channel,
+            None,
+        )
         .unwrap();
     store.create_human("bob").unwrap();
-    store.join_channel("eng", "bob", chorus::store::messages::types::SenderType::Human).unwrap();
+    store
+        .join_channel(
+            "eng",
+            "bob",
+            chorus::store::messages::types::SenderType::Human,
+        )
+        .unwrap();
     store.create_human("alice").unwrap();
-    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+    store
+        .join_channel(
+            "eng",
+            "alice",
+            chorus::store::messages::types::SenderType::Human,
+        )
+        .unwrap();
 
     store.create_tasks("eng", "bob", &["t"]).unwrap();
     store.update_tasks_claim("eng", "alice", &[1]).unwrap();
@@ -1777,10 +1816,21 @@ fn claim_task_emits_claimed_event_to_parent_channel() {
 fn unclaim_task_emits_unclaimed_event() {
     let (store, _dir) = make_store();
     store
-        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .create_channel(
+            "eng",
+            None,
+            chorus::store::channels::ChannelType::Channel,
+            None,
+        )
         .unwrap();
     store.create_human("alice").unwrap();
-    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+    store
+        .join_channel(
+            "eng",
+            "alice",
+            chorus::store::messages::types::SenderType::Human,
+        )
+        .unwrap();
     store.create_tasks("eng", "alice", &["t"]).unwrap();
     store.update_tasks_claim("eng", "alice", &[1]).unwrap();
 
@@ -1807,10 +1857,21 @@ fn unclaim_task_emits_unclaimed_event() {
 fn update_task_status_emits_status_changed_event() {
     let (store, _dir) = make_store();
     store
-        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .create_channel(
+            "eng",
+            None,
+            chorus::store::channels::ChannelType::Channel,
+            None,
+        )
         .unwrap();
     store.create_human("alice").unwrap();
-    store.join_channel("eng", "alice", chorus::store::messages::types::SenderType::Human).unwrap();
+    store
+        .join_channel(
+            "eng",
+            "alice",
+            chorus::store::messages::types::SenderType::Human,
+        )
+        .unwrap();
     store.create_tasks("eng", "alice", &["t"]).unwrap();
     store.update_tasks_claim("eng", "alice", &[1]).unwrap();
 

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1704,3 +1704,38 @@ fn task_event_payload_serializes_none_fields_as_json_null() {
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["nextStatus"], "todo");
 }
+
+#[test]
+fn create_tasks_emits_task_event_to_parent_channel() {
+    let (store, _dir) = make_store();
+    let parent_id = store
+        .create_channel("eng", None, chorus::store::channels::ChannelType::Channel, None)
+        .unwrap();
+    store.create_human("bob").unwrap();
+    store.join_channel("eng", "bob", chorus::store::messages::types::SenderType::Human).unwrap();
+
+    let result = store
+        .create_tasks("eng", "bob", &["wire up the bridge"])
+        .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let event_rows: Vec<(String, String)> = store
+        .conn_for_test()
+        .prepare("SELECT sender_type, content FROM messages WHERE channel_id = ?1 ORDER BY seq")
+        .unwrap()
+        .query_map(rusqlite::params![parent_id], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+
+    assert_eq!(event_rows.len(), 1);
+    assert_eq!(event_rows[0].0, "system");
+
+    let parsed: serde_json::Value = serde_json::from_str(&event_rows[0].1).unwrap();
+    assert_eq!(parsed["kind"], "task_event");
+    assert_eq!(parsed["action"], "created");
+    assert_eq!(parsed["actor"], "bob");
+    assert_eq!(parsed["taskNumber"], 1);
+    assert_eq!(parsed["nextStatus"], "todo");
+    assert_eq!(parsed["title"], "wire up the bridge");
+}

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -1678,3 +1678,29 @@ fn task_event_payload_round_trips_through_json() {
     assert_eq!(parsed["actor"], "alice");
     assert_eq!(parsed["subChannelId"], "22222222-2222-2222-2222-222222222222");
 }
+
+#[test]
+fn task_event_payload_serializes_none_fields_as_json_null() {
+    use chorus::store::tasks::events::{TaskEventAction, TaskEventPayload};
+    use chorus::store::tasks::TaskStatus;
+
+    // Created events set prev_status = None and claimed_by = None. The frontend
+    // parser needs `null` for these (not missing keys) to distinguish "event
+    // explicitly cleared the field" from "producer forgot the field".
+    let created = TaskEventPayload {
+        action: TaskEventAction::Created,
+        task_number: 1,
+        title: "t".into(),
+        sub_channel_id: "s".into(),
+        actor: "a".into(),
+        prev_status: None,
+        next_status: TaskStatus::Todo,
+        claimed_by: None,
+    };
+    let parsed: serde_json::Value =
+        serde_json::from_str(&created.to_json_string().unwrap()).unwrap();
+    assert!(parsed["prevStatus"].is_null(), "expected JSON null, got {:?}", parsed["prevStatus"]);
+    assert!(parsed["claimedBy"].is_null(), "expected JSON null, got {:?}", parsed["claimedBy"]);
+    assert_eq!(parsed["action"], "created");
+    assert_eq!(parsed["nextStatus"], "todo");
+}

--- a/ui/src/components/chat/MessageList.test.tsx
+++ b/ui/src/components/chat/MessageList.test.tsx
@@ -1,0 +1,91 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+import { MessageList } from "./MessageList";
+import type { HistoryMessage } from "../../data/chat";
+
+// MessageList calls the store in TWO shapes:
+//   useStore() — returns full state (destructured for advanceConversationLastReadSeq)
+//   useStore((s) => s.setCurrentTaskDetail) — selector form for our new branch
+// The mock must support both or the test crashes before the assertion.
+vi.mock("../../store", () => {
+  const state = {
+    advanceConversationLastReadSeq: () => {},
+    setCurrentTaskDetail: () => {},
+  };
+  return {
+    useStore: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+// Partial-mock, not a full stub: `data/channels.ts` uses `queryOptions` at
+// module-load time, so replacing the whole react-query module with a stub
+// crashes the import graph before the test runs. Spread the real exports and
+// only override `useQueryClient`, which is what MessageList actually calls.
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      setQueryData: () => {},
+      invalidateQueries: () => {},
+    }),
+  };
+});
+
+describe("MessageList — task_event rendering", () => {
+  it("renders exactly one task-thread for a sequence of events on the same task", () => {
+    const msgs: HistoryMessage[] = [
+      {
+        id: "m1",
+        seq: 1,
+        content: JSON.stringify({
+          kind: "task_event",
+          action: "created",
+          taskNumber: 7,
+          title: "wire up",
+          subChannelId: "s",
+          actor: "alice",
+          nextStatus: "todo",
+        }),
+        senderName: "system",
+        senderType: "system",
+        createdAt: "2026-04-23T10:00:00Z",
+        senderDeleted: false,
+      },
+      {
+        id: "m2",
+        seq: 2,
+        content: JSON.stringify({
+          kind: "task_event",
+          action: "claimed",
+          taskNumber: 7,
+          title: "wire up",
+          subChannelId: "s",
+          actor: "alice",
+          prevStatus: "todo",
+          nextStatus: "in_progress",
+          claimedBy: "alice",
+        }),
+        senderName: "system",
+        senderType: "system",
+        createdAt: "2026-04-23T10:05:00Z",
+        senderDeleted: false,
+      },
+    ];
+    const html = renderToStaticMarkup(
+      <MessageList
+        targetKey="eng"
+        conversationId="cid"
+        messages={msgs}
+        loading={false}
+        lastReadSeq={0}
+        currentUser="alice"
+      />,
+    );
+    const occurrences = (html.match(/data-testid="task-thread-7"/g) ?? [])
+      .length;
+    expect(occurrences).toBe(1);
+    expect(html).toContain('data-state="in_progress"');
+  });
+});

--- a/ui/src/components/chat/MessageList.tsx
+++ b/ui/src/components/chat/MessageList.tsx
@@ -9,7 +9,6 @@ import { updateReadCursor, historyQueryKeys } from "../../data";
 import type { HistoryMessage, HistoryResponse } from "../../data";
 import { useStore } from "../../store";
 import { useTraceStore } from "../../store/traceStore";
-import { parseTaskEvent } from "../../data/taskEvents";
 import { useTaskEventLog } from "../../hooks/useTaskEventLog";
 import { TaskEventMessage } from "./TaskEventMessage";
 import "./MessageList.css";
@@ -91,7 +90,7 @@ export function MessageList({
   const queryClient = useQueryClient();
   const queryKey = historyQueryKeys.history(conversationId ?? "");
   const { advanceConversationLastReadSeq } = useStore();
-  const taskStates = useTaskEventLog(messages);
+  const taskEventIndex = useTaskEventLog(messages);
   const setCurrentTaskDetail = useStore((s) => s.setCurrentTaskDetail);
 
   // ── Sync refs with props ──
@@ -337,45 +336,46 @@ export function MessageList({
       {messages.map((msg, i) => {
         // Task-event system messages short-circuit to the TaskEventMessage
         // renderer. Suppress repeated events for the same task so we render
-        // one card per task, anchored at its latest event.
-        if (msg.senderType === "system") {
-          const ev = parseTaskEvent(msg.content);
-          if (ev) {
-            const state = taskStates.get(ev.taskNumber);
-            const isLatestForTask = state && state.latestSeq === msg.seq;
+        // one card per task, anchored at its latest event. The hook already
+        // parsed the payload once when building `taskEventIndex`; the render
+        // loop just asks "does this seq belong to a task?" — O(1), no JSON
+        // re-parse.
+        const taskNumber = taskEventIndex.taskNumberBySeq.get(msg.seq);
+        if (msg.senderType === "system" && taskNumber !== undefined) {
+          const state = taskEventIndex.byTaskNumber.get(taskNumber);
+          const isLatestForTask = state && state.latestSeq === msg.seq;
 
-            // Even when we suppress the task-card render (not the latest
-            // event), we still need the wrapper div so visibility tracking
-            // hits the row AND the unread divider anchors on the right seq.
-            // Returning null here loses the unread anchor entirely.
-            return (
+          // Even when we suppress the task-card render (not the latest
+          // event), we still need the wrapper div so visibility tracking
+          // hits the row AND the unread divider anchors on the right seq.
+          // Returning null here loses the unread anchor entirely.
+          return (
+            <div
+              key={msg.id}
+              ref={(el) => {
+                if (el) messageRowRefs.current.set(msg.id, el);
+                else messageRowRefs.current.delete(msg.id);
+              }}
+            >
               <div
-                key={msg.id}
-                ref={(el) => {
-                  if (el) messageRowRefs.current.set(msg.id, el);
-                  else messageRowRefs.current.delete(msg.id);
-                }}
-              >
-                <div
-                  ref={i === firstUnreadIndex ? firstUnreadAnchorRef : undefined}
+                ref={i === firstUnreadIndex ? firstUnreadAnchorRef : undefined}
+              />
+              {hasUnread && i === firstUnreadIndex && <NewMessageDivider />}
+              {isLatestForTask && state && (
+                <TaskEventMessage
+                  taskState={state}
+                  onOpen={() =>
+                    setCurrentTaskDetail({
+                      parentChannelId: conversationId ?? "",
+                      parentSlug: targetKey ?? "",
+                      taskNumber,
+                      returnToTab: "chat",
+                    })
+                  }
                 />
-                {hasUnread && i === firstUnreadIndex && <NewMessageDivider />}
-                {isLatestForTask && state && (
-                  <TaskEventMessage
-                    taskState={state}
-                    onOpen={() =>
-                      setCurrentTaskDetail({
-                        parentChannelId: conversationId ?? "",
-                        parentSlug: targetKey ?? "",
-                        taskNumber: ev.taskNumber,
-                        returnToTab: "chat",
-                      })
-                    }
-                  />
-                )}
-              </div>
-            );
-          }
+              )}
+            </div>
+          );
         }
 
         // Bind trace to message:

--- a/ui/src/components/chat/MessageList.tsx
+++ b/ui/src/components/chat/MessageList.tsx
@@ -9,6 +9,9 @@ import { updateReadCursor, historyQueryKeys } from "../../data";
 import type { HistoryMessage, HistoryResponse } from "../../data";
 import { useStore } from "../../store";
 import { useTraceStore } from "../../store/traceStore";
+import { parseTaskEvent } from "../../data/taskEvents";
+import { useTaskEventLog } from "../../hooks/useTaskEventLog";
+import { TaskEventMessage } from "./TaskEventMessage";
 import "./MessageList.css";
 import type { RefObject } from "react";
 
@@ -88,6 +91,8 @@ export function MessageList({
   const queryClient = useQueryClient();
   const queryKey = historyQueryKeys.history(conversationId ?? "");
   const { advanceConversationLastReadSeq } = useStore();
+  const taskStates = useTaskEventLog(messages);
+  const setCurrentTaskDetail = useStore((s) => s.setCurrentTaskDetail);
 
   // ── Sync refs with props ──
   useEffect(() => {
@@ -330,6 +335,49 @@ export function MessageList({
         <div className="message-list-empty">{emptyLabel}</div>
       )}
       {messages.map((msg, i) => {
+        // Task-event system messages short-circuit to the TaskEventMessage
+        // renderer. Suppress repeated events for the same task so we render
+        // one card per task, anchored at its latest event.
+        if (msg.senderType === "system") {
+          const ev = parseTaskEvent(msg.content);
+          if (ev) {
+            const state = taskStates.get(ev.taskNumber);
+            const isLatestForTask = state && state.latestSeq === msg.seq;
+
+            // Even when we suppress the task-card render (not the latest
+            // event), we still need the wrapper div so visibility tracking
+            // hits the row AND the unread divider anchors on the right seq.
+            // Returning null here loses the unread anchor entirely.
+            return (
+              <div
+                key={msg.id}
+                ref={(el) => {
+                  if (el) messageRowRefs.current.set(msg.id, el);
+                  else messageRowRefs.current.delete(msg.id);
+                }}
+              >
+                <div
+                  ref={i === firstUnreadIndex ? firstUnreadAnchorRef : undefined}
+                />
+                {hasUnread && i === firstUnreadIndex && <NewMessageDivider />}
+                {isLatestForTask && state && (
+                  <TaskEventMessage
+                    taskState={state}
+                    onOpen={() =>
+                      setCurrentTaskDetail({
+                        parentChannelId: conversationId ?? "",
+                        parentSlug: targetKey ?? "",
+                        taskNumber: ev.taskNumber,
+                        returnToTab: "chat",
+                      })
+                    }
+                  />
+                )}
+              </div>
+            );
+          }
+        }
+
         // Bind trace to message:
         // 1. Exact runId match on the LAST message for this run → telescope tracks latest message
         // 2. Inactive trace with no runId match → fallback to last message by agent

--- a/ui/src/components/chat/TaskEventMessage.css
+++ b/ui/src/components/chat/TaskEventMessage.css
@@ -3,7 +3,7 @@
  *   .task-event-thread[data-state="<status>"]  → outer state machine
  *   .task-event-status[data-status="<status>"] → colored status pill
  *   .task-event-card[data-claimed="true|false"] → claimer row visibility
- *   .task-event-ev.show                         → timeline event entry
+ *   .task-event-ev.is-show                      → timeline event entry
  *
  * State transitions are 100% CSS — React only toggles data attributes.
  * Ported from the variant-d.html prototype with a `task-event-*` prefix on

--- a/ui/src/components/chat/TaskEventMessage.css
+++ b/ui/src/components/chat/TaskEventMessage.css
@@ -42,6 +42,14 @@
   border: 1px solid var(--color-border);
   background: var(--color-popover);
   padding: 10px 12px;
+  transition: background 0.15s ease;
+}
+.task-event-card:hover {
+  /* Large-surface hover: accent tint, not primary-invert. Matches the
+   * `.task-event-done-row:hover` pattern so card-view and pill-view feel
+   * identical, and mirrors `.message-item:hover` — the house recipe for
+   * large feed surfaces. Documented in `docs/DESIGN.md`. */
+  background: var(--color-accent);
 }
 .task-event-card-head {
   display: flex;

--- a/ui/src/components/chat/TaskEventMessage.css
+++ b/ui/src/components/chat/TaskEventMessage.css
@@ -1,0 +1,206 @@
+/*
+ * Animated task-event card ↔ done-pill recipe. CSS contract:
+ *   .task-event-thread[data-state="<status>"]  → outer state machine
+ *   .task-event-status[data-status="<status>"] → colored status pill
+ *   .task-event-card[data-claimed="true|false"] → claimer row visibility
+ *   .task-event-ev.show                         → timeline event entry
+ *
+ * State transitions are 100% CSS — React only toggles data attributes.
+ * Ported from the variant-d.html prototype with a `task-event-*` prefix on
+ * every class so we don't collide with the `.task-card` / `.task-column`
+ * rules in TasksPanel.css.
+ */
+
+:root {
+  --task-event-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.task-event-thread {
+  position: relative;
+}
+
+.task-event-thread .task-event-card-view {
+  overflow: hidden;
+  max-height: 400px;
+  opacity: 1;
+  transition:
+    max-height 260ms var(--task-event-ease),
+    opacity 180ms ease 100ms;
+}
+.task-event-thread[data-state="done"] .task-event-card-view {
+  max-height: 0;
+  opacity: 0;
+}
+
+.task-event-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  border: 1px solid var(--color-border);
+  background: var(--color-popover);
+  padding: 10px 12px;
+}
+.task-event-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.task-event-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.07em;
+  text-transform: lowercase;
+  color: var(--color-muted-foreground);
+}
+
+.task-event-status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: lowercase;
+  padding: 2px 6px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-muted-foreground);
+  color: var(--color-muted-foreground);
+  transition:
+    border-left-color 220ms var(--task-event-ease),
+    color 220ms var(--task-event-ease);
+}
+.task-event-status[data-status="in_progress"] {
+  border-left-color: var(--color-accent-foreground);
+  color: var(--color-foreground);
+}
+.task-event-status[data-status="in_review"] {
+  border-left-color: var(--color-warning);
+  color: var(--color-warning);
+}
+.task-event-status[data-status="done"] {
+  border-left-color: var(--status-online);
+  color: var(--status-online);
+}
+
+.task-event-title {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--color-foreground);
+}
+.task-event-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-muted-foreground);
+  margin-top: 4px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.task-event-claimer {
+  display: inline-block;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    max-height 200ms var(--task-event-ease),
+    opacity 180ms ease-in 40ms;
+}
+.task-event-card[data-claimed="true"] .task-event-claimer {
+  max-height: 20px;
+  opacity: 1;
+}
+
+.task-event-timeline {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-muted-foreground);
+  padding: 6px 12px 0 12px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.task-event-ev {
+  display: inline-flex;
+  gap: 5px;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition:
+    opacity 180ms ease,
+    transform 180ms var(--task-event-ease);
+}
+.task-event-ev.is-show {
+  opacity: 1;
+  transform: translateX(0);
+}
+.task-event-ev.is-review {
+  color: var(--color-warning);
+}
+.task-event-ev.is-done {
+  color: var(--status-online);
+}
+
+.task-event-thread .task-event-pill-view {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    max-height 260ms var(--task-event-ease) 80ms,
+    opacity 200ms ease 180ms;
+}
+.task-event-thread[data-state="done"] .task-event-pill-view {
+  max-height: 60px;
+  opacity: 1;
+}
+/* Done-pill uses existing palette tokens — `docs/DESIGN.md` forbids raw hex
+ * or rgba values without a design-system source. The border-left-accent green
+ * carried by `.task-event-status[data-status="done"]` is enough signal; the
+ * pill itself keeps the muted cream background family.
+ */
+.task-event-done-row {
+  display: flex;
+  gap: 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--status-online);
+  background: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-muted-foreground);
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+.task-event-done-row:hover {
+  background: var(--color-accent);
+}
+.task-event-done-tag {
+  color: var(--status-online);
+  font-weight: 600;
+}
+.task-event-done-strike {
+  text-decoration: line-through;
+  color: var(--color-foreground);
+  opacity: 0.65;
+}
+.task-event-done-open {
+  margin-left: auto;
+  border: 1px solid var(--color-border);
+  padding: 1px 6px;
+  color: var(--color-muted-foreground);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task-event-thread .task-event-card-view,
+  .task-event-thread .task-event-pill-view,
+  .task-event-status,
+  .task-event-claimer,
+  .task-event-ev {
+    transition: none !important;
+  }
+}

--- a/ui/src/components/chat/TaskEventMessage.test.tsx
+++ b/ui/src/components/chat/TaskEventMessage.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import { TaskEventMessage } from './TaskEventMessage'
+import type { TaskState } from '../../hooks/useTaskEventLog'
+
+function state(partial: Partial<TaskState>): TaskState {
+  return {
+    taskNumber: 7,
+    title: 'wire up the bridge',
+    subChannelId: 'sub-1',
+    status: 'todo',
+    claimedBy: null,
+    events: [
+      {
+        eventId: 'e1',
+        seq: 1,
+        action: 'created',
+        actor: 'alice',
+        nextStatus: 'todo',
+        createdAt: '2026-04-23T10:00:00Z',
+      },
+    ],
+    latestSeq: 1,
+    ...partial,
+  }
+}
+
+describe('TaskEventMessage', () => {
+  it('renders the living card when status is not done', () => {
+    const html = renderToStaticMarkup(
+      <TaskEventMessage taskState={state({ status: 'in_progress', claimedBy: 'alice' })} onOpen={() => {}} />,
+    )
+    expect(html).toContain('wire up the bridge')
+    expect(html).toContain('#7')
+    expect(html).toContain('claimed by alice')
+    expect(html).toContain('data-state="in_progress"')
+    expect(html).toContain('data-status="in_progress"')
+    expect(html).toContain('task-event-thread')
+  })
+
+  it('renders the done pill when status is done', () => {
+    const html = renderToStaticMarkup(
+      <TaskEventMessage taskState={state({ status: 'done', claimedBy: 'alice' })} onOpen={() => {}} />,
+    )
+    expect(html).toContain('data-state="done"')
+    // The card-view is still rendered in markup (CSS collapses it) — we just
+    // verify the pill-view contents exist.
+    expect(html).toContain('task-event-done-row')
+  })
+
+  it('renders one timeline event per history entry, in order', () => {
+    const html = renderToStaticMarkup(
+      <TaskEventMessage
+        taskState={state({
+          status: 'in_review',
+          claimedBy: 'alice',
+          events: [
+            { eventId: 'e1', seq: 1, action: 'created', actor: 'alice', nextStatus: 'todo', createdAt: '2026-04-23T10:00:00Z' },
+            { eventId: 'e2', seq: 2, action: 'claimed', actor: 'alice', nextStatus: 'in_progress', createdAt: '2026-04-23T10:05:00Z' },
+            { eventId: 'e3', seq: 3, action: 'status_changed', actor: 'alice', prevStatus: 'in_progress', nextStatus: 'in_review', createdAt: '2026-04-23T11:00:00Z' },
+          ],
+        })}
+        onOpen={() => {}}
+      />,
+    )
+    expect(html).toContain('alice claimed')
+    expect(html).toContain('in review')
+  })
+})

--- a/ui/src/components/chat/TaskEventMessage.tsx
+++ b/ui/src/components/chat/TaskEventMessage.tsx
@@ -1,0 +1,120 @@
+import type { TaskState } from '../../hooks/useTaskEventLog'
+import type { TaskStatus } from '../../data/tasks'
+import './TaskEventMessage.css'
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  todo: 'todo',
+  in_progress: 'in progress',
+  in_review: 'in review',
+  done: 'done',
+}
+
+interface TaskEventMessageProps {
+  taskState: TaskState
+  /** Invoked when the user clicks the card or the done-pill row. Typically
+   *  opens the task detail overlay. */
+  onOpen: () => void
+}
+
+/**
+ * Render one task thread. The outer `data-state` attribute drives the
+ * card-vs-pill swap via CSS `max-height` transitions. Prior state is
+ * preserved across status changes — React rerenders, CSS animates.
+ */
+export function TaskEventMessage({
+  taskState,
+  onOpen,
+}: TaskEventMessageProps) {
+  const { taskNumber, title, status, claimedBy, events } = taskState
+  const isDone = status === 'done'
+  return (
+    <div
+      className="task-event-thread"
+      data-state={status}
+      data-testid={`task-thread-${taskNumber}`}
+    >
+      {/* Both card and pill render at all times so the CSS transitions have
+          something to animate between. Hide the inactive one from assistive
+          tech and remove it from the tab order — max-height:0 + opacity:0
+          alone does NOT prevent focus or screen-reader discovery. */}
+      <div
+        className="task-event-card-view"
+        aria-hidden={isDone || undefined}
+      >
+        <button
+          type="button"
+          className="task-event-card"
+          data-claimed={claimedBy ? 'true' : 'false'}
+          onClick={onOpen}
+          aria-label={`open task #${taskNumber}`}
+          tabIndex={isDone ? -1 : 0}
+        >
+          <div className="task-event-card-head">
+            <span className="task-event-num">#{taskNumber}</span>
+            <span className="task-event-status" data-status={status}>
+              {STATUS_LABEL[status]}
+            </span>
+          </div>
+          <span className="task-event-title">{title}</span>
+          <span className="task-event-meta">
+            <span className="task-event-claimer">
+              {claimedBy ? `claimed by ${claimedBy}` : ''}
+            </span>
+          </span>
+        </button>
+        <div className="task-event-timeline" role="list">
+          {events.map((e) => (
+            <span
+              key={e.eventId}
+              className={[
+                'task-event-ev',
+                'is-show',
+                e.nextStatus === 'in_review' && 'is-review',
+                e.nextStatus === 'done' && 'is-done',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              role="listitem"
+            >
+              {formatEvent(e.action, e.actor, e.nextStatus)}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div
+        className="task-event-pill-view"
+        aria-hidden={!isDone || undefined}
+      >
+        <button
+          type="button"
+          className="task-event-done-row"
+          onClick={onOpen}
+          aria-label={`open completed task #${taskNumber}`}
+          tabIndex={isDone ? 0 : -1}
+        >
+          <span className="task-event-done-tag">done</span>
+          <span>#{taskNumber}</span>
+          <span className="task-event-done-strike">{title}</span>
+          <span className="task-event-done-open">open →</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function formatEvent(
+  action: TaskState['events'][number]['action'],
+  actor: string,
+  nextStatus: TaskStatus,
+): string {
+  switch (action) {
+    case 'created':
+      return `${actor} created`
+    case 'claimed':
+      return `${actor} claimed`
+    case 'unclaimed':
+      return `${actor} unclaimed`
+    case 'status_changed':
+      return `→ ${STATUS_LABEL[nextStatus]}`
+  }
+}

--- a/ui/src/data/taskEvents.test.ts
+++ b/ui/src/data/taskEvents.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { parseTaskEvent } from './taskEvents'
+
+describe('parseTaskEvent', () => {
+  it('parses a well-formed task_event JSON string', () => {
+    const content = JSON.stringify({
+      kind: 'task_event',
+      action: 'claimed',
+      taskNumber: 7,
+      title: 'wire up the bridge',
+      subChannelId: 'sub-1',
+      actor: 'alice',
+      prevStatus: 'todo',
+      nextStatus: 'in_progress',
+      claimedBy: 'alice',
+    })
+    const parsed = parseTaskEvent(content)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.action).toBe('claimed')
+    expect(parsed!.taskNumber).toBe(7)
+    expect(parsed!.nextStatus).toBe('in_progress')
+  })
+
+  it('returns null for non-JSON content', () => {
+    expect(parseTaskEvent('hello world')).toBeNull()
+  })
+
+  it('returns null when kind is not task_event', () => {
+    expect(parseTaskEvent(JSON.stringify({ kind: 'other' }))).toBeNull()
+  })
+
+  it('returns null when required fields are missing', () => {
+    expect(
+      parseTaskEvent(JSON.stringify({ kind: 'task_event', action: 'claimed' })),
+    ).toBeNull()
+  })
+
+  it('returns null for an unknown action', () => {
+    const content = JSON.stringify({
+      kind: 'task_event',
+      action: 'deleted',
+      taskNumber: 1,
+      title: 't',
+      subChannelId: 's',
+      actor: 'a',
+      nextStatus: 'todo',
+    })
+    expect(parseTaskEvent(content)).toBeNull()
+  })
+
+  it('returns null when prevStatus is present but not a valid status', () => {
+    const content = JSON.stringify({
+      kind: 'task_event',
+      action: 'claimed',
+      taskNumber: 1,
+      title: 't',
+      subChannelId: 's',
+      actor: 'a',
+      prevStatus: 'garbage',
+      nextStatus: 'in_progress',
+    })
+    expect(parseTaskEvent(content)).toBeNull()
+  })
+
+  it('returns null when taskNumber is not an integer', () => {
+    const content = JSON.stringify({
+      kind: 'task_event',
+      action: 'created',
+      taskNumber: 1.5,
+      title: 't',
+      subChannelId: 's',
+      actor: 'a',
+      nextStatus: 'todo',
+    })
+    expect(parseTaskEvent(content)).toBeNull()
+  })
+
+  it('returns null when claimedBy is present but wrong type', () => {
+    const content = JSON.stringify({
+      kind: 'task_event',
+      action: 'claimed',
+      taskNumber: 1,
+      title: 't',
+      subChannelId: 's',
+      actor: 'a',
+      nextStatus: 'in_progress',
+      claimedBy: 42,
+    })
+    expect(parseTaskEvent(content)).toBeNull()
+  })
+})

--- a/ui/src/data/taskEvents.ts
+++ b/ui/src/data/taskEvents.ts
@@ -1,0 +1,105 @@
+import type { TaskStatus } from './tasks'
+
+export type TaskEventAction =
+  | 'created'
+  | 'claimed'
+  | 'unclaimed'
+  | 'status_changed'
+
+export interface TaskEventPayload {
+  kind: 'task_event'
+  action: TaskEventAction
+  taskNumber: number
+  title: string
+  subChannelId: string
+  actor: string
+  prevStatus?: TaskStatus
+  nextStatus: TaskStatus
+  claimedBy?: string | null
+}
+
+const VALID_ACTIONS: readonly TaskEventAction[] = [
+  'created',
+  'claimed',
+  'unclaimed',
+  'status_changed',
+]
+const VALID_STATUSES: readonly TaskStatus[] = [
+  'todo',
+  'in_progress',
+  'in_review',
+  'done',
+]
+
+/**
+ * Safely parse a message.content string into a TaskEventPayload. Returns null
+ * for anything that isn't a well-formed task_event JSON. Never throws.
+ *
+ * Called for every system-sender message in the chat feed. Performance matters.
+ */
+export function parseTaskEvent(content: string): TaskEventPayload | null {
+  if (!content || content[0] !== '{') return null
+  let raw: unknown
+  try {
+    raw = JSON.parse(content)
+  } catch {
+    return null
+  }
+  if (!raw || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  if (obj.kind !== 'task_event') return null
+  if (typeof obj.action !== 'string' || !VALID_ACTIONS.includes(obj.action as TaskEventAction)) {
+    return null
+  }
+  // taskNumber must be a finite integer. Strict TS won't narrow `unknown` to
+  // `number` via `Number.isInteger` alone, so check both: the typeof first
+  // narrows the type, then Number.isInteger rejects floats (`typeof 1.5 ===
+  // 'number'` so a pure typeof check would let them through).
+  if (typeof obj.taskNumber !== 'number' || !Number.isInteger(obj.taskNumber)) {
+    return null
+  }
+  if (typeof obj.title !== 'string') return null
+  if (typeof obj.subChannelId !== 'string') return null
+  if (typeof obj.actor !== 'string') return null
+  if (typeof obj.nextStatus !== 'string' || !VALID_STATUSES.includes(obj.nextStatus as TaskStatus)) {
+    return null
+  }
+  // prevStatus is optional, but when present it MUST be a valid status — a
+  // malformed value means the producer is broken, and silently dropping it
+  // weakens the "parseTaskEvent returns null on anything wrong" contract.
+  let prevStatus: TaskStatus | undefined
+  if (obj.prevStatus === undefined || obj.prevStatus === null) {
+    prevStatus = undefined
+  } else if (
+    typeof obj.prevStatus === 'string' &&
+    VALID_STATUSES.includes(obj.prevStatus as TaskStatus)
+  ) {
+    prevStatus = obj.prevStatus as TaskStatus
+  } else {
+    return null
+  }
+  // claimedBy: absent / null / string. A wrong-type value (number, object,
+  // array) means the producer is broken — fail the parse instead of silently
+  // coercing to undefined, which would paint the card as unclaimed.
+  let claimedBy: string | null | undefined
+  if (obj.claimedBy === undefined) {
+    claimedBy = undefined
+  } else if (obj.claimedBy === null) {
+    claimedBy = null
+  } else if (typeof obj.claimedBy === 'string') {
+    claimedBy = obj.claimedBy
+  } else {
+    return null
+  }
+  return {
+    kind: 'task_event',
+    action: obj.action as TaskEventAction,
+    taskNumber: obj.taskNumber,
+    title: obj.title,
+    subChannelId: obj.subChannelId,
+    actor: obj.actor,
+    prevStatus,
+    nextStatus: obj.nextStatus as TaskStatus,
+    claimedBy,
+  }
+}

--- a/ui/src/hooks/useTaskEventLog.test.ts
+++ b/ui/src/hooks/useTaskEventLog.test.ts
@@ -30,8 +30,9 @@ describe('deriveTaskStates', () => {
         senderDeleted: false,
       },
     ]
-    const states = deriveTaskStates(msgs)
-    expect(states.size).toBe(0)
+    const index = deriveTaskStates(msgs)
+    expect(index.byTaskNumber.size).toBe(0)
+    expect(index.taskNumberBySeq.size).toBe(0)
   })
 
   it('converges to the correct state after create → claim → in_review → done', () => {
@@ -73,12 +74,15 @@ describe('deriveTaskStates', () => {
         nextStatus: 'done',
       }),
     ]
-    const states = deriveTaskStates(msgs)
-    const task = states.get(7)!
+    const index = deriveTaskStates(msgs)
+    const task = index.byTaskNumber.get(7)!
     expect(task.status).toBe('done')
     expect(task.claimedBy).toBe('alice')
     expect(task.events).toHaveLength(4)
     expect(task.title).toBe('t')
+    // Inverse index covers every emitted task_event seq.
+    expect(index.taskNumberBySeq.get(1)).toBe(7)
+    expect(index.taskNumberBySeq.get(4)).toBe(7)
   })
 
   it('applies events in seq order regardless of array order', () => {
@@ -111,8 +115,8 @@ describe('deriveTaskStates', () => {
         claimedBy: 'a',
       }),
     ]
-    const states = deriveTaskStates(msgs)
-    expect(states.get(1)!.status).toBe('in_review')
+    const index = deriveTaskStates(msgs)
+    expect(index.byTaskNumber.get(1)!.status).toBe('in_review')
   })
 
   it('handles unclaimed by clearing claimedBy', () => {
@@ -144,8 +148,8 @@ describe('deriveTaskStates', () => {
         claimedBy: null,
       }),
     ]
-    const states = deriveTaskStates(msgs)
-    expect(states.get(1)!.claimedBy).toBeNull()
-    expect(states.get(1)!.status).toBe('todo')
+    const index = deriveTaskStates(msgs)
+    expect(index.byTaskNumber.get(1)!.claimedBy).toBeNull()
+    expect(index.byTaskNumber.get(1)!.status).toBe('todo')
   })
 })

--- a/ui/src/hooks/useTaskEventLog.test.ts
+++ b/ui/src/hooks/useTaskEventLog.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { deriveTaskStates } from './useTaskEventLog'
+import type { HistoryMessage } from '../data/chat'
+
+function taskEventMsg(
+  seq: number,
+  event: Record<string, unknown>,
+): HistoryMessage {
+  return {
+    id: `m-${seq}`,
+    seq,
+    content: JSON.stringify({ kind: 'task_event', ...event }),
+    senderName: 'system',
+    senderType: 'system',
+    createdAt: new Date(seq * 1000).toISOString(),
+    senderDeleted: false,
+  }
+}
+
+describe('deriveTaskStates', () => {
+  it('returns empty map when no task events present', () => {
+    const msgs: HistoryMessage[] = [
+      {
+        id: 'm1',
+        seq: 1,
+        content: 'hello',
+        senderName: 'alice',
+        senderType: 'human',
+        createdAt: '2026-04-23T10:00:00Z',
+        senderDeleted: false,
+      },
+    ]
+    const states = deriveTaskStates(msgs)
+    expect(states.size).toBe(0)
+  })
+
+  it('converges to the correct state after create → claim → in_review → done', () => {
+    const msgs: HistoryMessage[] = [
+      taskEventMsg(1, {
+        action: 'created',
+        taskNumber: 7,
+        title: 't',
+        subChannelId: 's',
+        actor: 'alice',
+        nextStatus: 'todo',
+      }),
+      taskEventMsg(2, {
+        action: 'claimed',
+        taskNumber: 7,
+        title: 't',
+        subChannelId: 's',
+        actor: 'alice',
+        prevStatus: 'todo',
+        nextStatus: 'in_progress',
+        claimedBy: 'alice',
+      }),
+      taskEventMsg(3, {
+        action: 'status_changed',
+        taskNumber: 7,
+        title: 't',
+        subChannelId: 's',
+        actor: 'alice',
+        prevStatus: 'in_progress',
+        nextStatus: 'in_review',
+      }),
+      taskEventMsg(4, {
+        action: 'status_changed',
+        taskNumber: 7,
+        title: 't',
+        subChannelId: 's',
+        actor: 'alice',
+        prevStatus: 'in_review',
+        nextStatus: 'done',
+      }),
+    ]
+    const states = deriveTaskStates(msgs)
+    const task = states.get(7)!
+    expect(task.status).toBe('done')
+    expect(task.claimedBy).toBe('alice')
+    expect(task.events).toHaveLength(4)
+    expect(task.title).toBe('t')
+  })
+
+  it('applies events in seq order regardless of array order', () => {
+    const msgs: HistoryMessage[] = [
+      taskEventMsg(3, {
+        action: 'status_changed',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        prevStatus: 'in_progress',
+        nextStatus: 'in_review',
+      }),
+      taskEventMsg(1, {
+        action: 'created',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        nextStatus: 'todo',
+      }),
+      taskEventMsg(2, {
+        action: 'claimed',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        prevStatus: 'todo',
+        nextStatus: 'in_progress',
+        claimedBy: 'a',
+      }),
+    ]
+    const states = deriveTaskStates(msgs)
+    expect(states.get(1)!.status).toBe('in_review')
+  })
+
+  it('handles unclaimed by clearing claimedBy', () => {
+    const msgs: HistoryMessage[] = [
+      taskEventMsg(1, {
+        action: 'created',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        nextStatus: 'todo',
+      }),
+      taskEventMsg(2, {
+        action: 'claimed',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        nextStatus: 'in_progress',
+        claimedBy: 'a',
+      }),
+      taskEventMsg(3, {
+        action: 'unclaimed',
+        taskNumber: 1,
+        title: 't',
+        subChannelId: 's',
+        actor: 'a',
+        nextStatus: 'todo',
+        claimedBy: null,
+      }),
+    ]
+    const states = deriveTaskStates(msgs)
+    expect(states.get(1)!.claimedBy).toBeNull()
+    expect(states.get(1)!.status).toBe('todo')
+  })
+})

--- a/ui/src/hooks/useTaskEventLog.ts
+++ b/ui/src/hooks/useTaskEventLog.ts
@@ -25,13 +25,25 @@ export interface TaskState {
   latestSeq: number
 }
 
+export interface TaskEventIndex {
+  /** Per-task state, keyed by taskNumber. */
+  byTaskNumber: Map<number, TaskState>
+  /** Inverse index: seq → taskNumber. Lets the render loop detect a
+   *  task_event row in O(1) without re-parsing JSON content. */
+  taskNumberBySeq: Map<number, number>
+}
+
 /**
- * Reduce a message stream into per-task state. Pure function: same input
- * yields same output. Messages that aren't task_event system messages are
- * ignored. Out-of-order arrivals are tolerated — events are applied in seq
- * order.
+ * Reduce a message stream into per-task state + a seq→taskNumber inverse
+ * index. Pure function: same input yields same output. Non-task_event
+ * messages are ignored. Out-of-order arrivals are tolerated — events are
+ * applied in seq order.
+ *
+ * Internally builds each task's `events` list with in-place `push`, not
+ * spread-copy, so the cost is O(n) over n total events, not O(k²) over
+ * k events per task.
  */
-export function deriveTaskStates(messages: HistoryMessage[]): Map<number, TaskState> {
+export function deriveTaskStates(messages: HistoryMessage[]): TaskEventIndex {
   const parsed: { msg: HistoryMessage; ev: TaskEventPayload }[] = []
   for (const msg of messages) {
     if (msg.senderType !== 'system') continue
@@ -41,8 +53,12 @@ export function deriveTaskStates(messages: HistoryMessage[]): Map<number, TaskSt
   }
   parsed.sort((a, b) => a.msg.seq - b.msg.seq)
 
-  const out = new Map<number, TaskState>()
+  const byTaskNumber = new Map<number, TaskState>()
+  const taskNumberBySeq = new Map<number, number>()
+
   for (const { msg, ev } of parsed) {
+    taskNumberBySeq.set(msg.seq, ev.taskNumber)
+
     const record: TaskEventRecord = {
       eventId: msg.id,
       seq: msg.seq,
@@ -52,9 +68,10 @@ export function deriveTaskStates(messages: HistoryMessage[]): Map<number, TaskSt
       nextStatus: ev.nextStatus,
       createdAt: msg.createdAt,
     }
-    const prev = out.get(ev.taskNumber)
+
+    const prev = byTaskNumber.get(ev.taskNumber)
     if (!prev) {
-      out.set(ev.taskNumber, {
+      byTaskNumber.set(ev.taskNumber, {
         taskNumber: ev.taskNumber,
         title: ev.title,
         subChannelId: ev.subChannelId,
@@ -64,21 +81,22 @@ export function deriveTaskStates(messages: HistoryMessage[]): Map<number, TaskSt
         latestSeq: msg.seq,
       })
     } else {
-      out.set(ev.taskNumber, {
-        ...prev,
-        title: ev.title,
-        subChannelId: ev.subChannelId,
-        status: ev.nextStatus,
-        claimedBy: ev.claimedBy === undefined ? prev.claimedBy : (ev.claimedBy ?? null),
-        events: [...prev.events, record],
-        latestSeq: msg.seq,
-      })
+      // Mutation is safe: `prev` is a local object owned by this call, and
+      // the returned Map is built fresh on every memo recompute.
+      prev.title = ev.title
+      prev.subChannelId = ev.subChannelId
+      prev.status = ev.nextStatus
+      if (ev.claimedBy !== undefined) {
+        prev.claimedBy = ev.claimedBy ?? null
+      }
+      prev.events.push(record)
+      prev.latestSeq = msg.seq
     }
   }
-  return out
+  return { byTaskNumber, taskNumberBySeq }
 }
 
 /** React hook wrapping `deriveTaskStates` with memoization. */
-export function useTaskEventLog(messages: HistoryMessage[]): Map<number, TaskState> {
+export function useTaskEventLog(messages: HistoryMessage[]): TaskEventIndex {
   return useMemo(() => deriveTaskStates(messages), [messages])
 }

--- a/ui/src/hooks/useTaskEventLog.ts
+++ b/ui/src/hooks/useTaskEventLog.ts
@@ -1,0 +1,84 @@
+import { useMemo } from 'react'
+import type { HistoryMessage } from '../data/chat'
+import { parseTaskEvent, type TaskEventPayload } from '../data/taskEvents'
+import type { TaskStatus } from '../data/tasks'
+
+export interface TaskEventRecord {
+  eventId: string
+  seq: number
+  action: TaskEventPayload['action']
+  actor: string
+  prevStatus?: TaskStatus
+  nextStatus: TaskStatus
+  createdAt: string
+}
+
+export interface TaskState {
+  taskNumber: number
+  title: string
+  subChannelId: string
+  status: TaskStatus
+  claimedBy: string | null
+  /** Event history in seq order, oldest first. */
+  events: TaskEventRecord[]
+  /** seq of the latest event applied — used for repeat-suppression. */
+  latestSeq: number
+}
+
+/**
+ * Reduce a message stream into per-task state. Pure function: same input
+ * yields same output. Messages that aren't task_event system messages are
+ * ignored. Out-of-order arrivals are tolerated — events are applied in seq
+ * order.
+ */
+export function deriveTaskStates(messages: HistoryMessage[]): Map<number, TaskState> {
+  const parsed: { msg: HistoryMessage; ev: TaskEventPayload }[] = []
+  for (const msg of messages) {
+    if (msg.senderType !== 'system') continue
+    const ev = parseTaskEvent(msg.content)
+    if (!ev) continue
+    parsed.push({ msg, ev })
+  }
+  parsed.sort((a, b) => a.msg.seq - b.msg.seq)
+
+  const out = new Map<number, TaskState>()
+  for (const { msg, ev } of parsed) {
+    const record: TaskEventRecord = {
+      eventId: msg.id,
+      seq: msg.seq,
+      action: ev.action,
+      actor: ev.actor,
+      prevStatus: ev.prevStatus,
+      nextStatus: ev.nextStatus,
+      createdAt: msg.createdAt,
+    }
+    const prev = out.get(ev.taskNumber)
+    if (!prev) {
+      out.set(ev.taskNumber, {
+        taskNumber: ev.taskNumber,
+        title: ev.title,
+        subChannelId: ev.subChannelId,
+        status: ev.nextStatus,
+        claimedBy: ev.claimedBy ?? null,
+        events: [record],
+        latestSeq: msg.seq,
+      })
+    } else {
+      out.set(ev.taskNumber, {
+        ...prev,
+        title: ev.title,
+        subChannelId: ev.subChannelId,
+        status: ev.nextStatus,
+        claimedBy: ev.claimedBy === undefined ? prev.claimedBy : (ev.claimedBy ?? null),
+        events: [...prev.events, record],
+        latestSeq: msg.seq,
+      })
+    }
+  }
+  return out
+}
+
+/** React hook wrapping `deriveTaskStates` with memoization. */
+export function useTaskEventLog(messages: HistoryMessage[]): Map<number, TaskState> {
+  return useMemo(() => deriveTaskStates(messages), [messages])
+}


### PR DESCRIPTION
## Summary

Adds a compact, expressive feed of task state changes directly in the parent channel, so members see lifecycle events without digging into the kanban. Task mutations (`create` / `claim` / `unclaim` / `status change`) post a `sender_type = 'system'` message carrying a JSON `task_event` payload; the frontend folds consecutive events per task into a single living card that compresses to a pill when the task reaches `done`.

**Backend**
- `TaskEventPayload` + `TaskEventAction` types (`src/store/tasks/events.rs`) with camelCase JSON emission
- Task mutations share `tx` with the event-message insert (`Immediate` transaction) — atomic by construction
- New `create_system_message_tx` + `emit_system_stream_events` helpers in `src/store/messages/posting.rs` keep the DB write and WebSocket fanout cleanly separated
- `format_message_for_agent` bridge adapter formats task-event JSON as a one-line human sentence so agents don't see raw JSON in their context

**Frontend**
- `parseTaskEvent` with strict payload validation (`ui/src/data/taskEvents.ts`)
- `useTaskEventLog` folds the message log into per-task `TaskState` (claimedBy preserved across events that omit it)
- `TaskEventMessage` renders card + pill simultaneously; CSS state machine (`data-state` + `data-status`) swaps visibility with `prefers-reduced-motion` opt-out
- `MessageList` collapses a run of events for the same task into one component, keeping visibility wrappers for unread-anchor correctness

**Docs / QA**
- `docs/BACKEND.md` updated for the new system-message callers and the task-event contract
- `qa/cases/playwright/TSK-004.spec.ts` smoke covering the full create → claim → review → done flow

## Test plan
- [x] `cargo test` (all 518 backend tests green)
- [x] `cargo test --test e2e_tests` (lifecycle + batch-create e2e green)
- [x] `cd ui && npm run test` (77 frontend tests green)
- [x] `cd ui && npx tsc --noEmit` (clean)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [ ] Manual dev-server smoke: create task, claim, flip status, verify card transitions and pill collapse on `done`
- [ ] `/gstack-qa` on the channel-task-event path before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)