### PR TITLE
Add GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture_investigation.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_investigation.yml
@@ -1,0 +1,60 @@
+name: Architecture / Investigation
+description: Capture technical design notes, root-cause analysis, debt, or systemic behavior before concrete work is planned.
+title: "architecture: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for technical investigations and architecture notes. If investigation confirms a shipped defect, file or link a Bug Report.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What system behavior or architectural concern needs attention?
+      placeholder: "Agent creation blocks the HTTP response on driver handshake round-trips."
+    validations:
+      required: true
+  - type: textarea
+    id: area
+    attributes:
+      label: Area / subsystem
+      placeholder: "Agent manager, runtime drivers, ACP bridge, workspace data model, CLI setup."
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      placeholder: "handle_create_agent waits until driver initialization returns before the agent appears in the sidebar."
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / code references
+      description: Include files, functions, issue links, logs, or traces.
+      placeholder: |
+        src/agent/manager.rs:264
+        src/agent/drivers/codex.rs:584
+        #125
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: Suspected or known root cause
+      placeholder: "The manager inserts active agents only after handle.run(init_prompt).await completes."
+  - type: textarea
+    id: approaches
+    attributes:
+      label: Candidate approaches
+      placeholder: |
+        1. Insert pending agent before driver handshake.
+        2. Split process spawn from session initialization.
+        3. Keep synchronous path but surface progress explicitly.
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / migration concerns
+      placeholder: "Could create phantom active agents if initialization fails after insertion."
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Related issues, docs, decisions, or follow-up work.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Report broken shipped behavior, regressions, or suspected defects.
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when something is broken. If this is a product idea, UX critique, or architecture note, choose another template.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: "Creating an agent fails after selecting the Codex runtime."
+    validations:
+      required: true
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      options:
+        - UI
+        - Backend
+        - CLI
+        - Agents / Drivers
+        - Workspace / Data
+        - QA / Tests
+        - Docs
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the shortest reliable path to trigger the problem. Partial steps are okay if this came from logs or a screenshot.
+      placeholder: |
+        1. Start Chorus with `./dev.sh`
+        2. Open #all
+        3. Click Create Agent
+        4. Select Codex
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "The agent appears in the sidebar and reaches an idle/ready state."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: "The request hangs for several seconds, then the UI shows no new agent."
+    validations:
+      required: true
+  - type: textarea
+    id: logs-screenshots
+    attributes:
+      label: Logs / screenshots
+      description: Paste terminal logs, browser console output, screenshots, traces, or API responses.
+      render: shell
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        OS:
+        Browser:
+        Chorus commit/branch:
+        Data dir: default ~/.chorus or custom temp dir
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any related issues, suspected cause, or workaround.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/product_design_request.yml
+++ b/.github/ISSUE_TEMPLATE/product_design_request.yml
@@ -1,0 +1,62 @@
+name: Product / Design Request
+description: Propose product behavior, UX improvements, onboarding, copy, or visual design work.
+title: "product/design: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for feature ideas, UX/design critiques, onboarding improvements, copy changes, and product refinements.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should improve?
+      placeholder: "Improve the empty #all state so first-time users know how to create an agent and start collaborating."
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Problem / motivation
+      description: What user problem or product gap does this address?
+      placeholder: "The shell looks complete, but new users have to infer the first useful workflow."
+    validations:
+      required: true
+  - type: textarea
+    id: affected-workflow
+    attributes:
+      label: Screen, flow, or workflow affected
+      placeholder: "Desktop #all empty state, Agents section, Tasks tab, Create Agent modal."
+  - type: textarea
+    id: current-experience
+    attributes:
+      label: Current experience
+      placeholder: "The page says there are no messages, but does not explain how agents, chat, and tasks connect."
+  - type: textarea
+    id: desired-experience
+    attributes:
+      label: Desired experience
+      placeholder: "The empty state gives a clear first action and preserves the flat industrial design language."
+  - type: textarea
+    id: references
+    attributes:
+      label: Screenshots, mockups, or references
+      description: Link images, issue comments, docs, or comparable flows.
+      placeholder: "https://github.com/Fullstop000/Chorus/issues/128#issuecomment-4350377179"
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / non-goals
+      placeholder: "Desktop first-run only. Mobile is intentionally out of scope."
+  - type: textarea
+    id: design-system-notes
+    attributes:
+      label: Design-system notes
+      description: Mention constraints from docs/DESIGN.md or existing product language.
+      placeholder: "Zero radius, no shadows, no gradients, mono chat-adjacent copy."
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open questions
+      placeholder: "Should the primary first action be sending a message or creating an agent?"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,20 @@ Do NOT answer directly or use other tools first.
 | `/project-memory`          | Record a decision, bug postmortem, fact, or pattern |
 
 
+### Issues
+
+When creating GitHub issues, use the matching form in `.github/ISSUE_TEMPLATE/`:
+
+| Form | Use For |
+| --- | --- |
+| `bug_report.yml` | Broken shipped behavior, regressions, or suspected defects |
+| `product_design_request.yml` | Product behavior, UX/design critique, onboarding, copy, and visual refinements |
+| `architecture_investigation.yml` | Technical design notes, root-cause writeups, debt, or systemic issues before concrete work is planned |
+
+If an investigation confirms a defect, open or link a Bug Report instead of
+continuing to track it only as an architecture note.
+
+
 Browser: use `/gstack-browse`. Never use `mcp__claude-in-chrome__`* tools.
 Run `/gstack-upgrade` to update skill inventory.
 
@@ -138,7 +152,6 @@ Run `/gstack-upgrade` to update skill inventory.
 1. **Every rule earns its place by preventing a real problem.** No rule without an incident.
 2. **Adding a rule means deleting a weaker one.** Fixed budget. Growth is not progress.
 3. **Update in the same PR that made you wish it said something.**
-4. **Annual audit.** Read every rule, every doc pointer. Delete what's stale. If you didn't delete anything, you didn't audit.
 
 
 ---


### PR DESCRIPTION
## Summary
- Add separate GitHub Issue Forms for bug reports, product/design requests, and architecture investigations.
- Add issue template chooser config with blank issues enabled for maintainer escape hatches.
- Keep feature/design merged into one product/design form and omit acceptance/validation-plan fields per project preference.

## Test Plan
- [x] `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |p| YAML.load_file(p); puts "ok #{p}" }'`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `git show --stat --oneline --name-only HEAD` confirmed only `.github/ISSUE_TEMPLATE/*` files are tracked in the commit.
