### PR TITLE
fix(ui): auth cache mismatch after DB wipe

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -93,7 +93,15 @@ function syncWhoami(
     // Switching local human identity invalidates the cached selection state
     // (current channel/agent, inbox cursors). Reset before adopting the new id
     // so stale ids/cursors from the previous session don't leak in.
-    if (currentUserId) resetUserSession();
+    if (currentUserId) {
+      resetUserSession();
+      // Wipe the React Query cache so stale API data (channels, agents,
+      // messages) from the previous human session doesn't persist.
+      appQueryClient.clear();
+      // Re-seed whoami so the query that just resolved doesn't flicker into
+      // a loading state while components re-mount.
+      appQueryClient.setQueryData(channelQueryKeys.whoami, whoami);
+    }
     setCurrentUser(whoami);
   }, [whoami, currentUserId, setCurrentUser, resetUserSession]);
 }

--- a/ui/src/data/agents.ts
+++ b/ui/src/data/agents.ts
@@ -199,12 +199,12 @@ export function isAgentActive(agent: AgentInfo): boolean {
 // ── Query definitions ──
 
 export const agentQueryKeys = {
-  agents: ['agents'] as const,
+  agents: (humanId: string) => ['agents', humanId] as const,
 } as const
 
 export const agentsQuery = (memberHumanId: string) =>
   queryOptions({
-    queryKey: agentQueryKeys.agents,
+    queryKey: agentQueryKeys.agents(memberHumanId),
     queryFn: listAgents,
     enabled: !!memberHumanId,
   })

--- a/ui/src/data/channels.ts
+++ b/ui/src/data/channels.ts
@@ -207,14 +207,14 @@ export const channelQueryKeys = {
   whoami: ['whoami'] as const,
   /** React-query cache segment keyed by the local human's stable id. */
   channels: (humanId: string) => ['channels', humanId] as const,
-  humans: ['humans'] as const,
+  humans: (humanId: string) => ['humans', humanId] as const,
   members: (channelId: string | null) => ['channelMembers', channelId] as const,
 } as const
 
 export const whoamiQuery = queryOptions({
   queryKey: channelQueryKeys.whoami,
   queryFn: () => getWhoami(),
-  staleTime: Infinity,
+  staleTime: 5 * 60 * 1000,
 })
 
 export const channelsQuery = (memberHumanId: string) =>
@@ -228,7 +228,7 @@ export const channelsQuery = (memberHumanId: string) =>
 
 export const humansQuery = (memberHumanId: string) =>
   queryOptions({
-    queryKey: channelQueryKeys.humans,
+    queryKey: channelQueryKeys.humans(memberHumanId),
     queryFn: listHumans,
     enabled: !!memberHumanId,
   })

--- a/ui/src/hooks/data.ts
+++ b/ui/src/hooks/data.ts
@@ -158,8 +158,8 @@ export function useRefresh() {
   }, [currentUserId, queryClient])
 
   const refreshAgents = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents })
-  }, [queryClient])
+    await queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents(currentUserId) })
+  }, [currentUserId, queryClient])
 
   const refreshTeams = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: teamQueryKeys.teams })
@@ -167,10 +167,10 @@ export function useRefresh() {
 
   const refreshServerInfo = useCallback(async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents }),
+      queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents(currentUserId) }),
       queryClient.invalidateQueries({ queryKey: channelQueryKeys.channels(currentUserId) }),
       queryClient.invalidateQueries({ queryKey: teamQueryKeys.teams }),
-      queryClient.invalidateQueries({ queryKey: channelQueryKeys.humans }),
+      queryClient.invalidateQueries({ queryKey: channelQueryKeys.humans(currentUserId) }),
       queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.workspaces }),
       queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.current }),
     ])

--- a/ui/src/hooks/useTraceSubscription.ts
+++ b/ui/src/hooks/useTraceSubscription.ts
@@ -3,11 +3,13 @@ import { useQueryClient } from '@tanstack/react-query'
 import { agentQueryKeys } from '../data'
 import { getSession } from '../transport/session'
 import { useTraceStore } from '../store/traceStore'
+import { useStore } from '../store/uiStore'
 
 /** Subscribe to agent trace frames and push them into the trace store. */
 export function useTraceSubscription(viewer: string | null) {
   const pushEvent = useTraceStore((s) => s.pushEvent)
   const queryClient = useQueryClient()
+  const currentUserId = useStore((s) => s.currentUserId)
 
   useEffect(() => {
     if (!viewer) return
@@ -18,7 +20,7 @@ export function useTraceSubscription(viewer: string | null) {
       if (refreshTimer != null) return
       refreshTimer = window.setTimeout(() => {
         refreshTimer = null
-        void queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents })
+        void queryClient.invalidateQueries({ queryKey: agentQueryKeys.agents(currentUserId) })
       }, 100)
     })
 
@@ -26,5 +28,5 @@ export function useTraceSubscription(viewer: string | null) {
       unsubscribe()
       if (refreshTimer != null) window.clearTimeout(refreshTimer)
     }
-  }, [viewer, pushEvent, queryClient])
+  }, [viewer, pushEvent, queryClient, currentUserId])
 }


### PR DESCRIPTION
## Summary

Fixes auth cache mismatch that occurs when the backend SQLite DB is wiped and regenerated while the frontend is running (or on next load).

## Root Causes

1. `whoamiQuery` used `staleTime: Infinity` — cached identity never became stale, so the frontend never detected a new human ID after DB wipe
2. `agentsQuery` and `humansQuery` were not keyed by human ID — their cache keys were static (`['agents']`, `['humans']`), so stale data from the previous session persisted after identity change
3. `syncWhoami` only reset Zustand state, not React Query cache — stale API data from the previous human session leaked into the new session

## Changes

| File | Change |
|------|--------|
| `data/channels.ts` | `whoamiQuery.staleTime`: Infinity → 5min; `humansQuery` key now includes `humanId` |
| `data/agents.ts` | `agentsQuery` key now includes `humanId` |
| `App.tsx` | `syncWhoami` now calls `appQueryClient.clear()` on identity switch |
| `hooks/data.ts` | Updated `refreshAgents` / `refreshServerInfo` to use new keyed patterns |
| `hooks/useTraceSubscription.ts` | Updated invalidation to use keyed `agentsQuery` |

## Verification

- `cd ui && npx tsc --noEmit` ✅ clean
- `cd ui && npm run test -- --run` ✅ **85/85 tests pass**

Closes #122
