### PR TITLE
fix(ui): accessibility - aria-label, headings, system message markdown

### DIFF
--- a/ui/src/components/chat/MentionTextarea.tsx
+++ b/ui/src/components/chat/MentionTextarea.tsx
@@ -171,6 +171,8 @@ export function MentionTextarea({
         onKeyDown={handleKeyDown}
         disabled={disabled}
         rows={rows}
+        aria-label={placeholder ?? 'Message input'}
+        role="textbox"
       />
     </div>
   )

--- a/ui/src/components/chat/MessageItem.tsx
+++ b/ui/src/components/chat/MessageItem.tsx
@@ -159,7 +159,17 @@ function SystemMessageItem({ message }: { message: HistoryMessage }) {
       title={fullTime}
     >
       <div className="system-message-divider__line" />
-      <span className="system-message-divider__label">{message.content}</span>
+      <div className="system-message-divider__label">
+        <ReactMarkdown
+          components={{
+            p({ children }) {
+              return <>{children}</>;
+            },
+          }}
+        >
+          {message.content}
+        </ReactMarkdown>
+      </div>
       <div className="system-message-divider__line" />
     </div>
   );

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,5 +1,18 @@
 @import "tailwindcss";
 
+/* Visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 @theme {
   --color-background: #f4f2ed;
   --color-foreground: #23201a;

--- a/ui/src/pages/MainPanel.tsx
+++ b/ui/src/pages/MainPanel.tsx
@@ -228,6 +228,13 @@ export function MainPanel() {
         >
           {activeTab === "chat" && (
             <>
+              <h1 className="sr-only">
+                {currentAgent
+                  ? `Chat with ${currentAgent.display_name ?? currentAgent.name}`
+                  : currentChannel
+                    ? `Chat in ${currentChannel.name}`
+                    : "Chat"}
+              </h1>
               <ChatPanel
                 target={chatTarget}
                 conversationId={activeConversationId}
@@ -244,16 +251,40 @@ export function MainPanel() {
               />
             </>
           )}
-          {activeTab === "tasks" && <TasksPanel />}
-          {activeTab === "profile" && <ProfilePanel />}
+          {activeTab === "tasks" && (
+            <>
+              <h1 className="sr-only">Tasks</h1>
+              <TasksPanel />
+            </>
+          )}
+          {activeTab === "profile" && (
+            <>
+              <h1 className="sr-only">
+                {currentAgent
+                  ? `Profile: ${currentAgent.display_name ?? currentAgent.name}`
+                  : "Profile"}
+              </h1>
+              <ProfilePanel />
+            </>
+          )}
           {activeTab === "activity" && currentAgent && (
-            <TelescopeActivity
-              agentId={currentAgent.id}
-              agentName={currentAgent.name}
-            />
+            <>
+              <h1 className="sr-only">
+                Activity: {currentAgent.display_name ?? currentAgent.name}
+              </h1>
+              <TelescopeActivity
+                agentId={currentAgent.id}
+                agentName={currentAgent.name}
+              />
+            </>
           )}
           {activeTab === "workspace" && currentAgent && (
-            <WorkspacePanel agentId={currentAgent.id} />
+            <>
+              <h1 className="sr-only">
+                Workspace: {currentAgent.display_name ?? currentAgent.name}
+              </h1>
+              <WorkspacePanel agentId={currentAgent.id} />
+            </>
           )}
           {!showHeader && (
             <div
@@ -267,6 +298,7 @@ export function MainPanel() {
                 gap: 8,
               }}
             >
+              <h1 className="sr-only">Chorus — Select a channel or agent to get started</h1>
               <span className="empty-state-icon">[chorus::idle]</span>
               <span>Select a channel or agent to get started</span>
             </div>


### PR DESCRIPTION
## Summary

Fixes 3 verified accessibility/rendering bugs from #122.

## Changes

| File | Fix |
|------|-----|
| `MentionTextarea.tsx` | Added `aria-label` and `role=textbox` to the message textarea so screen readers can discover it |
| `MainPanel.tsx` | Added visually-hidden `<h1>` headings to every panel (chat, tasks, profile, activity, workspace, empty state) |
| `index.css` | Added `.sr-only` utility class |
| `MessageItem.tsx` | System messages now render through `ReactMarkdown` so markdown like `**bold**` displays correctly |

## Verification

- `cd ui && npx tsc --noEmit` ✅ clean
- `cd ui && npm run test -- --run` ✅ **85/85 tests pass**

## Notes

The modal "cross-wiring" bugs reported in #122 (e.g. "Add channel opens Create Agent modal") were investigated and determined to be **browse-tool artifacts** — the code handlers are all correctly wired with distinct callbacks. The symptoms match stale DOM reference behavior in the headless browser agent.

Closes #122