### PR TITLE
fix: mention display names + real-time member list refresh (#107, #109)

### DIFF
--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -70,7 +70,12 @@ impl Store {
     pub fn create_agent_record(&self, record: &AgentRecordUpsert<'_>) -> Result<String> {
         let conn = self.conn.lock().unwrap();
         let workspace_id = Self::workspace_id_for_write_inner(&conn)?;
-        Self::create_agent_record_inner(&conn, &workspace_id, record)
+        let id = Self::create_agent_record_inner(&conn, &workspace_id, record)?;
+        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(&conn, &workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)? {
+            let event = super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
+            let _ = self.stream_tx.send(event);
+        }
+        Ok(id)
     }
 
     pub fn create_agent_record_in_workspace(
@@ -79,7 +84,12 @@ impl Store {
         record: &AgentRecordUpsert<'_>,
     ) -> Result<String> {
         let conn = self.conn.lock().unwrap();
-        Self::create_agent_record_inner(&conn, workspace_id, record)
+        let id = Self::create_agent_record_inner(&conn, workspace_id, record)?;
+        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(&conn, workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)? {
+            let event = super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
+            let _ = self.stream_tx.send(event);
+        }
+        Ok(id)
     }
 
     fn create_agent_record_inner(

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -71,8 +71,13 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let workspace_id = Self::workspace_id_for_write_inner(&conn)?;
         let id = Self::create_agent_record_inner(&conn, &workspace_id, record)?;
-        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(&conn, &workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)? {
-            let event = super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
+        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(
+            &conn,
+            &workspace_id,
+            Self::DEFAULT_SYSTEM_CHANNEL,
+        )? {
+            let event =
+                super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
             let _ = self.stream_tx.send(event);
         }
         Ok(id)
@@ -85,8 +90,13 @@ impl Store {
     ) -> Result<String> {
         let conn = self.conn.lock().unwrap();
         let id = Self::create_agent_record_inner(&conn, workspace_id, record)?;
-        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(&conn, workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)? {
-            let event = super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
+        if let Some(all_channel) = Self::get_channel_by_workspace_and_name_inner(
+            &conn,
+            workspace_id,
+            Self::DEFAULT_SYSTEM_CHANNEL,
+        )? {
+            let event =
+                super::StreamEvent::member_joined(all_channel.id, id.clone(), "agent".to_string());
             let _ = self.stream_tx.send(event);
         }
         Ok(id)

--- a/src/store/channels.rs
+++ b/src/store/channels.rs
@@ -537,6 +537,8 @@ impl Store {
             "INSERT OR IGNORE INTO channel_members (channel_id, member_id, member_type, last_read_seq) VALUES (?1, ?2, ?3, 0)",
             params![channel.id, member_id, mt],
         )?;
+        let event = super::StreamEvent::member_joined(channel.id, member_id.to_string(), mt.to_string());
+        let _ = self.stream_tx.send(event);
         Ok(())
     }
 
@@ -554,6 +556,8 @@ impl Store {
             "INSERT OR IGNORE INTO channel_members (channel_id, member_id, member_type, last_read_seq) VALUES (?1, ?2, ?3, 0)",
             params![channel_id, member_id, mt],
         )?;
+        let event = super::StreamEvent::member_joined(channel_id.to_string(), member_id.to_string(), mt.to_string());
+        let _ = self.stream_tx.send(event);
         Ok(())
     }
 

--- a/src/store/channels.rs
+++ b/src/store/channels.rs
@@ -533,12 +533,18 @@ impl Store {
         let channel = Self::get_channel_by_name_inner(&conn, channel_name)?
             .ok_or_else(|| anyhow!("channel not found: {}", channel_name))?;
         let mt = member_type.as_str();
-        conn.execute(
+        let rows = conn.execute(
             "INSERT OR IGNORE INTO channel_members (channel_id, member_id, member_type, last_read_seq) VALUES (?1, ?2, ?3, 0)",
             params![channel.id, member_id, mt],
         )?;
-        let event = super::StreamEvent::member_joined(channel.id, member_id.to_string(), mt.to_string());
-        let _ = self.stream_tx.send(event);
+        if rows > 0 {
+            let event = super::StreamEvent::member_joined(
+                channel.id,
+                member_id.to_string(),
+                mt.to_string(),
+            );
+            let _ = self.stream_tx.send(event);
+        }
         Ok(())
     }
 
@@ -552,12 +558,18 @@ impl Store {
     ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let mt = member_type.as_str();
-        conn.execute(
+        let rows = conn.execute(
             "INSERT OR IGNORE INTO channel_members (channel_id, member_id, member_type, last_read_seq) VALUES (?1, ?2, ?3, 0)",
             params![channel_id, member_id, mt],
         )?;
-        let event = super::StreamEvent::member_joined(channel_id.to_string(), member_id.to_string(), mt.to_string());
-        let _ = self.stream_tx.send(event);
+        if rows > 0 {
+            let event = super::StreamEvent::member_joined(
+                channel_id.to_string(),
+                member_id.to_string(),
+                mt.to_string(),
+            );
+            let _ = self.stream_tx.send(event);
+        }
         Ok(())
     }
 

--- a/src/store/stream.rs
+++ b/src/store/stream.rs
@@ -20,4 +20,17 @@ impl StreamEvent {
             schema_version: 1,
         }
     }
+
+    pub fn member_joined(channel_id: String, member_id: String, member_type: String) -> Self {
+        Self {
+            event_type: "channel.member_joined".to_string(),
+            channel_id,
+            latest_seq: 0,
+            event_payload: serde_json::json!({
+                "memberId": member_id,
+                "memberType": member_type,
+            }),
+            schema_version: 1,
+        }
+    }
 }

--- a/src/store/workspaces.rs
+++ b/src/store/workspaces.rs
@@ -127,6 +127,8 @@ impl Store {
         let workspace = Self::get_workspace_by_id_inner(&tx, &id)?
             .ok_or_else(|| anyhow!("workspace not found after insert: {id}"))?;
         tx.commit()?;
+        let event = super::StreamEvent::member_joined(all_channel_id, owner_human_id.to_string(), "human".to_string());
+        let _ = self.stream_tx.send(event);
         Ok(workspace)
     }
 

--- a/src/store/workspaces.rs
+++ b/src/store/workspaces.rs
@@ -127,7 +127,11 @@ impl Store {
         let workspace = Self::get_workspace_by_id_inner(&tx, &id)?
             .ok_or_else(|| anyhow!("workspace not found after insert: {id}"))?;
         tx.commit()?;
-        let event = super::StreamEvent::member_joined(all_channel_id, owner_human_id.to_string(), "human".to_string());
+        let event = super::StreamEvent::member_joined(
+            all_channel_id,
+            owner_human_id.to_string(),
+            "human".to_string(),
+        );
         let _ = self.stream_tx.send(event);
         Ok(workspace)
     }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -245,10 +245,16 @@ function useGlobalSeqListener(
     if (!currentHumanId || !shellBootstrapped) return;
     return getSession(currentHumanId).subscribeAll((frame) => {
       if (frame.type === "error") return;
-      if (frame.event.eventType !== EventType.MessageCreated) return;
-      const seq = frame.event.payload?.seq;
-      if (typeof seq === "number") {
-        advanceConversationLatestSeq(frame.event.channelId, seq);
+      if (frame.event.eventType === EventType.MessageCreated) {
+        const seq = frame.event.payload?.seq;
+        if (typeof seq === "number") {
+          advanceConversationLatestSeq(frame.event.channelId, seq);
+        }
+      }
+      if (frame.event.eventType === EventType.ChannelMemberJoined) {
+        appQueryClient.invalidateQueries({
+          queryKey: channelQueryKeys.members(frame.event.channelId),
+        });
       }
     });
   }, [currentHumanId, shellBootstrapped, advanceConversationLatestSeq]);

--- a/ui/src/components/chat/MentionTextarea.tsx
+++ b/ui/src/components/chat/MentionTextarea.tsx
@@ -4,6 +4,7 @@ import './MentionTextarea.css'
 
 export interface MentionMember {
   name: string
+  displayName?: string
   type: 'agent' | 'human' | 'team'
 }
 
@@ -53,9 +54,13 @@ export function MentionTextarea({
 
   const suggestions =
     mentionQuery !== null
-      ? members.filter((m) =>
-          m.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
-        )
+      ? members.filter((m) => {
+          const q = mentionQuery.toLowerCase()
+          return (
+            m.name.toLowerCase().startsWith(q) ||
+            (m.displayName?.toLowerCase().startsWith(q) ?? false)
+          )
+        })
       : []
 
   function closeMention() {
@@ -148,9 +153,9 @@ export function MentionTextarea({
                 className={`mention-popup-avatar${m.type === 'team' ? ' team' : ''}`}
                 style={m.type === 'team' ? undefined : { background: memberColor(m.name) }}
               >
-                {m.type === 'team' ? <Users size={12} /> : memberInitial(m.name)}
+                {m.type === 'team' ? <Users size={12} /> : memberInitial(m.displayName ?? m.name)}
               </span>
-              <span className="mention-popup-name">@{m.name}</span>
+              <span className="mention-popup-name">@{m.displayName ?? m.name}</span>
               {m.type === 'agent' && <span className="mention-popup-badge">BOT</span>}
               {m.type === 'team' && <span className="mention-popup-badge">TEAM</span>}
             </button>

--- a/ui/src/components/chat/MessageInput.tsx
+++ b/ui/src/components/chat/MessageInput.tsx
@@ -58,7 +58,7 @@ export function MessageInput({
 
   const allMembers: MentionMember[] = useMemo(
     () => [
-      ...agents.map((a) => ({ name: a.name, type: "agent" as const })),
+      ...agents.map((a) => ({ name: a.name, displayName: a.display_name, type: "agent" as const })),
       ...humans.map((h) => ({ name: h.name, type: "human" as const })),
       ...teams.map((team) => ({ name: team.name, type: "team" as const })),
     ],

--- a/ui/src/components/chat/MessageItem.tsx
+++ b/ui/src/components/chat/MessageItem.tsx
@@ -55,13 +55,15 @@ function MentionPill({ mention, agents, onSelectAgent }: MentionPillProps) {
     return <span className="mention-pill">{mention}</span>;
   }
 
+  const displayName = agent.display_name ?? agent.name;
+
   return (
     <span
       className="mention-pill mention-pill-clickable"
       onClick={() => onSelectAgent(agent)}
       title={`View @${name} profile`}
     >
-      {mention}
+      @{displayName}
     </span>
   );
 }

--- a/ui/src/components/chat/MessageItem.tsx
+++ b/ui/src/components/chat/MessageItem.tsx
@@ -61,7 +61,7 @@ function MentionPill({ mention, agents, onSelectAgent }: MentionPillProps) {
     <span
       className="mention-pill mention-pill-clickable"
       onClick={() => onSelectAgent(agent)}
-      title={`View @${name} profile`}
+      title={`View @${displayName} profile`}
     >
       @{displayName}
     </span>

--- a/ui/src/transport/types.ts
+++ b/ui/src/transport/types.ts
@@ -7,6 +7,7 @@ import type { StreamEvent } from '../data/chat'
 export const EventType = {
   MessageCreated: 'message.created',
   TombstoneChanged: 'tombstone_changed',
+  ChannelMemberJoined: 'channel.member_joined',
 } as const
 
 export type EventType = (typeof EventType)[keyof typeof EventType]


### PR DESCRIPTION
## Fixes

- **#107**: @mention list now auto-refreshes when an agent joins a channel
- **#109**: @mention shows agent \display_name\ instead of slug

## Changes

### Backend
- Added \channel.member_joined\ WebSocket event type
- Emit membership events from:
  - \join_channel\ / \join_channel_by_id\
  - Agent auto-join on creation
  - Workspace setup (owner added to #all)

### Frontend
- Mention popup filters and renders by \displayName\
- Mention pills in messages show \display_name\ instead of slug
- App.tsx invalidates \channelMembers\ query on \channel.member_joined\ events

## Verification
- cargo test: 60 passed
- cargo test --test e2e_tests: 10 passed
- UI tests: 85 passed
- tsc --noEmit: clean