### PR TITLE
feat: self-introduction prompt for newly created agents (#108)

### DIFF
--- a/src/agent/lifecycle.rs
+++ b/src/agent/lifecycle.rs
@@ -7,10 +7,19 @@ use crate::agent::activity_log::ActivityLogResponse;
 use crate::store::messages::ReceivedMessage;
 
 pub trait AgentLifecycle: Send + Sync {
+    /// Start (or wake) an agent process.
+    ///
+    /// `wake_message` carries the unread message that triggered this start, if
+    /// any. `init_directive`, when `Some`, is delivered as the first prompt
+    /// verbatim, overriding the auto-generated greeting/wake/resume prompt.
+    /// Used by the agent-creation path to ask a brand-new agent to introduce
+    /// itself; left `None` for restart, manual-start, and message-driven wake
+    /// paths so existing behavior is unchanged.
     fn start_agent<'a>(
         &'a self,
         agent_name: &'a str,
         wake_message: Option<ReceivedMessage>,
+        init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
 
     fn notify_agent<'a>(

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -131,6 +131,7 @@ impl AgentManager {
         &self,
         agent_name: &str,
         wake_message: Option<ReceivedMessage>,
+        init_directive: Option<String>,
     ) -> anyhow::Result<()> {
         // Already running? Inspect the existing handle's state — only
         // bail if it's truly live. Closed/Failed/Idle handles get evicted
@@ -245,6 +246,7 @@ impl AgentManager {
             is_resume,
             &unread_summary,
             wake_message.as_ref(),
+            init_directive.as_deref(),
         );
 
         activity_log::set_activity_state(
@@ -491,7 +493,15 @@ fn build_start_prompt(
     is_resume: bool,
     unread_summary: &std::collections::HashMap<String, i64>,
     wake_message: Option<&ReceivedMessage>,
+    init_directive: Option<&str>,
 ) -> String {
+    // Caller-provided init directive takes precedence over the auto-generated
+    // prompt — used by the agent-creation path to inject a one-shot
+    // "introduce yourself" instruction. See AgentLifecycle::start_agent.
+    if let Some(directive) = init_directive {
+        return directive.to_string();
+    }
+
     if let Some(msg) = wake_message {
         let target = format_message_target(msg);
         let attachment_count = msg.attachments.as_ref().map_or(0, Vec::len);
@@ -550,8 +560,14 @@ impl AgentLifecycle for AgentManager {
         &'a self,
         agent_name: &'a str,
         wake_message: Option<ReceivedMessage>,
+        init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::start_agent(self, agent_name, wake_message))
+        Box::pin(AgentManager::start_agent(
+            self,
+            agent_name,
+            wake_message,
+            init_directive,
+        ))
     }
 
     fn notify_agent<'a>(
@@ -655,6 +671,45 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    fn build_start_prompt_returns_init_directive_verbatim() {
+        let unread = std::collections::HashMap::new();
+        let directive = "say hi please";
+        let out = build_start_prompt("Bot", false, &unread, None, Some(directive));
+        assert_eq!(out, directive);
+    }
+
+    #[test]
+    fn build_start_prompt_directive_overrides_wake_and_resume_branches() {
+        // Even with a wake_message and resume signal set, the directive wins —
+        // it's the explicit override path the agent-creation flow relies on.
+        let unread = std::collections::HashMap::from([("general".to_string(), 3)]);
+        let wake = ReceivedMessage {
+            message_id: "m1".into(),
+            channel_name: "general".into(),
+            channel_type: "channel".into(),
+            sender_name: "alice".into(),
+            sender_type: "human".into(),
+            content: "ping".into(),
+            timestamp: "2026-04-28T00:00:00Z".into(),
+            attachments: None,
+            forwarded_from: None,
+        };
+        let directive = "introduce yourself";
+        let out =
+            build_start_prompt("Bot", true, &unread, Some(&wake), Some(directive));
+        assert_eq!(out, directive);
+    }
+
+    #[test]
+    fn build_start_prompt_falls_through_when_directive_is_none() {
+        // No directive, no wake message, not a resume → existing benign greeting.
+        let unread = std::collections::HashMap::new();
+        let out = build_start_prompt("Bot", false, &unread, None, None);
+        assert!(out.contains("Hello Bot"));
+        assert!(out.contains("acknowledgement"));
+    }
+
     #[tokio::test]
     async fn start_agent_with_fake_driver() {
         let dir = tempdir().unwrap();
@@ -663,7 +718,7 @@ mod tests {
 
         let manager = make_test_manager(store, dir.path());
 
-        let result = manager.start_agent("v2bot", None).await;
+        let result = manager.start_agent("v2bot", None, None).await;
 
         assert!(result.is_ok(), "start_agent should succeed: {result:?}");
 
@@ -687,7 +742,7 @@ mod tests {
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None).await.unwrap();
+        manager.start_agent("v2bot", None, None).await.unwrap();
 
         // First stop should succeed.
         let r1 = manager.stop_agent("v2bot").await;
@@ -712,7 +767,7 @@ mod tests {
 
         let manager = make_test_manager(store.clone(), dir.path());
 
-        manager.start_agent("v2bot", None).await.unwrap();
+        manager.start_agent("v2bot", None, None).await.unwrap();
 
         manager.sleep_agent("v2bot").await.unwrap();
 
@@ -737,10 +792,10 @@ mod tests {
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None).await.unwrap();
+        manager.start_agent("v2bot", None, None).await.unwrap();
 
         // Second start should be a no-op (returns Ok).
-        let r2 = manager.start_agent("v2bot", None).await;
+        let r2 = manager.start_agent("v2bot", None, None).await;
 
         assert!(r2.is_ok(), "duplicate start should be no-op: {r2:?}");
 
@@ -755,7 +810,7 @@ mod tests {
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None).await.unwrap();
+        manager.start_agent("v2bot", None, None).await.unwrap();
 
         let result = manager.notify_agent("v2bot").await;
         assert!(result.is_ok(), "notify should succeed: {result:?}");
@@ -874,7 +929,7 @@ mod tests {
 
         // Before the fix this returned Ok(()) immediately (contains_key hit).
         // After the fix it must evict and restart.
-        let result = manager.start_agent("recovery-bot", None).await;
+        let result = manager.start_agent("recovery-bot", None, None).await;
         assert!(
             result.is_ok(),
             "start_agent should succeed after evicting a Failed handle: {result:?}",
@@ -927,7 +982,7 @@ mod tests {
             .inject_session_for_test("live-bot", Box::new(active_handle))
             .await;
 
-        let result = manager.start_agent("live-bot", None).await;
+        let result = manager.start_agent("live-bot", None, None).await;
         assert!(
             result.is_ok(),
             "start_agent on an Active agent should be Ok: {result:?}",

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -696,8 +696,7 @@ mod tests {
             forwarded_from: None,
         };
         let directive = "introduce yourself";
-        let out =
-            build_start_prompt("Bot", true, &unread, Some(&wake), Some(directive));
+        let out = build_start_prompt("Bot", true, &unread, Some(&wake), Some(directive));
         assert_eq!(out, directive);
     }
 

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -367,7 +367,18 @@ pub(crate) async fn create_and_start_agent(
             .store
             .join_channel_by_id(&channel.id, &id, SenderType::Agent);
     }
-    let start_error = if let Err(err) = state.lifecycle.start_agent(&name, None).await {
+    // Brand-new agent — ask it to introduce itself in the system channel.
+    // The directive is delivered as the first prompt; the agent's model
+    // produces the intro text and posts it via send_message.
+    let intro_directive = format!(
+        "You have just been added to #{ch}. Use the send_message tool to post a brief one-or-two-sentence introduction of yourself in #{ch}, then stop.",
+        ch = crate::store::Store::DEFAULT_SYSTEM_CHANNEL,
+    );
+    let start_error = if let Err(err) = state
+        .lifecycle
+        .start_agent(&name, None, Some(intro_directive))
+        .await
+    {
         let error_detail = format_anyhow_error(&err);
         warn!(agent = %name, error = %error_detail, "agent created but failed to start");
         Some(format!("{err}"))
@@ -454,7 +465,7 @@ pub async fn handle_update_agent(
             .stop_agent(&name)
             .await
             .map_err(internal_err)?;
-        if let Err(err) = state.lifecycle.start_agent(&name, None).await {
+        if let Err(err) = state.lifecycle.start_agent(&name, None, None).await {
             return Err(app_err!(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "agent updated but restart failed: {err}"
@@ -506,7 +517,7 @@ pub async fn handle_restart_agent(
         }
     }
 
-    if let Err(err) = state.lifecycle.start_agent(&name, None).await {
+    if let Err(err) = state.lifecycle.start_agent(&name, None, None).await {
         return Err(app_err!(
             AppErrorCode::AgentRestartFailed,
             "restart failed: {err}"
@@ -567,7 +578,7 @@ pub async fn handle_agent_start(
     info!(agent = %name, "starting agent");
     state
         .lifecycle
-        .start_agent(&name, None)
+        .start_agent(&name, None, None)
         .await
         .map_err(internal_err)?;
     info!(agent = %name, "agent started");

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -359,24 +359,48 @@ pub(crate) async fn create_and_start_agent(
             last_error.unwrap_or_else(|| "unknown".to_string())
         )
     })?;
+    // Track the system-channel join: the intro directive only makes sense
+    // if the agent actually became a member of #all. Other auto-join
+    // failures are logged but don't block — historically this loop
+    // swallowed all errors, and we don't want to gate creation on a
+    // non-system channel.
+    let mut joined_system_channel = false;
     for channel in state
         .store
         .get_auto_join_channels_for_workspace(active_workspace_id.as_deref())?
     {
-        let _ = state
+        let is_system = channel.name == crate::store::Store::DEFAULT_SYSTEM_CHANNEL;
+        match state
             .store
-            .join_channel_by_id(&channel.id, &id, SenderType::Agent);
+            .join_channel_by_id(&channel.id, &id, SenderType::Agent)
+        {
+            Ok(_) => {
+                if is_system {
+                    joined_system_channel = true;
+                }
+            }
+            Err(err) => warn!(
+                agent = %name,
+                channel = %channel.name,
+                error = %format_anyhow_error(&err),
+                "auto-join failed",
+            ),
+        }
     }
     // Brand-new agent — ask it to introduce itself in the system channel.
     // The directive is delivered as the first prompt; the agent's model
-    // produces the intro text and posts it via send_message.
-    let intro_directive = format!(
-        "You have just been added to #{ch}. Use the send_message tool to post a brief one-or-two-sentence introduction of yourself in #{ch}, then stop.",
-        ch = crate::store::Store::DEFAULT_SYSTEM_CHANNEL,
-    );
+    // picks the right messaging tool from its system prompt and writes
+    // the intro itself. Only issued when the system-channel join landed —
+    // otherwise we'd send the agent on an impossible errand.
+    let intro_directive = joined_system_channel.then(|| {
+        format!(
+            "You have just been added to #{ch}. Post a brief one-or-two-sentence introduction of yourself in #{ch}, then stop.",
+            ch = crate::store::Store::DEFAULT_SYSTEM_CHANNEL,
+        )
+    });
     let start_error = if let Err(err) = state
         .lifecycle
-        .start_agent(&name, None, Some(intro_directive))
+        .start_agent(&name, None, intro_directive)
         .await
     {
         let error_detail = format_anyhow_error(&err);

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -858,7 +858,7 @@ pub(crate) async fn deliver_message_to_agents(
                     .get_received_message_for_agent_name(&recipient_name, message_id)?;
                 state
                     .lifecycle
-                    .start_agent(&recipient_name, wake_message)
+                    .start_agent(&recipient_name, wake_message, None)
                     .await?
             }
         }

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -104,7 +104,7 @@ async fn restart_agent_member(
         .map_err(internal_err)?;
     state
         .lifecycle
-        .start_agent(agent_name, None)
+        .start_agent(agent_name, None, None)
         .await
         .map_err(internal_err)?;
     Ok(())

--- a/tests/agent_status_derivation_tests.rs
+++ b/tests/agent_status_derivation_tests.rs
@@ -35,6 +35,7 @@ impl AgentLifecycle for MockLifecycle {
         &'a self,
         agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async move {
             self.running.lock().unwrap().insert(agent_name.to_string());

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -78,6 +78,7 @@ impl AgentLifecycle for NoopLifecycle {
         &'a self,
         _agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -21,6 +21,7 @@ impl AgentLifecycle for NoopLifecycle {
         &'a self,
         _agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -109,6 +109,7 @@ impl AgentLifecycle for NoopLifecycle {
         &'a self,
         _agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -99,6 +99,7 @@ impl AgentLifecycle for NoopLifecycle {
         &'a self,
         _agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -3472,13 +3472,12 @@ async fn test_create_agent_passes_intro_directive_referencing_system_channel() {
         "directive should reference #{expected_channel}: {directive:?}"
     );
     assert!(
-        directive.contains("send_message"),
-        "directive should tell the agent which tool to use: {directive:?}"
-    );
-    assert!(
         directive.contains("introduc"),
         "directive should mention introducing: {directive:?}"
     );
+    // Tool name is intentionally NOT asserted: runtimes can prefix tools
+    // (e.g. mcp__chat__send_message), and the agent's standing system
+    // prompt already names the tool. Hardcoding it here would be brittle.
     // wake_message stays None for a fresh creation — the directive is
     // the only first-prompt source.
     assert!(started[0].1.is_none());

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -3495,7 +3495,9 @@ async fn test_manual_restart_does_not_fire_intro_directive() {
                 .method("POST")
                 .uri("/api/agents/bot1/restart")
                 .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&serde_json::json!({ "mode": "restart" })).unwrap()))
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({ "mode": "restart" })).unwrap(),
+                ))
                 .unwrap(),
         )
         .await

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -97,9 +97,13 @@ fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
     (store, router, dir)
 }
 
+/// One observed `start_agent` invocation: `(agent_name, wake_message, init_directive)`.
+/// Tests assert against the recorded sequence to pin call-site behavior.
+type StartedCall = (String, Option<ReceivedMessage>, Option<String>);
+
 #[derive(Default)]
 struct MockLifecycle {
-    started: Mutex<Vec<(String, Option<ReceivedMessage>)>>,
+    started: Mutex<Vec<StartedCall>>,
     stopped: Mutex<Vec<String>>,
     notified: Mutex<Vec<String>>,
     activity_logs: ActivityLogMap,
@@ -138,7 +142,7 @@ impl MockLifecycle {
             .lock()
             .unwrap()
             .iter()
-            .map(|(name, _)| name.clone())
+            .map(|(name, _, _)| name.clone())
             .collect()
     }
 
@@ -146,7 +150,7 @@ impl MockLifecycle {
         self.notified.lock().unwrap().clone()
     }
 
-    fn started_calls(&self) -> Vec<(String, Option<ReceivedMessage>)> {
+    fn started_calls(&self) -> Vec<StartedCall> {
         self.started.lock().unwrap().clone()
     }
 
@@ -168,12 +172,14 @@ impl AgentLifecycle for MockLifecycle {
         &'a self,
         agent_name: &'a str,
         wake_message: Option<ReceivedMessage>,
+        init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async move {
-            self.started
-                .lock()
-                .unwrap()
-                .push((agent_name.to_string(), wake_message));
+            self.started.lock().unwrap().push((
+                agent_name.to_string(),
+                wake_message,
+                init_directive,
+            ));
             self.running.lock().unwrap().insert(agent_name.to_string());
             Ok(())
         })
@@ -235,6 +241,7 @@ impl AgentLifecycle for FailStartLifecycle {
         &'a self,
         _agent_name: &'a str,
         _wake_message: Option<ReceivedMessage>,
+        _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Err(anyhow::anyhow!("runtime unavailable")) })
     }
@@ -3419,5 +3426,88 @@ async fn public_send_allows_empty_content_with_attachments() {
         resp.status(),
         StatusCode::BAD_REQUEST,
         "empty content with attachments should not be rejected"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Agent self-introduction (#108)
+//
+// New agents auto-join the system channel on creation; before this
+// change they did so silently, leaving humans staring at a member list
+// with no idea who the new arrival was for. We now hand the agent's
+// first run an init directive asking it to introduce itself in #all.
+// These tests pin the wiring: the directive flows from
+// create_and_start_agent into AgentLifecycle::start_agent, and the
+// other start paths (manual restart, message wake) do not.
+// ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_agent_passes_intro_directive_referencing_system_channel() {
+    let (store, app, lifecycle) = setup_with_lifecycle();
+    store.ensure_builtin_channels("alice").unwrap();
+
+    let req = serde_json::json!({ "name": "newbot", "runtime": "claude", "model": "sonnet" });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/agents")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let started = lifecycle.started_calls();
+    assert_eq!(started.len(), 1, "create-agent should fire one start");
+    let directive = started[0]
+        .2
+        .as_ref()
+        .expect("create-agent must pass an init directive");
+    let expected_channel = Store::DEFAULT_SYSTEM_CHANNEL;
+    assert!(
+        directive.contains(expected_channel),
+        "directive should reference #{expected_channel}: {directive:?}"
+    );
+    assert!(
+        directive.contains("send_message"),
+        "directive should tell the agent which tool to use: {directive:?}"
+    );
+    assert!(
+        directive.contains("introduc"),
+        "directive should mention introducing: {directive:?}"
+    );
+    // wake_message stays None for a fresh creation — the directive is
+    // the only first-prompt source.
+    assert!(started[0].1.is_none());
+}
+
+#[tokio::test]
+async fn test_manual_restart_does_not_fire_intro_directive() {
+    // setup_with_lifecycle() already seeds bot1 in the default workspace.
+    let (_store, app, lifecycle) = setup_with_lifecycle();
+    lifecycle.mark_running("bot1");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/agents/bot1/restart")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&serde_json::json!({ "mode": "restart" })).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let started = lifecycle.started_calls();
+    assert_eq!(started.len(), 1);
+    assert_eq!(started[0].0, "bot1");
+    assert!(
+        started[0].2.is_none(),
+        "restart must not pass an init directive — only first-time creation does"
     );
 }


### PR DESCRIPTION
Closes #108.

## Summary

- New agents auto-join `#all` but said nothing on arrival — humans saw a bare join notice. After this change, the agent introduces itself in `#all` using `send_message`. The text is generated by the agent's model on its first run, not from a static template.
- `AgentLifecycle::start_agent` gains an `init_directive: Option<String>` parameter. `build_start_prompt` returns the directive verbatim when present; existing wake / resume / fresh-start branches are unchanged when `None`.
- Only `create_and_start_agent` passes `Some(directive)`. Manual restart, message-driven wake, and update-triggered restart all pass `None` — restart paths don't accidentally fire intros.
- Trio members go through the same creation path, so each gets an intro in `#all`; the trio channel still gets the existing "Team assembled" kickoff.

## Design notes

- The directive references `Store::DEFAULT_SYSTEM_CHANNEL` rather than hardcoding `#all` — a future channel rename won't desync.
- Best-effort: if the agent fails to start or the model declines to post, no retry. Documented as accepted in the design doc; revisit if it shows up in practice. Persistent "intro pending" state was deliberately deferred.
- The `Option<ReceivedMessage>` + `Option<String>` pair on `start_agent` is intentional: a `StartReason` enum was considered and rejected as YAGNI for a single new caller.

## Test plan

- [x] `cargo test` — 327 lib unit tests, 76 server e2e tests, all 0 failures.
  - +3 unit tests for `build_start_prompt(init_directive=Some/None)` covering directive verbatim, override of wake/resume, and fall-through.
  - +2 e2e tests: `test_create_agent_passes_intro_directive_referencing_system_channel`, `test_manual_restart_does_not_fire_intro_directive`.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [ ] Live driver verification (Claude/Codex agent actually posting in `#all`) — not run from this branch; QA pass to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)