### PR TITLE
chore: add GEMINI.md symlink to AGENTS.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/agent/event_forwarder.rs
+++ b/src/agent/event_forwarder.rs
@@ -412,7 +412,9 @@ pub(super) fn spawn_event_forwarder(
                                         "⚠️ @{} completed a run without replying. Common causes: not authenticated, authentication expired, or a runtime error. Check agent logs for details.",
                                         key
                                     );
-                                    if let Err(e) = store.create_system_message(&channel_id, &warning) {
+                                    if let Err(e) =
+                                        store.create_system_message(&channel_id, &warning)
+                                    {
                                         warn!(
                                             agent = %key,
                                             channel_id = %channel_id,
@@ -772,7 +774,10 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(count, 0, "expected no system warning when send_message was used");
+        assert_eq!(
+            count, 0,
+            "expected no system warning when send_message was used"
+        );
     }
 
     /// In a group channel an agent may be watching without replying; silence

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -250,7 +250,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
                 if !is_tty {
                     return Err(crate::cli::UserError(format!(
                         "refusing to delete @{name} without --yes on non-interactive stdin"
-                    )).into());
+                    ))
+                    .into());
                 }
                 if locked.read_line(&mut line).is_err() {
                     return Err(crate::cli::UserError("Abort.".into()).into());
@@ -290,7 +291,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
                 if wipe {
                     return Err(crate::cli::UserError(format!(
                         "Agent deleted but workspace cleanup failed: {warning}"
-                    )).into());
+                    ))
+                    .into());
                 }
                 tracing::warn!("{warning}");
             }

--- a/src/cli/channel/create.rs
+++ b/src/cli/channel/create.rs
@@ -15,7 +15,8 @@ pub async fn run(
         return Err(crate::cli::UserError(format!(
             "{}: {normalized}",
             chorus::store::channels::INVALID_CHANNEL_NAME_MSG
-        )).into());
+        ))
+        .into());
     }
     let description = description.unwrap_or_default();
     let client = super::http::client();

