### PR TITLE
chore: add AI agent and IDE config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ node_modules
 .superpowers
 .codex
 .context/
+
+# AI agent / IDE config files
+.cursor/
+.cursorrules
+.kiro/
+.mcp.json
+.opencode.json
+.windsurfrules


### PR DESCRIPTION
Adds common AI agent and IDE configuration files to .gitignore:

- .cursor/ — Cursor IDE settings
- .cursorrules — Cursor rules file
- .kiro/ — Kiro IDE settings
- .mcp.json — MCP configuration
- .opencode.json — OpenCode settings
- .windsurfrules — Windsurf rules file

These are local developer environment files that should not be committed.