### PR TITLE
fix: resolve archived channels in CLI del/join; add channel members command

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -26,23 +26,25 @@ Living list of follow-ups that are out of scope for the current branch but worth
   - **Depends on:** Nothing.
   - **Discovered:** 2026-04-18 during channel CLI subcommand refactor (spec non-goal).
 
-- [ ] **`chorus channel del` / `join` should find archived channels by name** — `resolve_channel_id` in `src/cli/channel/mod.rs` calls `GET /api/channels` without `include_archived=true`, so archived rows are invisible to the CLI. The server's `handle_delete_channel` accepts archived user channels, but the CLI turns them into "channel not found" and leaves no way to clean up by name.
+- [x] **`chorus channel del` / `join` should find archived channels by name** — `resolve_channel_id` in `src/cli/channel/mod.rs` calls `GET /api/channels` without `include_archived=true`, so archived rows are invisible to the CLI. The server's `handle_delete_channel` accepts archived user channels, but the CLI turns them into "channel not found" and leaves no way to clean up by name.
   - **Why:** Edge case today, but the failure mode is silent and confusing: the channel exists, the server can delete it, yet the CLI claims it doesn't exist.
   - **Pros:** One-line fix (append `?include_archived=true` to the resolver URL).
   - **Cons:** Slightly larger response payloads for the helper. Immaterial at Chorus's scale.
   - **How to start:** Change `let url = format!("{server_url}/api/channels");` in `resolve_channel_id` to include the query param. Add an integration test: create → archive via store → `chorus channel del <name> --yes` succeeds.
   - **Depends on:** Nothing.
   - **Discovered:** 2026-04-18 during Codex review of PR #61.
+  - **Fixed:** 2026-04-28 on `fix/channel-cli-archived-members`.
 
 - [x] **`chorus channel create` auto-joins the server-side OS user, not the CLI caller** — fixed by the ID-first human identity foundation on `identity-foundation-id-first` (`559dfb6`) and verified by `/gstack-qa` on 2026-04-26. `handle_create_channel` now joins the configured local human ID from server state instead of calling `whoami::username()` on the server process. Hosted/multi-user caller identity remains tracked under the architecture TODO below.
 
-- [ ] **`chorus channel members <name>`** — list who's in a channel from the CLI.
+- [x] **`chorus channel members <name>`** — list who's in a channel from the CLI.
   - **Why:** Server already exposes `GET /api/channels/{id}/members`. Today only the web UI consumes it. Scripters and debuggers would benefit from CLI access.
   - **Pros:** Zero new server work — the endpoint exists. Small CLI addition.
   - **Cons:** None material.
   - **How to start:** New `src/cli/channel/members.rs` that resolves name→id via the shared helper, GETs `/api/channels/{id}/members`, and prints a formatted list (mirror `status.rs` row style).
   - **Depends on:** Nothing.
   - **Discovered:** 2026-04-18 during channel CLI subcommand refactor (spec non-goal).
+  - **Fixed:** 2026-04-28 on `fix/channel-cli-archived-members`.
 
 ## Architecture
 

--- a/src/cli/channel/members.rs
+++ b/src/cli/channel/members.rs
@@ -24,11 +24,17 @@ pub async fn run(name: String, server_url: &str) -> anyhow::Result<()> {
         .get("memberCount")
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
-    tracing::info!("{member_count} member{} in #{normalized}:", if member_count == 1 { "" } else { "s" });
+    tracing::info!(
+        "{member_count} member{} in #{normalized}:",
+        if member_count == 1 { "" } else { "s" }
+    );
     if let Some(members) = data.get("members").and_then(|v| v.as_array()) {
         for m in members {
             let member_name = m.get("memberName").and_then(|v| v.as_str()).unwrap_or("?");
-            let member_type = m.get("memberType").and_then(|v| v.as_str()).unwrap_or("unknown");
+            let member_type = m
+                .get("memberType")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
             let display = m
                 .get("displayName")
                 .and_then(|v| v.as_str())

--- a/src/cli/channel/members.rs
+++ b/src/cli/channel/members.rs
@@ -1,0 +1,43 @@
+//! `chorus channel members <name>` — list members of a channel.
+
+use anyhow::Context;
+
+pub async fn run(name: String, server_url: &str) -> anyhow::Result<()> {
+    let client = super::http::client();
+    let normalized = super::normalize_channel_name(&name);
+    let channel_id = super::resolve_channel_id(&client, server_url, &normalized).await?;
+
+    let url = format!("{server_url}/api/channels/{channel_id}/members");
+    let res = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("is the Chorus server running at {server_url}?"))?;
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(super::surface_http_error(status, &body));
+    }
+    let data: serde_json::Value = serde_json::from_str(&body)
+        .with_context(|| format!("unexpected response from {url}: not JSON"))?;
+    let member_count = data
+        .get("memberCount")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    tracing::info!("{member_count} member{} in #{normalized}:", if member_count == 1 { "" } else { "s" });
+    if let Some(members) = data.get("members").and_then(|v| v.as_array()) {
+        for m in members {
+            let member_name = m.get("memberName").and_then(|v| v.as_str()).unwrap_or("?");
+            let member_type = m.get("memberType").and_then(|v| v.as_str()).unwrap_or("unknown");
+            let display = m
+                .get("displayName")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty());
+            match display {
+                Some(d) => tracing::info!("  @{member_name} ({member_type}) — {d}"),
+                None => tracing::info!("  @{member_name} ({member_type})"),
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/cli/channel/mod.rs
+++ b/src/cli/channel/mod.rs
@@ -9,6 +9,7 @@ mod delete;
 mod history;
 mod join;
 mod list;
+mod members;
 
 use anyhow::Context;
 use clap::Subcommand;
@@ -50,6 +51,8 @@ pub(crate) enum ChannelCommands {
         #[arg(long, default_value = "20", value_parser = clap::value_parser!(i64).range(1..=HISTORY_LIMIT_MAX))]
         limit: i64,
     },
+    /// List members of a channel
+    Members { name: String },
 }
 
 pub async fn run(server_url: String, cmd: ChannelCommands) -> anyhow::Result<()> {
@@ -61,6 +64,7 @@ pub async fn run(server_url: String, cmd: ChannelCommands) -> anyhow::Result<()>
         ChannelCommands::Join { name } => join::run(name, &server_url).await,
         ChannelCommands::List { all } => list::run(all, &server_url).await,
         ChannelCommands::History { name, limit } => history::run(name, limit, &server_url).await,
+        ChannelCommands::Members { name } => members::run(name, &server_url).await,
     }
 }
 
@@ -91,7 +95,7 @@ pub(super) async fn resolve_channel_id(
     name: &str,
 ) -> anyhow::Result<String> {
     let normalized = normalize_channel_name(name);
-    let url = format!("{server_url}/api/channels");
+    let url = format!("{server_url}/api/channels?include_archived=true");
     let res = client
         .get(&url)
         .send()


### PR DESCRIPTION
## Summary

Two CLI fixes, one line and one new subcommand:

- Pass `?include_archived=true` in `resolve_channel_id` so `channel del` and `channel join` can discover archived channels by name. (fixes #118)
- Add `chorus channel members <name>` subcommand consuming the existing `GET /api/channels/{id}/members` endpoint. Zero server work. (fixes #119)

## Verification

```
cargo fmt --check        # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test               # 324 + 22 + all integration suites pass
```