--- a/src/cli/channel/delete.rs
+++ b/src/cli/channel/delete.rs
@@ -66,7 +66,8 @@ pub async fn run(name: String, yes: bool, server_url: &str) -> anyhow::Result<()
             ConfirmOutcome::RefuseNonInteractive => {
                 return Err(crate::cli::UserError(format!(
                     "refusing to delete #{normalized} without --yes on non-interactive stdin"
-                )).into());
+                ))
+                .into());
             }
         }
     }

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -122,7 +122,11 @@ async fn check_auth(name: &str) -> ProbeAuth {
 }
 
 async fn check_claude_auth() -> ProbeAuth {
-    let Ok(output) = TokioCommand::new("claude").args(["auth", "status"]).output().await else {
+    let Ok(output) = TokioCommand::new("claude")
+        .args(["auth", "status"])
+        .output()
+        .await
+    else {
         return ProbeAuth::Unauthed;
     };
     if !output.status.success() {
@@ -141,7 +145,11 @@ async fn check_claude_auth() -> ProbeAuth {
 }
 
 async fn check_codex_auth() -> ProbeAuth {
-    let Ok(output) = TokioCommand::new("codex").args(["login", "status"]).output().await else {
+    let Ok(output) = TokioCommand::new("codex")
+        .args(["login", "status"])
+        .output()
+        .await
+    else {
         return ProbeAuth::Unauthed;
     };
     let combined = format!(
@@ -180,7 +188,11 @@ async fn check_kimi_auth() -> ProbeAuth {
 }
 
 async fn check_opencode_auth() -> ProbeAuth {
-    let Ok(output) = TokioCommand::new("opencode").args(["auth", "status"]).output().await else {
+    let Ok(output) = TokioCommand::new("opencode")
+        .args(["auth", "status"])
+        .output()
+        .await
+    else {
         return ProbeAuth::Unauthed;
     };
     if output.status.success() {
@@ -194,7 +206,11 @@ async fn check_gemini_auth() -> ProbeAuth {
     if std::env::var("GEMINI_API_KEY").is_ok_and(|v| !v.trim().is_empty()) {
         return ProbeAuth::Authed;
     }
-    let Ok(output) = TokioCommand::new("gemini").args(["auth", "status"]).output().await else {
+    let Ok(output) = TokioCommand::new("gemini")
+        .args(["auth", "status"])
+        .output()
+        .await
+    else {
         return ProbeAuth::Unauthed;
     };
     if !output.status.success() {
@@ -695,7 +711,9 @@ mod tests {
 
     #[tokio::test]
     async fn check_tool_returns_none_for_missing_binary() {
-        assert!(check_tool_async("definitely-not-a-real-binary-xyzzy").await.is_none());
+        assert!(check_tool_async("definitely-not-a-real-binary-xyzzy")
+            .await
+            .is_none());
     }
 
     #[test]

--- a/src/server/handlers/channels.rs
+++ b/src/server/handlers/channels.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 
 use super::{app_err, ApiResult, AppState};
 use crate::server::error::AppErrorCode;
-use crate::store::channels::{is_valid_channel_name, normalize_channel_name, Channel, ChannelMemberProfile, ChannelType, INVALID_CHANNEL_NAME_MSG};
+use crate::store::channels::{
+    is_valid_channel_name, normalize_channel_name, Channel, ChannelMemberProfile, ChannelType,
+    INVALID_CHANNEL_NAME_MSG,
+};
 use crate::store::messages::SenderType;
 use crate::store::ChannelListParams;
 

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -303,7 +303,10 @@ async fn send_message_to_channel(
     suppress_event: bool,
 ) -> ApiResult<SendResponse> {
     if content.trim().is_empty() && attachment_ids.is_empty() {
-        return Err(app_err!(StatusCode::BAD_REQUEST, "message content cannot be empty"));
+        return Err(app_err!(
+            StatusCode::BAD_REQUEST,
+            "message content cannot be empty"
+        ));
     }
     let store = &state.store;
     let sender_type = sender_type_for_actor(store, actor_id)?;

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -2241,13 +2241,18 @@ async fn test_create_team_endpoint() {
     assert_eq!(bot_member.member_type, "agent");
     assert_eq!(bot_member.role, "operator");
 
-    let human_member = members.iter().find(|m| m.member_name == current_user).unwrap();
+    let human_member = members
+        .iter()
+        .find(|m| m.member_name == current_user)
+        .unwrap();
     assert_eq!(human_member.member_type, "human");
     assert_eq!(human_member.role, "operator");
 
     // Creator is also joined to the team channel.
     let channel_members = store.get_channel_members(&ch.id).unwrap();
-    assert!(channel_members.iter().any(|m| m.member_name == current_user));
+    assert!(channel_members
+        .iter()
+        .any(|m| m.member_name == current_user));
 
     assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
     assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
@@ -2306,7 +2311,9 @@ async fn test_create_team_does_not_duplicate_creator_when_explicitly_in_members(
     // Explicit creator is also joined to the team channel via the member loop.
     let ch = store.get_channel_by_name("eng-team").unwrap().unwrap();
     let channel_members = store.get_channel_members(&ch.id).unwrap();
-    assert!(channel_members.iter().any(|m| m.member_name == current_user));
+    assert!(channel_members
+        .iter()
+        .any(|m| m.member_name == current_user));
 }
 
 #[tokio::test]
@@ -3115,7 +3122,6 @@ async fn test_restart_agent_start_fails_returns_agent_restart_failed() {
     let body = body_json(resp).await;
     assert_eq!(body["code"], "AGENT_RESTART_FAILED");
 }
-
 
 #[tokio::test]
 async fn create_channel_rejects_invalid_names() {


### PR DESCRIPTION
Adds GEMINI.md as a soft link to AGENTS.md, following the same pattern as CLAUDE.md. One source of truth for agent instructions across Claude, Kimi, and Gemini.