### PR TITLE
refactor(store): separate Store into pure DAO + EventBus + filesystem paths

### DIFF
--- a/qa/cases/playwright/ENV-001.spec.ts
+++ b/qa/cases/playwright/ENV-001.spec.ts
@@ -47,8 +47,8 @@ test.describe('ENV-001', () => {
     })
 
     await test.step('Step 5: whoami matches visible user', async () => {
-      const { username } = await getWhoami(request)
-      await expect(page.locator('.sidebar-footer')).toContainText(username)
+      const { name } = await getWhoami(request)
+      await expect(page.locator('.sidebar-footer')).toContainText(name)
     })
 
     expect(errors, `console errors: ${errors.join('; ')}`).toEqual([])

--- a/qa/cases/playwright/TSK-001.spec.ts
+++ b/qa/cases/playwright/TSK-001.spec.ts
@@ -64,7 +64,7 @@ test.describe("TSK-001", () => {
       await page.getByRole("button", { name: "Start", exact: true }).click();
       // Status pill should flip once the refetch lands.
       await expect(
-        page.locator(".task-detail__status").filter({ hasText: "in_progress" }),
+        page.locator(".task-detail__status").filter({ hasText: "in progress" }),
       ).toBeVisible({ timeout: 15_000 });
     });
 

--- a/qa/cases/playwright/package-lock.json
+++ b/qa/cases/playwright/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "chorus-qa-playwright",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chorus-qa-playwright",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/src/agent/event_forwarder.rs
+++ b/src/agent/event_forwarder.rs
@@ -31,8 +31,8 @@ use crate::agent::drivers::acp_protocol;
 use crate::agent::drivers::{AgentEventItem, DriverEvent, FinishReason, ProcessState};
 use crate::agent::manager::ManagedAgent;
 use crate::agent::trace::{self, AgentTraceStore, TraceEvent, TraceEventKind};
-use crate::store::StreamEvent;
 use crate::store::Store;
+use crate::store::StreamEvent;
 
 /// Extract a short human-readable summary from an ACP tool-call `input`
 /// object. Probes the common argument keys drivers use (`file_path`,

--- a/src/agent/event_forwarder.rs
+++ b/src/agent/event_forwarder.rs
@@ -31,6 +31,7 @@ use crate::agent::drivers::acp_protocol;
 use crate::agent::drivers::{AgentEventItem, DriverEvent, FinishReason, ProcessState};
 use crate::agent::manager::ManagedAgent;
 use crate::agent::trace::{self, AgentTraceStore, TraceEvent, TraceEventKind};
+use crate::store::StreamEvent;
 use crate::store::Store;
 
 /// Extract a short human-readable summary from an ACP tool-call `input`
@@ -154,6 +155,7 @@ pub(super) fn spawn_event_forwarder(
     activity_logs: Arc<ActivityLogMap>,
     trace_store: Arc<AgentTraceStore>,
     trace_tx: broadcast::Sender<TraceEvent>,
+    stream_tx: broadcast::Sender<StreamEvent>,
     store: Arc<Store>,
     agents: Arc<Mutex<HashMap<String, ManagedAgent>>>,
 ) -> tokio::task::JoinHandle<()> {
@@ -434,15 +436,18 @@ pub(super) fn spawn_event_forwarder(
                                         "⚠️ @{} completed a run without replying. Common causes: not authenticated, authentication expired, or a runtime error. Check agent logs for details.",
                                         key
                                     );
-                                    if let Err(e) =
-                                        store.create_system_message(&channel_id, &warning)
-                                    {
-                                        warn!(
-                                            agent = %key,
-                                            channel_id = %channel_id,
-                                            error = %e,
-                                            "failed to post empty-run warning"
-                                        );
+                                    match store.create_system_message(&channel_id, &warning) {
+                                        Ok((_, event)) => {
+                                            let _ = stream_tx.send(event);
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                agent = %key,
+                                                channel_id = %channel_id,
+                                                error = %e,
+                                                "failed to post empty-run warning"
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -590,6 +595,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -599,6 +605,7 @@ mod tests {
             activity_logs,
             trace_store,
             trace_tx.clone(),
+            stream_tx,
             store,
             agents,
         );
@@ -709,6 +716,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -718,6 +726,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents,
         );
@@ -787,6 +796,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -796,6 +806,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents,
         );
@@ -886,6 +897,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -910,6 +922,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents.clone(),
         );
@@ -988,6 +1001,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -997,6 +1011,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents,
         );
@@ -1065,6 +1080,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -1074,6 +1090,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents,
         );
@@ -1141,6 +1158,7 @@ mod tests {
         let activity_logs = Arc::new(ActivityLogMap::default());
         let trace_store = Arc::new(AgentTraceStore::new());
         let (trace_tx, _trace_rx) = broadcast::channel::<TraceEvent>(64);
+        let (stream_tx, _stream_rx) = broadcast::channel::<StreamEvent>(64);
         let agents: Arc<Mutex<HashMap<String, ManagedAgent>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
@@ -1150,6 +1168,7 @@ mod tests {
             activity_logs,
             trace_store.clone(),
             trace_tx.clone(),
+            stream_tx,
             store.clone(),
             agents,
         );

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -20,6 +20,7 @@ use crate::agent::trace::{self, AgentTraceStore, TraceEvent, TraceEventKind};
 use crate::agent::AgentLifecycle;
 use crate::agent::AgentRuntime;
 use crate::store::messages::ReceivedMessage;
+use crate::store::stream::StreamEvent;
 use crate::store::Store;
 
 /// Managed agent backed by a [`RuntimeDriver`] + [`Session`].
@@ -102,6 +103,9 @@ pub struct AgentManager {
     /// Broadcast sender for agent trace events (tool calls, thinking, etc.).
     /// Decoupled from Store so the persistence layer can be swapped.
     trace_tx: tokio::sync::broadcast::Sender<crate::agent::trace::TraceEvent>,
+    /// Broadcast sender for stream events (messages, channel activity).
+    /// Passed to event forwarder so it can publish system messages.
+    stream_tx: tokio::sync::broadcast::Sender<StreamEvent>,
     /// Optional explicit bridge endpoint. When `None`, agent startup reads the
     /// shared discovery file from `~/.chorus/bridge.json`. Tests set this to a
     /// synthetic URL, and `chorus serve` points it at the co-hosted bridge so
@@ -124,6 +128,7 @@ impl AgentManager {
         store: Arc<Store>,
         data_dir: PathBuf,
         trace_tx: tokio::sync::broadcast::Sender<crate::agent::trace::TraceEvent>,
+        stream_tx: tokio::sync::broadcast::Sender<StreamEvent>,
     ) -> Self {
         Self {
             driver_registry: build_driver_registry(),
@@ -133,6 +138,7 @@ impl AgentManager {
             store,
             data_dir,
             trace_tx,
+            stream_tx,
             bridge_endpoint_override: None,
         }
     }
@@ -295,6 +301,7 @@ impl AgentManager {
             self.activity_logs.clone(),
             self.trace_store.clone(),
             self.trace_tx.clone(),
+            self.stream_tx.clone(),
             self.store.clone(),
             self.agents.clone(),
         );
@@ -561,7 +568,8 @@ impl AgentManager {
     /// construction via [`register_driver`] if the test needs to start agents.
     pub fn new_for_test(store: Arc<Store>, data_dir: std::path::PathBuf) -> Self {
         let (trace_tx, _) = tokio::sync::broadcast::channel(64);
-        let mut mgr = AgentManager::new(store, data_dir, trace_tx);
+        let (stream_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut mgr = AgentManager::new(store, data_dir, trace_tx, stream_tx);
         mgr.bridge_endpoint_override = Some("http://127.0.0.1:1".to_string());
         mgr
     }
@@ -802,7 +810,8 @@ mod tests {
 
     fn make_test_manager(store: Arc<Store>, dir: &std::path::Path) -> AgentManager {
         let (trace_tx, _) = tokio::sync::broadcast::channel(64);
-        let mut manager = AgentManager::new(store, dir.join("agents"), trace_tx);
+        let (stream_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut manager = AgentManager::new(store, dir.join("agents"), trace_tx, stream_tx);
         let fake = Arc::new(FakeDriver::new(AgentRuntime::Codex));
         manager.register_driver(AgentRuntime::Codex, fake);
         // Tests use a synthetic endpoint — the FakeDriver ignores it, but the
@@ -979,7 +988,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(":memory:").unwrap());
         let (trace_tx, _) = tokio::sync::broadcast::channel(64);
-        let mut manager = AgentManager::new(store, dir.path().join("agents"), trace_tx);
+        let (stream_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut manager = AgentManager::new(store, dir.path().join("agents"), trace_tx, stream_tx);
         manager.set_bridge_endpoint_override("http://127.0.0.1:9999");
         let got = manager.resolve_bridge_endpoint().unwrap();
         assert_eq!(got, "http://127.0.0.1:9999");
@@ -1002,7 +1012,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(":memory:").unwrap());
         let (trace_tx, _) = tokio::sync::broadcast::channel(64);
-        let manager = AgentManager::new(store, dir.path().join("agents"), trace_tx);
+        let (stream_tx, _) = tokio::sync::broadcast::channel(64);
+        let manager = AgentManager::new(store, dir.path().join("agents"), trace_tx, stream_tx);
         let err = manager
             .resolve_bridge_endpoint()
             .expect_err("must fail when no override and no bridge");

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -99,6 +99,9 @@ pub struct AgentManager {
     trace_store: Arc<AgentTraceStore>,
     store: Arc<Store>,
     data_dir: PathBuf,
+    /// Broadcast sender for agent trace events (tool calls, thinking, etc.).
+    /// Decoupled from Store so the persistence layer can be swapped.
+    trace_tx: tokio::sync::broadcast::Sender<crate::agent::trace::TraceEvent>,
     /// Optional explicit bridge endpoint. When `None`, agent startup reads the
     /// shared discovery file from `~/.chorus/bridge.json`. Tests set this to a
     /// synthetic URL, and `chorus serve` points it at the co-hosted bridge so
@@ -117,7 +120,11 @@ pub fn build_driver_registry() -> HashMap<AgentRuntime, Arc<dyn RuntimeDriver>> 
 }
 
 impl AgentManager {
-    pub fn new(store: Arc<Store>, data_dir: PathBuf) -> Self {
+    pub fn new(
+        store: Arc<Store>,
+        data_dir: PathBuf,
+        trace_tx: tokio::sync::broadcast::Sender<crate::agent::trace::TraceEvent>,
+    ) -> Self {
         Self {
             driver_registry: build_driver_registry(),
             agents: Arc::new(Mutex::new(HashMap::new())),
@@ -125,6 +132,7 @@ impl AgentManager {
             trace_store: Arc::new(AgentTraceStore::new()),
             store,
             data_dir,
+            trace_tx,
             bridge_endpoint_override: None,
         }
     }
@@ -286,7 +294,7 @@ impl AgentManager {
             event_rx,
             self.activity_logs.clone(),
             self.trace_store.clone(),
-            self.store.trace_sender(),
+            self.trace_tx.clone(),
             self.store.clone(),
             self.agents.clone(),
         );
@@ -370,7 +378,7 @@ impl AgentManager {
             // End any active trace run.
             trace::emit_active_event(
                 &self.trace_store,
-                &self.store.trace_sender(),
+                &self.trace_tx.clone(),
                 agent_name,
                 TraceEventKind::Error {
                     message: "Agent stopped".to_string(),
@@ -479,7 +487,7 @@ impl AgentManager {
 
             let agents_ref = self.agents.clone();
             let trace_store = self.trace_store.clone();
-            let trace_tx = self.store.trace_sender();
+            let trace_tx = self.trace_tx.clone();
             let name = agent_name.to_string();
 
             tokio::spawn(async move {
@@ -552,7 +560,8 @@ impl AgentManager {
     /// or bridge process are required. Register drivers explicitly after
     /// construction via [`register_driver`] if the test needs to start agents.
     pub fn new_for_test(store: Arc<Store>, data_dir: std::path::PathBuf) -> Self {
-        let mut mgr = AgentManager::new(store, data_dir);
+        let (trace_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut mgr = AgentManager::new(store, data_dir, trace_tx);
         mgr.bridge_endpoint_override = Some("http://127.0.0.1:1".to_string());
         mgr
     }
@@ -792,7 +801,8 @@ mod tests {
     use tempfile::tempdir;
 
     fn make_test_manager(store: Arc<Store>, dir: &std::path::Path) -> AgentManager {
-        let mut manager = AgentManager::new(store, dir.join("agents"));
+        let (trace_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut manager = AgentManager::new(store, dir.join("agents"), trace_tx);
         let fake = Arc::new(FakeDriver::new(AgentRuntime::Codex));
         manager.register_driver(AgentRuntime::Codex, fake);
         // Tests use a synthetic endpoint — the FakeDriver ignores it, but the
@@ -968,7 +978,8 @@ mod tests {
     fn resolve_bridge_endpoint_returns_override_when_set() {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(":memory:").unwrap());
-        let mut manager = AgentManager::new(store, dir.path().join("agents"));
+        let (trace_tx, _) = tokio::sync::broadcast::channel(64);
+        let mut manager = AgentManager::new(store, dir.path().join("agents"), trace_tx);
         manager.set_bridge_endpoint_override("http://127.0.0.1:9999");
         let got = manager.resolve_bridge_endpoint().unwrap();
         assert_eq!(got, "http://127.0.0.1:9999");
@@ -990,7 +1001,8 @@ mod tests {
         }
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(":memory:").unwrap());
-        let manager = AgentManager::new(store, dir.path().join("agents"));
+        let (trace_tx, _) = tokio::sync::broadcast::channel(64);
+        let manager = AgentManager::new(store, dir.path().join("agents"), trace_tx);
         let err = manager
             .resolve_bridge_endpoint()
             .expect_err("must fail when no override and no bridge");

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -45,7 +45,7 @@ pub async fn run(
     // user running the server process.
 
     let server_url = format!("http://localhost:{port}");
-    let mut manager = AgentManager::new(store.clone(), agents_dir.clone(), event_bus.trace_sender());
+    let mut manager = AgentManager::new(store.clone(), agents_dir.clone(), event_bus.trace_sender(), event_bus.stream_sender());
 
     // Shared cancellation token — cancelled on Ctrl-C and used to shut down
     // both the main server and the bridge together.

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 
 use chorus::agent::manager::AgentManager;
+use chorus::server::event_bus::EventBus;
 use chorus::store::Store;
 use tokio_util::sync::CancellationToken;
 
@@ -32,8 +33,8 @@ pub async fn run(
     std::fs::create_dir_all(&logs_dir)?;
     std::fs::create_dir_all(&agents_dir)?;
     let db_path = data_subdir.join("chorus.db");
-    let store =
-        Arc::new(Store::open(db_path.to_str().unwrap())?.with_agents_dir(agents_dir.clone()));
+    let store = Arc::new(Store::open(db_path.to_str().unwrap())?);
+    let event_bus = Arc::new(EventBus::new());
 
     // The local human (id + name) is resolved during `build_router_with_services`
     // from `ChorusConfig::local_human` or, on first run, by inserting a row keyed
@@ -44,7 +45,7 @@ pub async fn run(
     // user running the server process.
 
     let server_url = format!("http://localhost:{port}");
-    let mut manager = AgentManager::new(store.clone(), agents_dir);
+    let mut manager = AgentManager::new(store.clone(), agents_dir.clone(), event_bus.trace_sender());
 
     // Shared cancellation token — cancelled on Ctrl-C and used to shut down
     // both the main server and the bridge together.
@@ -155,6 +156,9 @@ pub async fn run(
 
     let router = chorus::server::build_router_with_services(
         store.clone(),
+        event_bus.clone(),
+        data_dir.clone(),
+        agents_dir.clone(),
         manager.clone(),
         Arc::new(
             chorus::agent::runtime_status::SystemRuntimeStatusProvider::new(
@@ -167,7 +171,7 @@ pub async fn run(
     // Spawn background trace writer for Telescope persistence.
     chorus::store::trace_writer::spawn_trace_writer(
         db_path.to_str().unwrap().to_string(),
-        store.subscribe_traces(),
+        event_bus.subscribe_traces(),
     );
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}")).await?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -45,7 +45,12 @@ pub async fn run(
     // user running the server process.
 
     let server_url = format!("http://localhost:{port}");
-    let mut manager = AgentManager::new(store.clone(), agents_dir.clone(), event_bus.trace_sender(), event_bus.stream_sender());
+    let mut manager = AgentManager::new(
+        store.clone(),
+        agents_dir.clone(),
+        event_bus.trace_sender(),
+        event_bus.stream_sender(),
+    );
 
     // Shared cancellation token — cancelled on Ctrl-C and used to shut down
     // both the main server and the bridge together.

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -486,7 +486,7 @@ fn ensure_setup_workspace(
     if let Some(workspace) = store.get_active_workspace()? {
         return Ok(workspace);
     }
-    store.create_local_workspace(workspace_name, owner_human_id)
+    store.create_local_workspace(workspace_name, owner_human_id).map(|(w, _)| w)
 }
 
 /// Resolve (or seed) the local human row and write `(id, name)` back to
@@ -922,7 +922,7 @@ mod tests {
         let store = Store::open(db_path.to_str().unwrap()).unwrap();
         let alice = store.create_local_human("alice").unwrap();
         let bob = store.create_local_human("bob").unwrap();
-        let existing = store
+        let (existing, _event) = store
             .create_local_workspace("Existing Workspace", &alice.id)
             .unwrap();
 

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -486,7 +486,13 @@ fn ensure_setup_workspace(
     if let Some(workspace) = store.get_active_workspace()? {
         return Ok(workspace);
     }
-    store.create_local_workspace(workspace_name, owner_human_id).map(|(w, _)| w)
+    // The dropped StreamEvent here is intentional: `chorus setup` runs as
+    // a one-shot CLI before any server starts, so no EventBus subscriber
+    // exists to receive it. The runtime path through `handle_create_workspace`
+    // does publish; this is the setup-only branch.
+    store
+        .create_local_workspace(workspace_name, owner_human_id)
+        .map(|(w, _)| w)
 }
 
 /// Resolve (or seed) the local human row and write `(id, name)` back to

--- a/src/server/event_bus.rs
+++ b/src/server/event_bus.rs
@@ -1,0 +1,52 @@
+use tokio::sync::broadcast;
+
+use crate::agent::trace::TraceEvent;
+use crate::store::stream::StreamEvent;
+
+/// Application-level event bus for real-time stream and trace broadcasts.
+///
+/// Decoupled from the persistence layer so [`Store`] remains a pure DAO
+/// and can be replaced with Mongo/Supabase backends without carrying
+/// WebSocket broadcast state.
+#[derive(Clone)]
+pub struct EventBus {
+    stream_tx: broadcast::Sender<StreamEvent>,
+    trace_tx: broadcast::Sender<TraceEvent>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let (stream_tx, _) = broadcast::channel(256);
+        let (trace_tx, _) = broadcast::channel(1024);
+        Self {
+            stream_tx,
+            trace_tx,
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<StreamEvent> {
+        self.stream_tx.subscribe()
+    }
+
+    pub fn subscribe_traces(&self) -> broadcast::Receiver<TraceEvent> {
+        self.trace_tx.subscribe()
+    }
+
+    pub fn trace_sender(&self) -> broadcast::Sender<TraceEvent> {
+        self.trace_tx.clone()
+    }
+
+    /// Publish a single stream event. Best-effort: errors are dropped
+    /// because the DB rows are the source of truth.
+    pub fn publish_stream(&self, event: StreamEvent) {
+        let _ = self.stream_tx.send(event);
+    }
+
+
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/server/event_bus.rs
+++ b/src/server/event_bus.rs
@@ -36,6 +36,10 @@ impl EventBus {
         self.trace_tx.clone()
     }
 
+    pub fn stream_sender(&self) -> broadcast::Sender<StreamEvent> {
+        self.stream_tx.clone()
+    }
+
     /// Publish a single stream event. Best-effort: errors are dropped
     /// because the DB rows are the source of truth.
     pub fn publish_stream(&self, event: StreamEvent) {

--- a/src/server/event_bus.rs
+++ b/src/server/event_bus.rs
@@ -45,8 +45,6 @@ impl EventBus {
     pub fn publish_stream(&self, event: StreamEvent) {
         let _ = self.stream_tx.send(event);
     }
-
-
 }
 
 impl Default for EventBus {

--- a/src/server/handlers/agent_workspace.rs
+++ b/src/server/handlers/agent_workspace.rs
@@ -80,7 +80,7 @@ pub async fn handle_agent_workspace(
     AxumPath(PublicResourceIdPath { id }): AxumPath<PublicResourceIdPath>,
 ) -> ApiResult<serde_json::Value> {
     let agent = resolve_public_agent(&state, &id)?;
-    let workspace_dir = state.store.agents_dir().join(&agent.name);
+    let workspace_dir = state.agents_dir.clone().join(&agent.name);
     if !workspace_dir.exists() {
         return Ok(Json(serde_json::json!({
             "path": workspace_dir.to_string_lossy(),
@@ -101,7 +101,7 @@ pub async fn handle_agent_workspace_file(
     Query(params): Query<WorkspaceFileParams>,
 ) -> ApiResult<serde_json::Value> {
     let agent = resolve_public_agent(&state, &id)?;
-    let workspace_dir = state.store.agents_dir().join(&agent.name);
+    let workspace_dir = state.agents_dir.clone().join(&agent.name);
     let relative = sanitize_workspace_path(&params.path)?;
     let file_path = workspace_dir.join(&relative);
 

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -374,7 +374,10 @@ pub(crate) async fn create_and_start_agent(
             .store
             .join_channel_by_id(&channel.id, &id, SenderType::Agent)
         {
-            Ok(_) => {
+            Ok((_, events)) => {
+                for event in events {
+                    state.event_bus.publish_stream(event);
+                }
                 if is_system {
                     joined_system_channel = true;
                 }
@@ -510,7 +513,7 @@ pub async fn handle_restart_agent(
     let agent = resolve_public_agent(&state, &id)?;
     let name = agent.name.clone();
     let _transition = acquire_transition(&state, &name)?;
-    let agents_dir = state.store.agents_dir();
+    let agents_dir = state.agents_dir.clone();
     let workspace = AgentWorkspace::new(&agents_dir);
 
     state
@@ -579,7 +582,7 @@ pub async fn handle_delete_agent(
         .map_err(internal_err)?;
 
     if matches!(req.mode, DeleteMode::DeleteWorkspace) {
-        let agents_dir = state.store.agents_dir();
+        let agents_dir = state.agents_dir.clone();
         let workspace = AgentWorkspace::new(&agents_dir);
         if let Err(e) = workspace.delete_if_exists(&name) {
             return Ok(Json(serde_json::json!({

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -335,11 +335,14 @@ pub(crate) async fn create_and_start_agent(
         let create_result = match active_workspace_id.as_deref() {
             Some(workspace_id) => state
                 .store
-                .create_agent_record_in_workspace(workspace_id, &record),
-            None => state.store.create_agent_record(&record),
+                .create_agent_record_in_workspace_with_events(workspace_id, &record),
+            None => state.store.create_agent_record_with_events(&record),
         };
         match create_result {
-            Ok(id) => {
+            Ok((id, events)) => {
+                for event in events {
+                    state.event_bus.publish_stream(event);
+                }
                 slug_result = Some((candidate, id));
                 break;
             }

--- a/src/server/handlers/attachments.rs
+++ b/src/server/handlers/attachments.rs
@@ -30,7 +30,7 @@ async fn store_upload(state: AppState, mut multipart: Multipart) -> ApiResult<se
         .unwrap_or_default();
 
     let file_id = Uuid::new_v4().to_string();
-    let attachments_dir = state.store.attachments_dir();
+    let attachments_dir = state.attachments_dir();
     std::fs::create_dir_all(&attachments_dir).map_err(internal_err)?;
 
     let stored_path = attachments_dir.join(format!("{}{}", file_id, ext));

--- a/src/server/handlers/channels.rs
+++ b/src/server/handlers/channels.rs
@@ -162,9 +162,13 @@ pub async fn handle_create_channel(
             app_err!(StatusCode::BAD_REQUEST, msg)
         }
     })?;
-    let _ = state
+    let (_, events) = state
         .store
-        .join_channel_by_id(&channel_id, &state.local_human_id, SenderType::Human);
+        .join_channel_by_id(&channel_id, &state.local_human_id, SenderType::Human)
+        .unwrap_or_default();
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "id": channel_id, "name": name })))
 }
 
@@ -217,10 +221,13 @@ pub async fn handle_invite_channel_member(
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?
         .ok_or_else(|| app_err!(StatusCode::BAD_REQUEST, "member not found: {member_name}"))?;
 
-    state
+    let (_, events) = state
         .store
         .join_channel_by_id(&channel.id, &member_id, member_type)
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
 
     let members = state
         .store

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -416,7 +416,7 @@ async fn send_message_to_channel(
     let preview = content_preview(content);
     info!(agent = %actor_id, target = %format!("#{}", channel.name), content = %preview, "send_message");
 
-    let message_id = store
+    let (message_id, event) = store
         .create_message(CreateMessage {
             channel_name: &channel.name,
             sender_id: actor_id,
@@ -427,6 +427,9 @@ async fn send_message_to_channel(
             run_id: run_id.as_deref(),
         })
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    if let Some(ev) = event {
+        state.event_bus.publish_stream(ev);
+    }
 
     info!(agent = %actor_id, msg = %message_id, content=%content, "send_message ok");
 
@@ -499,7 +502,7 @@ async fn forward_team_mentions(
 
         let sender_name = actor_label(state, sender_id, sender_type)
             .map_err(|(_, Json(error))| anyhow::anyhow!(error.error))?;
-        let forwarded_message_id = state.store.create_message_with_forwarded_from(
+        let (forwarded_message_id, event) = state.store.create_message_with_forwarded_from(
             &team_channel.id,
             sender_id,
             sender_type,
@@ -510,6 +513,7 @@ async fn forward_team_mentions(
                 sender_name,
             }),
         )?;
+        state.event_bus.publish_stream(event);
 
         deliver_message_to_agents(state, &team_channel.id, sender_id, &forwarded_message_id)
             .await?;
@@ -574,7 +578,7 @@ pub async fn handle_receive(
     }
 
     debug!(agent = %agent_id, timeout_ms, "receive_message: long-polling");
-    let mut rx = store.subscribe();
+    let mut rx = state.event_bus.subscribe();
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
 
     loop {

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -177,9 +177,7 @@ pub async fn handle_ui_server_info(State(state): State<AppState>) -> ApiResult<s
 pub async fn handle_system_info(State(state): State<AppState>) -> ApiResult<dto::SystemInfo> {
     let data_dir = state.data_dir.to_string_lossy().into_owned();
     let data_dir_path = state.data_dir.clone();
-    let db_size_bytes = std::fs::metadata(state.db_path())
-        .map(|m| m.len())
-        .ok();
+    let db_size_bytes = std::fs::metadata(state.db_path()).map(|m| m.len()).ok();
 
     let config = ChorusConfig::load(&data_dir_path)
         .ok()

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -24,6 +24,7 @@ pub use templates::*;
 pub use workspaces::*;
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use axum::extract::{Path, State};
@@ -39,6 +40,7 @@ use crate::agent::AgentLifecycle;
 use crate::agent::AgentRuntime;
 use crate::config::ChorusConfig;
 use crate::server::error::{app_err, internal_err, ApiResult, ErrorResponse};
+use crate::server::event_bus::EventBus;
 use crate::store::Store;
 use dto::ServerInfo;
 
@@ -46,6 +48,9 @@ use dto::ServerInfo;
 #[derive(Clone)]
 pub struct AppState {
     pub store: Arc<Store>,
+    pub event_bus: Arc<EventBus>,
+    pub data_dir: PathBuf,
+    pub agents_dir: PathBuf,
     pub active_workspace_id: Arc<RwLock<Option<String>>>,
     pub local_human_id: String,
     pub local_human_name: String,
@@ -71,6 +76,18 @@ impl AppState {
     pub async fn set_active_workspace_id(&self, workspace_id: Option<String>) {
         let mut guard = self.active_workspace_id.write().await;
         *guard = workspace_id;
+    }
+
+    pub fn attachments_dir(&self) -> PathBuf {
+        self.data_dir.join("data").join("attachments")
+    }
+
+    pub fn db_path(&self) -> PathBuf {
+        self.data_dir.join("data").join("chorus.db")
+    }
+
+    pub fn teams_dir(&self) -> PathBuf {
+        self.data_dir.join("data").join("teams")
     }
 }
 
@@ -158,20 +175,9 @@ pub async fn handle_ui_server_info(State(state): State<AppState>) -> ApiResult<s
 }
 
 pub async fn handle_system_info(State(state): State<AppState>) -> ApiResult<dto::SystemInfo> {
-    let data_dir = state
-        .store
-        .data_dir()
-        .parent()
-        .unwrap_or_else(|| state.store.data_dir())
-        .to_string_lossy()
-        .into_owned();
-    let data_dir_path = state
-        .store
-        .data_dir()
-        .parent()
-        .unwrap_or_else(|| state.store.data_dir())
-        .to_path_buf();
-    let db_size_bytes = std::fs::metadata(state.store.db_path())
+    let data_dir = state.data_dir.to_string_lossy().into_owned();
+    let data_dir_path = state.data_dir.clone();
+    let db_size_bytes = std::fs::metadata(state.db_path())
         .map(|m| m.len())
         .ok();
 
@@ -235,12 +241,7 @@ pub async fn handle_logs(
     axum::extract::Query(params): axum::extract::Query<LogsParams>,
 ) -> ApiResult<serde_json::Value> {
     let tail = params.tail.unwrap_or(200).min(2000);
-    let logs_dir = state
-        .store
-        .data_dir()
-        .parent()
-        .unwrap_or_else(|| state.store.data_dir())
-        .join("logs");
+    let logs_dir = state.data_dir.join("logs");
     let log_path = logs_dir.join("chorus.log");
     let lines = match tokio::fs::read_to_string(&log_path).await {
         Ok(content) => {

--- a/src/server/handlers/tasks.rs
+++ b/src/server/handlers/tasks.rs
@@ -100,10 +100,13 @@ pub async fn handle_create_tasks(
 ) -> ApiResult<serde_json::Value> {
     let channel_name = strip_channel_prefix(&req.channel);
     let titles: Vec<&str> = req.tasks.iter().map(|t| t.title.as_str()).collect();
-    let tasks = state
+    let (tasks, events) = state
         .store
         .create_tasks(channel_name, &agent_id, SenderType::Agent, &titles)
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "tasks": tasks })))
 }
 
@@ -113,7 +116,7 @@ pub async fn handle_claim_tasks(
     Json(req): Json<ClaimTasksRequest>,
 ) -> ApiResult<serde_json::Value> {
     let channel_name = strip_channel_prefix(&req.channel);
-    let results = state
+    let (results, events) = state
         .store
         .update_tasks_claim(
             channel_name,
@@ -122,6 +125,9 @@ pub async fn handle_claim_tasks(
             &req.task_numbers,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "results": results })))
 }
 
@@ -131,10 +137,13 @@ pub async fn handle_unclaim_task(
     Json(req): Json<UnclaimTaskRequest>,
 ) -> ApiResult<serde_json::Value> {
     let channel_name = strip_channel_prefix(&req.channel);
-    state
+    let events = state
         .store
         .update_task_unclaim(channel_name, &agent_id, SenderType::Agent, req.task_number)
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -146,7 +155,7 @@ pub async fn handle_update_task_status(
     let channel_name = strip_channel_prefix(&req.channel);
     let new_status = TaskStatus::from_status_str(&req.status)
         .ok_or_else(|| app_err!(StatusCode::BAD_REQUEST, "invalid status: {}", req.status))?;
-    state
+    let events = state
         .store
         .update_task_status(
             channel_name,
@@ -156,6 +165,9 @@ pub async fn handle_update_task_status(
             new_status,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -183,7 +195,7 @@ pub async fn handle_public_create_tasks(
 ) -> ApiResult<serde_json::Value> {
     let channel = load_channel_by_id(&state, &conversation_id)?;
     let titles: Vec<&str> = req.tasks.iter().map(|t| t.title.as_str()).collect();
-    let tasks = state
+    let (tasks, events) = state
         .store
         .create_tasks(
             &channel.name,
@@ -192,6 +204,9 @@ pub async fn handle_public_create_tasks(
             &titles,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "tasks": tasks })))
 }
 
@@ -201,7 +216,7 @@ pub async fn handle_public_claim_tasks(
     Json(req): Json<ClaimTasksRequest>,
 ) -> ApiResult<serde_json::Value> {
     let channel = load_channel_by_id(&state, &conversation_id)?;
-    let results = state
+    let (results, events) = state
         .store
         .update_tasks_claim(
             &channel.name,
@@ -210,6 +225,9 @@ pub async fn handle_public_claim_tasks(
             &req.task_numbers,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "results": results })))
 }
 
@@ -219,7 +237,7 @@ pub async fn handle_public_unclaim_task(
     Json(req): Json<UnclaimTaskRequest>,
 ) -> ApiResult<serde_json::Value> {
     let channel = load_channel_by_id(&state, &conversation_id)?;
-    state
+    let events = state
         .store
         .update_task_unclaim(
             &channel.name,
@@ -228,6 +246,9 @@ pub async fn handle_public_unclaim_task(
             req.task_number,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -256,7 +277,7 @@ pub async fn handle_public_update_task_status(
     let channel = load_channel_by_id(&state, &conversation_id)?;
     let new_status = TaskStatus::from_status_str(&req.status)
         .ok_or_else(|| app_err!(StatusCode::BAD_REQUEST, "invalid status: {}", req.status))?;
-    state
+    let events = state
         .store
         .update_task_status(
             &channel.name,
@@ -266,5 +287,8 @@ pub async fn handle_public_update_task_status(
             new_status,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -77,7 +77,7 @@ async fn sync_team_roles_and_agents(
     team: &Team,
     members: &[TeamMember],
 ) -> Result<(), (axum::http::StatusCode, Json<super::ErrorResponse>)> {
-    let agents_dir = state.store.agents_dir();
+    let agents_dir = state.agents_dir.clone();
     let agent_workspace = AgentWorkspace::new(&agents_dir);
 
     for member in members {
@@ -182,18 +182,21 @@ pub async fn handle_create_team(
     // username — the server stops trusting `whoami::username()` for request
     // identity entirely.
     if !creator_in_members {
-        state
+        let (_, events) = state
             .store
             .join_channel_by_id(&team_channel_id, &local_human_id, SenderType::Human)
             .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+        for event in events {
+            state.event_bus.publish_stream(event);
+        }
         state
             .store
             .create_team_member(&team_id, &local_human_id, "human", "operator")
             .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
     }
 
-    let teams_dir = state.store.teams_dir();
-    let agents_dir = state.store.agents_dir();
+    let teams_dir = state.teams_dir();
+    let agents_dir = state.agents_dir.clone();
     let team_workspace = TeamWorkspace::new(teams_dir);
     let agent_workspace = AgentWorkspace::new(&agents_dir);
 
@@ -218,10 +221,13 @@ pub async fn handle_create_team(
                 &member.role,
             )
             .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
-        state
+        let (_, events) = state
             .store
             .join_channel_by_id(&team_channel_id, &member.member_id, sender_type)
             .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+        for event in events {
+            state.event_bus.publish_stream(event);
+        }
 
         if sender_type == SenderType::Agent {
             agent_workspace
@@ -340,12 +346,12 @@ pub async fn handle_delete_team(
             .map_err(internal_err)?;
     }
 
-    let team_workspace = TeamWorkspace::new(state.store.teams_dir());
+    let team_workspace = TeamWorkspace::new(state.teams_dir());
     team_workspace
         .delete_team(&team.name)
         .map_err(internal_err)?;
 
-    let agents_dir = state.store.agents_dir();
+    let agents_dir = state.agents_dir.clone();
     let agent_workspace = AgentWorkspace::new(&agents_dir);
     for agent_name in &agent_members {
         // Agent may have been deleted already — skip cleanup for missing agents.
@@ -372,7 +378,7 @@ pub async fn handle_add_team_member(
         .store
         .create_team_member(&team.id, &req.member_id, &req.member_type, &req.role)
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
-    state
+    let (_, events) = state
         .store
         .join_channel_by_id(
             team.channel_id
@@ -382,13 +388,16 @@ pub async fn handle_add_team_member(
             sender_type,
         )
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    for event in events {
+        state.event_bus.publish_stream(event);
+    }
 
     if sender_type == SenderType::Agent {
-        let team_workspace = TeamWorkspace::new(state.store.teams_dir());
+        let team_workspace = TeamWorkspace::new(state.teams_dir());
         team_workspace
             .init_member(&team.name, &req.member_name)
             .map_err(internal_err)?;
-        let agents_dir = state.store.agents_dir();
+        let agents_dir = state.agents_dir.clone();
         let agent_workspace = AgentWorkspace::new(&agents_dir);
         agent_workspace
             .init_team_memory(&req.member_name, &team.name, &req.role)

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -178,8 +178,9 @@ pub async fn handle_launch_trio(
     if !agents.is_empty() {
         let names: Vec<&str> = agents.iter().map(|a| a.display_name.as_str()).collect();
         let kickoff = format!("Team assembled: {}. Let's get to work.", names.join(", "));
-        if let Err(e) = state.store.create_system_message(&channel_id, &kickoff) {
-            warn!(error = %e, "failed to post trio kickoff message");
+        match state.store.create_system_message(&channel_id, &kickoff) {
+            Ok((_, event)) => state.event_bus.publish_stream(event),
+            Err(e) => warn!(error = %e, "failed to post trio kickoff message"),
         }
     }
 

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -101,9 +101,14 @@ pub async fn handle_launch_trio(
     // Join the human user to the channel.
     if let Ok(humans) = state.store.get_humans() {
         if let Some(human) = humans.first() {
-            let _ = state
+            if let Ok((_, events)) = state
                 .store
-                .join_channel(&channel_name, &human.id, SenderType::Human);
+                .join_channel(&channel_name, &human.id, SenderType::Human)
+            {
+                for event in events {
+                    state.event_bus.publish_stream(event);
+                }
+            }
         }
     }
 
@@ -163,9 +168,14 @@ pub async fn handle_launch_trio(
         }
 
         // Also join the trio channel (auto-join channels handled above).
-        let _ = state
+        if let Ok((_, events)) = state
             .store
-            .join_channel(&channel_name, &result.id, SenderType::Agent);
+            .join_channel(&channel_name, &result.id, SenderType::Agent)
+        {
+            for event in events {
+                state.event_bus.publish_stream(event);
+            }
+        }
 
         agents.push(LaunchTrioAgent {
             id: result.id,

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -101,9 +101,10 @@ pub async fn handle_launch_trio(
     // Join the human user to the channel.
     if let Ok(humans) = state.store.get_humans() {
         if let Some(human) = humans.first() {
-            if let Ok((_, events)) = state
-                .store
-                .join_channel(&channel_name, &human.id, SenderType::Human)
+            if let Ok((_, events)) =
+                state
+                    .store
+                    .join_channel(&channel_name, &human.id, SenderType::Human)
             {
                 for event in events {
                     state.event_bus.publish_stream(event);
@@ -168,9 +169,10 @@ pub async fn handle_launch_trio(
         }
 
         // Also join the trio channel (auto-join channels handled above).
-        if let Ok((_, events)) = state
-            .store
-            .join_channel(&channel_name, &result.id, SenderType::Agent)
+        if let Ok((_, events)) =
+            state
+                .store
+                .join_channel(&channel_name, &result.id, SenderType::Agent)
         {
             for event in events {
                 state.event_bus.publish_stream(event);

--- a/src/server/handlers/workspaces.rs
+++ b/src/server/handlers/workspaces.rs
@@ -126,10 +126,11 @@ pub async fn handle_create_workspace(
             "workspace name is required"
         ));
     }
-    let workspace = state
+    let (workspace, event) = state
         .store
         .create_local_workspace_without_activation(name, &state.local_human_id)
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
+    state.event_bus.publish_stream(event);
     let active_workspace_id = state.active_workspace_id().await;
     Ok(Json(workspace_response(
         &state,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -76,7 +76,8 @@ pub fn build_router_with_services(
         .ok()
         .flatten()
         .map(|workspace| workspace.id);
-    let (local_human_id, local_human_name) = resolve_local_human_identity(store.as_ref(), &data_dir);
+    let (local_human_id, local_human_name) =
+        resolve_local_human_identity(store.as_ref(), &data_dir);
 
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub use crate::utils::error;
+pub mod event_bus;
 mod handlers;
 pub mod transport;
 
@@ -43,6 +44,7 @@ use crate::agent::runtime_status::SharedRuntimeStatusProvider;
 use crate::agent::templates::AgentTemplate;
 use crate::agent::AgentLifecycle;
 use crate::config::ChorusConfig;
+use crate::server::event_bus::EventBus;
 use crate::store::Store;
 
 pub use handlers::dto;
@@ -54,6 +56,9 @@ pub use handlers::{AgentDetailResponse, AppState, HistoryResponse};
 
 pub fn build_router_with_services(
     store: Arc<Store>,
+    event_bus: Arc<EventBus>,
+    data_dir: std::path::PathBuf,
+    agents_dir: std::path::PathBuf,
     lifecycle: Arc<dyn AgentLifecycle>,
     runtime_status_provider: SharedRuntimeStatusProvider,
     templates: Vec<AgentTemplate>,
@@ -71,7 +76,7 @@ pub fn build_router_with_services(
         .ok()
         .flatten()
         .map(|workspace| workspace.id);
-    let (local_human_id, local_human_name) = resolve_local_human_identity(store.as_ref());
+    let (local_human_id, local_human_name) = resolve_local_human_identity(store.as_ref(), &data_dir);
 
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS
@@ -85,6 +90,9 @@ pub fn build_router_with_services(
 
     let state = AppState {
         store,
+        event_bus,
+        data_dir,
+        agents_dir,
         active_workspace_id: Arc::new(RwLock::new(active_workspace_id)),
         local_human_id,
         local_human_name,
@@ -246,11 +254,8 @@ pub fn build_router_with_services(
         .with_state(state)
 }
 
-fn resolve_local_human_identity(store: &Store) -> (String, String) {
-    let config_root = store
-        .data_dir()
-        .parent()
-        .unwrap_or_else(|| store.data_dir());
+fn resolve_local_human_identity(store: &Store, data_dir: &std::path::Path) -> (String, String) {
+    let config_root = data_dir;
     let configured = ChorusConfig::load(config_root)
         .ok()
         .flatten()

--- a/src/server/transport/realtime.rs
+++ b/src/server/transport/realtime.rs
@@ -40,10 +40,17 @@ pub async fn handle_events_ws(
     }
 
     let event_bus = state.event_bus.clone();
-    Ok(ws.on_upgrade(move |socket| realtime_session(socket, event_bus, state.store.clone(), params.viewer)))
+    Ok(ws.on_upgrade(move |socket| {
+        realtime_session(socket, event_bus, state.store.clone(), params.viewer)
+    }))
 }
 
-async fn realtime_session(mut socket: WebSocket, event_bus: Arc<EventBus>, store: Arc<crate::store::Store>, viewer: String) {
+async fn realtime_session(
+    mut socket: WebSocket,
+    event_bus: Arc<EventBus>,
+    store: Arc<crate::store::Store>,
+    viewer: String,
+) {
     let mut stream_rx = event_bus.subscribe();
     let mut trace_rx = event_bus.subscribe_traces();
 

--- a/src/server/transport/realtime.rs
+++ b/src/server/transport/realtime.rs
@@ -12,6 +12,7 @@ use tracing::{debug, warn};
 
 use crate::agent::trace::TraceEvent;
 use crate::server::error::{app_err, ErrorResponse};
+use crate::server::event_bus::EventBus;
 use crate::server::handlers::AppState;
 use crate::store::{Store, StreamEvent};
 
@@ -38,12 +39,13 @@ pub async fn handle_events_ws(
         ));
     }
 
-    Ok(ws.on_upgrade(move |socket| realtime_session(socket, state.store.clone(), params.viewer)))
+    let event_bus = state.event_bus.clone();
+    Ok(ws.on_upgrade(move |socket| realtime_session(socket, event_bus, state.store.clone(), params.viewer)))
 }
 
-async fn realtime_session(mut socket: WebSocket, store: Arc<Store>, viewer: String) {
-    let mut stream_rx = store.subscribe();
-    let mut trace_rx = store.subscribe_traces();
+async fn realtime_session(mut socket: WebSocket, event_bus: Arc<EventBus>, store: Arc<crate::store::Store>, viewer: String) {
+    let mut stream_rx = event_bus.subscribe();
+    let mut trace_rx = event_bus.subscribe_traces();
 
     loop {
         tokio::select! {

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -73,7 +73,8 @@ impl Store {
     }
 
     pub fn create_agent_record_with_events(
-        &self, record: &AgentRecordUpsert<'_>,
+        &self,
+        record: &AgentRecordUpsert<'_>,
     ) -> Result<(String, Vec<crate::store::stream::StreamEvent>)> {
         let (workspace_id, id) = {
             let conn = self.conn.lock().unwrap();
@@ -85,7 +86,9 @@ impl Store {
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(&workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+            if let Ok((_, evs)) =
+                self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent)
+            {
                 events.extend(evs);
             }
         }
@@ -97,7 +100,8 @@ impl Store {
         workspace_id: &str,
         record: &AgentRecordUpsert<'_>,
     ) -> Result<String> {
-        let (id, _events) = self.create_agent_record_in_workspace_with_events(workspace_id, record)?;
+        let (id, _events) =
+            self.create_agent_record_in_workspace_with_events(workspace_id, record)?;
         Ok(id)
     }
 
@@ -114,7 +118,9 @@ impl Store {
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+            if let Ok((_, evs)) =
+                self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent)
+            {
                 events.extend(evs);
             }
         }

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -68,18 +68,28 @@ pub struct AgentRecordUpsert<'a> {
 
 impl Store {
     pub fn create_agent_record(&self, record: &AgentRecordUpsert<'_>) -> Result<String> {
+        let (id, _events) = self.create_agent_record_with_events(record)?;
+        Ok(id)
+    }
+
+    pub fn create_agent_record_with_events(
+        &self, record: &AgentRecordUpsert<'_>,
+    ) -> Result<(String, Vec<crate::store::stream::StreamEvent>)> {
         let (workspace_id, id) = {
             let conn = self.conn.lock().unwrap();
             let workspace_id = Self::workspace_id_for_write_inner(&conn)?;
             let id = Self::create_agent_record_inner(&conn, &workspace_id, record)?;
             (workspace_id, id)
         };
+        let mut events = Vec::new();
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(&workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            let _ = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent);
+            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+                events.extend(evs);
+            }
         }
-        Ok(id)
+        Ok((id, events))
     }
 
     pub fn create_agent_record_in_workspace(
@@ -87,16 +97,28 @@ impl Store {
         workspace_id: &str,
         record: &AgentRecordUpsert<'_>,
     ) -> Result<String> {
+        let (id, _events) = self.create_agent_record_in_workspace_with_events(workspace_id, record)?;
+        Ok(id)
+    }
+
+    pub fn create_agent_record_in_workspace_with_events(
+        &self,
+        workspace_id: &str,
+        record: &AgentRecordUpsert<'_>,
+    ) -> Result<(String, Vec<crate::store::stream::StreamEvent>)> {
         let id = {
             let conn = self.conn.lock().unwrap();
             Self::create_agent_record_inner(&conn, workspace_id, record)?
         };
+        let mut events = Vec::new();
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            let _ = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent);
+            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+                events.extend(evs);
+            }
         }
-        Ok(id)
+        Ok((id, events))
     }
 
     fn create_agent_record_inner(

--- a/src/store/channels.rs
+++ b/src/store/channels.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::messages::SenderType;
+use super::stream::StreamEvent;
 use super::Store;
 
 /// Normalize a channel name for storage/display: trim, strip a single leading
@@ -551,12 +552,15 @@ impl Store {
 
     /// Join a channel and post a server-authored system message announcing the
     /// join. Idempotent: returns `Ok(false)` when the member is already present.
+    ///
+    /// On success returns `(joined, events)` where `events` should be published
+    /// via [`EventBus`](crate::server::event_bus::EventBus) by the caller.
     pub fn join_channel_by_id(
         &self,
         channel_id: &str,
         member_id: &str,
         member_type: SenderType,
-    ) -> Result<bool> {
+    ) -> Result<(bool, Vec<StreamEvent>)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let mt = member_type.as_str();
@@ -565,6 +569,7 @@ impl Store {
             params![channel_id, member_id, mt],
         )?;
         let joined = rows > 0;
+        let mut events = Vec::new();
         if joined {
             let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
                 .ok_or_else(|| anyhow!("channel not found: {}", channel_id))?;
@@ -593,20 +598,28 @@ impl Store {
                 Self::create_system_message_tx_with_payload(&tx, &channel, &content, &payload)?;
             tx.commit()?;
             drop(conn);
-            let event = super::StreamEvent::member_joined(
+            events.push(super::StreamEvent::member_joined(
                 channel_id.to_string(),
                 member_id.to_string(),
                 mt.to_string(),
+            ));
+            let event_payload = inserted.to_event_payload_with_payload(
+                channel.id.as_str(),
+                channel.channel_type.as_api_str(),
+                "system",
+                "system",
+                &content,
+                Some(payload),
             );
-            let _ = self.stream_tx.send(event);
-            self.emit_system_stream_events_with_payloads(
-                &channel,
-                vec![(inserted, content, Some(payload))],
-            )?;
+            events.push(super::StreamEvent::new(
+                channel.id.clone(),
+                inserted.seq,
+                serde_json::to_value(event_payload)?,
+            ));
         } else {
             tx.commit()?;
         }
-        Ok(joined)
+        Ok((joined, events))
     }
 
     /// Convenience wrapper that resolves the channel by name before joining.
@@ -615,7 +628,7 @@ impl Store {
         channel_name: &str,
         member_id: &str,
         member_type: SenderType,
-    ) -> Result<bool> {
+    ) -> Result<(bool, Vec<StreamEvent>)> {
         let conn = self.conn.lock().unwrap();
         let channel = Self::get_channel_by_name_inner(&conn, channel_name)?
             .ok_or_else(|| anyhow!("channel not found: {}", channel_name))?;

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -186,7 +186,11 @@ impl Store {
     }
 
     /// Post a server-authored message into a channel.
-    pub fn create_system_message(&self, channel_id: &str, content: &str) -> Result<(String, StreamEvent)> {
+    pub fn create_system_message(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<(String, StreamEvent)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
@@ -211,7 +215,10 @@ impl Store {
         Ok((message_id, stream_event))
     }
 
-    pub fn create_message(&self, message: CreateMessage<'_>) -> Result<(String, Option<StreamEvent>)> {
+    pub fn create_message(
+        &self,
+        message: CreateMessage<'_>,
+    ) -> Result<(String, Option<StreamEvent>)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_name_inner(&tx, message.channel_name)?
@@ -249,7 +256,11 @@ impl Store {
             inserted.seq,
             serde_json::to_value(payload)?,
         );
-        let event = if message.suppress_event { None } else { Some(stream_event) };
+        let event = if message.suppress_event {
+            None
+        } else {
+            Some(stream_event)
+        };
         Ok((inserted.id, event))
     }
 

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -99,7 +99,7 @@ impl Store {
         content: &str,
         attachment_ids: &[String],
         forwarded_from: Option<ForwardedFrom>,
-    ) -> Result<String> {
+    ) -> Result<(String, StreamEvent)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
@@ -129,8 +129,7 @@ impl Store {
             inserted.seq,
             serde_json::to_value(payload)?,
         );
-        let _ = self.stream_tx.send(stream_event);
-        Ok(inserted.id)
+        Ok((inserted.id, stream_event))
     }
 
     /// Insert a `sender_type = 'system'` message inside an existing transaction.
@@ -186,52 +185,8 @@ impl Store {
         )
     }
 
-    /// Emit `message.created` stream events for system messages that were
-    /// inserted via `create_system_message_tx` and committed by the caller.
-    /// Each `(inserted, content)` tuple produced inside the transaction maps
-    /// to one WebSocket event. Best-effort: send errors are dropped because
-    /// the DB rows are the source of truth.
-    pub(crate) fn emit_system_stream_events(
-        &self,
-        channel: &Channel,
-        pending: Vec<(InsertedMessage, String)>,
-    ) -> Result<()> {
-        let with_payloads = pending
-            .into_iter()
-            .map(|(inserted, content)| (inserted, content, None))
-            .collect();
-        self.emit_system_stream_events_with_payloads(channel, with_payloads)
-    }
-
-    /// Same as [`emit_system_stream_events`] but each tuple may carry a
-    /// structured JSON payload that ships in the `message.created` event
-    /// alongside the human-readable `content` fallback.
-    pub(crate) fn emit_system_stream_events_with_payloads(
-        &self,
-        channel: &Channel,
-        pending: Vec<(InsertedMessage, String, Option<Value>)>,
-    ) -> Result<()> {
-        for (inserted, content, payload) in pending {
-            let event_payload = inserted.to_event_payload_with_payload(
-                channel.id.as_str(),
-                channel.channel_type.as_api_str(),
-                "system",
-                SenderType::System.as_str(),
-                &content,
-                payload,
-            );
-            let stream_event = StreamEvent::new(
-                channel.id.clone(),
-                inserted.seq,
-                serde_json::to_value(event_payload)?,
-            );
-            let _ = self.stream_tx.send(stream_event);
-        }
-        Ok(())
-    }
-
     /// Post a server-authored message into a channel.
-    pub fn create_system_message(&self, channel_id: &str, content: &str) -> Result<String> {
+    pub fn create_system_message(&self, channel_id: &str, content: &str) -> Result<(String, StreamEvent)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
@@ -241,11 +196,22 @@ impl Store {
         tx.commit()?;
         drop(conn); // release the guard before fanout to avoid holding the mutex
 
-        self.emit_system_stream_events(&channel, vec![(inserted, content.to_string())])?;
-        Ok(message_id)
+        let payload = inserted.to_event_payload(
+            channel.id.as_str(),
+            channel.channel_type.as_api_str(),
+            "system",
+            SenderType::System.as_str(),
+            content,
+        );
+        let stream_event = StreamEvent::new(
+            channel.id.clone(),
+            inserted.seq,
+            serde_json::to_value(payload)?,
+        );
+        Ok((message_id, stream_event))
     }
 
-    pub fn create_message(&self, message: CreateMessage<'_>) -> Result<String> {
+    pub fn create_message(&self, message: CreateMessage<'_>) -> Result<(String, Option<StreamEvent>)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_name_inner(&tx, message.channel_name)?
@@ -283,10 +249,8 @@ impl Store {
             inserted.seq,
             serde_json::to_value(payload)?,
         );
-        if !message.suppress_event {
-            let _ = self.stream_tx.send(stream_event);
-        }
-        Ok(inserted.id)
+        let event = if message.suppress_event { None } else { Some(stream_event) };
+        Ok((inserted.id, event))
     }
 
     pub(crate) fn sender_name_for_id_tx(
@@ -312,6 +276,28 @@ impl Store {
             SenderType::System => Ok(sender_id.to_string()),
         }
     }
+}
+
+/// Build a `StreamEvent` from a system message insert result.
+pub(crate) fn system_message_stream_event(
+    channel: &Channel,
+    inserted: &InsertedMessage,
+    content: &str,
+    payload: Option<Value>,
+) -> StreamEvent {
+    let event_payload = inserted.to_event_payload_with_payload(
+        channel.id.as_str(),
+        channel.channel_type.as_api_str(),
+        "system",
+        "system",
+        content,
+        payload,
+    );
+    StreamEvent::new(
+        channel.id.clone(),
+        inserted.seq,
+        serde_json::to_value(event_payload).unwrap_or_default(),
+    )
 }
 
 #[cfg(test)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -12,14 +12,12 @@ pub mod teams;
 pub mod trace_writer;
 pub mod workspaces;
 
-use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use anyhow::Result;
 use rusqlite::{params, Connection, OptionalExtension};
-use tokio::sync::broadcast;
 
-use crate::utils::{derive_data_dir, parse_datetime};
+use crate::utils::parse_datetime;
 
 pub use agents::AgentRecordUpsert;
 pub use agents::{Agent, AgentEnvVar};
@@ -38,23 +36,10 @@ pub use tasks::{ClaimResult, TaskInfo, TaskStatus};
 pub use teams::{Team, TeamMember, TeamMembership};
 pub use workspaces::{Workspace, WorkspaceCounts, WorkspaceMode};
 
-use crate::agent::trace::TraceEvent;
-
-/// SQLite-backed persistence and pub/sub for new messages.
+/// SQLite-backed persistence layer.
 pub struct Store {
     /// Serialized access to the rusqlite connection.
     conn: Mutex<Connection>,
-    /// Broadcast channel for stream events (message.created only).
-    stream_tx: broadcast::Sender<StreamEvent>,
-    /// Broadcast channel for agent trace events (tool calls, thinking, etc.).
-    trace_tx: broadcast::Sender<TraceEvent>,
-    /// Root data directory (db parent, attachments, teams).
-    data_dir: PathBuf,
-    /// Optional override for the per-agent workspace root. When set, takes
-    /// precedence over `data_dir.join("agents")` so the server can keep
-    /// agent workspaces at the chorus-root level while chorus.db sits in
-    /// `<root>/data/`.
-    agents_dir_override: Option<PathBuf>,
 }
 
 impl Store {
@@ -66,45 +51,9 @@ impl Store {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
         Self::validate_supported_identity_schema(&conn)?;
         Self::init_schema(&conn)?;
-        let (stream_tx, _) = broadcast::channel(256);
-        let (trace_tx, _) = broadcast::channel(1024);
         Ok(Self {
             conn: Mutex::new(conn),
-            stream_tx,
-            trace_tx,
-            data_dir: derive_data_dir(path),
-            agents_dir_override: None,
         })
-    }
-
-    /// Builder: override the per-agent workspace directory. Intended for the
-    /// CLI `serve`/`run` path, which places agent workspaces at the chorus
-    /// root instead of inside `data/`.
-    pub fn with_agents_dir(mut self, dir: PathBuf) -> Self {
-        self.agents_dir_override = Some(dir);
-        self
-    }
-
-    /// Return the configured server data directory that owns the SQLite file.
-    pub fn data_dir(&self) -> &Path {
-        &self.data_dir
-    }
-
-    /// Return the directory used to persist uploaded attachments.
-    pub fn attachments_dir(&self) -> PathBuf {
-        self.data_dir.join("attachments")
-    }
-
-    /// Return the directory that contains per-agent workspaces.
-    pub fn agents_dir(&self) -> PathBuf {
-        self.agents_dir_override
-            .clone()
-            .unwrap_or_else(|| self.data_dir.join("agents"))
-    }
-
-    /// Return the directory used to persist per-team workspaces.
-    pub fn teams_dir(&self) -> PathBuf {
-        self.data_dir.join("teams")
     }
 
     /// Lock the database connection, handling mutex poison gracefully.
@@ -210,23 +159,6 @@ impl Store {
             .filter_map(Result::ok)
             .any(|name| name == column);
         Ok(exists)
-    }
-
-    pub fn subscribe(&self) -> broadcast::Receiver<StreamEvent> {
-        self.stream_tx.subscribe()
-    }
-
-    pub fn subscribe_traces(&self) -> broadcast::Receiver<TraceEvent> {
-        self.trace_tx.subscribe()
-    }
-
-    pub fn trace_sender(&self) -> broadcast::Sender<TraceEvent> {
-        self.trace_tx.clone()
-    }
-
-    /// Return the path to the SQLite database file (for trace_writer's separate connection).
-    pub fn db_path(&self) -> PathBuf {
-        self.data_dir.join("chorus.db")
     }
 
     /// Look up the channel_id for a given run_id (from the first message in that run).

--- a/src/store/sessions.rs
+++ b/src/store/sessions.rs
@@ -80,7 +80,7 @@ mod tests {
         let db_path = dir.path().join("db.sqlite");
         let store = Store::open(db_path.to_str().expect("utf-8 path")).unwrap();
         let alice = store.ensure_human_with_id("alice", "alice").unwrap();
-        let workspace = store.create_local_workspace("Test", &alice.id).unwrap();
+        let (workspace, _event) = store.create_local_workspace("Test", &alice.id).unwrap();
         store
             .conn
             .lock()

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -555,12 +555,8 @@ impl Store {
             Self::create_system_message_tx_with_payload(&tx, &channel, &content, &payload_json)?;
         tx.commit()?;
         drop(conn);
-        let event = posting::system_message_stream_event(
-            &channel,
-            &inserted,
-            &content,
-            Some(payload_json),
-        );
+        let event =
+            posting::system_message_stream_event(&channel, &inserted, &content, Some(payload_json));
         Ok(vec![event])
     }
 
@@ -666,12 +662,8 @@ impl Store {
 
         tx.commit()?;
         drop(conn);
-        let event = posting::system_message_stream_event(
-            &channel,
-            &inserted,
-            &content,
-            Some(payload_json),
-        );
+        let event =
+            posting::system_message_stream_event(&channel, &inserted, &content, Some(payload_json));
         Ok(vec![event])
     }
 }
@@ -967,11 +959,13 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");
@@ -1031,10 +1025,12 @@ mod sub_channel_tests {
         // Advance task 1 through InReview → Done. Task 2 stays in progress.
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let after: Vec<String> = store
             .get_inbox_conversation_notifications(&bob_id)
@@ -1077,10 +1073,12 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 
 use self::events::{TaskEventAction, TaskEventPayload};
 use super::channels::ChannelType;
-use super::messages::SenderType;
+use super::messages::{posting, SenderType};
+use super::stream::StreamEvent;
 use super::Store;
 
 // ── Types owned by this module ──
@@ -185,7 +186,7 @@ impl Store {
         creator_id: &str,
         creator_type: SenderType,
         titles: &[&str],
-    ) -> Result<Vec<TaskInfo>> {
+    ) -> Result<(Vec<TaskInfo>, Vec<StreamEvent>)> {
         // `transaction()` needs `&mut Connection`, so bind the guard as `mut`.
         let mut conn = self.conn.lock().unwrap();
         let channel = Self::get_channel_by_name_inner(&conn, channel_name)?
@@ -288,8 +289,13 @@ impl Store {
         tx.commit()?;
         drop(conn); // release the mutex guard before the stream fanout
 
-        self.emit_system_stream_events_with_payloads(&channel, pending_events)?;
-        Ok(result)
+        let events: Vec<StreamEvent> = pending_events
+            .into_iter()
+            .map(|(inserted, content, payload)| {
+                posting::system_message_stream_event(&channel, &inserted, &content, payload)
+            })
+            .collect();
+        Ok((result, events))
     }
 
     /// Fetch a single task by `(channel_name, task_number)`. Returns `Ok(None)`
@@ -347,7 +353,7 @@ impl Store {
         claimer_id: &str,
         claimer_type: SenderType,
         task_numbers: &[i64],
-    ) -> Result<Vec<ClaimResult>> {
+    ) -> Result<(Vec<ClaimResult>, Vec<StreamEvent>)> {
         // `transaction()` needs `&mut Connection`. Every successful claim in
         // this batch must atomically UPDATE the task row AND add the claimer
         // to the task's sub-channel — otherwise a crash between the two
@@ -452,8 +458,13 @@ impl Store {
         }
         tx.commit()?;
         drop(conn);
-        self.emit_system_stream_events_with_payloads(&channel, pending_events)?;
-        Ok(results)
+        let events: Vec<StreamEvent> = pending_events
+            .into_iter()
+            .map(|(inserted, content, payload)| {
+                posting::system_message_stream_event(&channel, &inserted, &content, payload)
+            })
+            .collect();
+        Ok((results, events))
     }
 
     pub fn update_task_unclaim(
@@ -462,7 +473,7 @@ impl Store {
         claimer_id: &str,
         claimer_type: SenderType,
         task_number: i64,
-    ) -> Result<()> {
+    ) -> Result<Vec<StreamEvent>> {
         // Atomic: UPDATE the task row and DELETE the claimer's sub-channel
         // membership in one transaction. The creator is never touched — only
         // the caller's own membership row is removed.
@@ -544,11 +555,13 @@ impl Store {
             Self::create_system_message_tx_with_payload(&tx, &channel, &content, &payload_json)?;
         tx.commit()?;
         drop(conn);
-        self.emit_system_stream_events_with_payloads(
+        let event = posting::system_message_stream_event(
             &channel,
-            vec![(inserted, content, Some(payload_json))],
-        )?;
-        Ok(())
+            &inserted,
+            &content,
+            Some(payload_json),
+        );
+        Ok(vec![event])
     }
 
     pub fn update_task_status(
@@ -558,7 +571,7 @@ impl Store {
         requester_id: &str,
         requester_type: SenderType,
         new_status: TaskStatus,
-    ) -> Result<()> {
+    ) -> Result<Vec<StreamEvent>> {
         // `transaction()` needs `&mut Connection`. The status UPDATE and the
         // sub-channel archive (when `new_status == Done`) must commit together
         // so an observer never sees a task marked Done whose sub-channel is
@@ -653,11 +666,13 @@ impl Store {
 
         tx.commit()?;
         drop(conn);
-        self.emit_system_stream_events_with_payloads(
+        let event = posting::system_message_stream_event(
             &channel,
-            vec![(inserted, content, Some(payload_json))],
-        )?;
-        Ok(())
+            &inserted,
+            &content,
+            Some(payload_json),
+        );
+        Ok(vec![event])
     }
 }
 
@@ -713,7 +728,7 @@ mod sub_channel_tests {
             .unwrap();
         let alice = seed_human(&store, "alice");
 
-        let result = store
+        let (result, _events) = store
             .create_tasks("eng", &alice.id, SenderType::Human, &["Ship the feature"])
             .unwrap();
         assert_eq!(result.len(), 1);
@@ -848,7 +863,7 @@ mod sub_channel_tests {
             .create_tasks("eng", &alice.id, SenderType::Human, &["Ship it"])
             .unwrap();
 
-        let results = store
+        let (results, _events) = store
             .update_tasks_claim("eng", &bob_id, SenderType::Agent, &[1])
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -915,7 +930,7 @@ mod sub_channel_tests {
         store
             .create_tasks("eng", &alice.id, SenderType::Human, &["Ship it"])
             .unwrap();
-        let claim = store
+        let (claim, _events) = store
             .update_tasks_claim("eng", &bob_id, SenderType::Agent, &[1])
             .unwrap();
         assert!(claim[0].success);
@@ -952,11 +967,11 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .unwrap();
+            .map(|_| ()).unwrap();
 
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .unwrap();
+            .map(|_| ()).unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");
@@ -1016,10 +1031,10 @@ mod sub_channel_tests {
         // Advance task 1 through InReview → Done. Task 2 stays in progress.
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .unwrap();
+            .map(|_| ()).unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .unwrap();
+            .map(|_| ()).unwrap();
 
         let after: Vec<String> = store
             .get_inbox_conversation_notifications(&bob_id)
@@ -1062,10 +1077,10 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .unwrap();
+            .map(|_| ()).unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .unwrap();
+            .map(|_| ()).unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");

--- a/src/store/workspaces.rs
+++ b/src/store/workspaces.rs
@@ -7,6 +7,7 @@ use std::io;
 use uuid::Uuid;
 
 use super::{parse_datetime, Store};
+use crate::store::stream::StreamEvent;
 use crate::utils::slug::slugify_base;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -58,7 +59,7 @@ pub struct WorkspaceCounts {
 }
 
 impl Store {
-    pub fn create_local_workspace(&self, name: &str, owner_human_id: &str) -> Result<Workspace> {
+    pub fn create_local_workspace(&self, name: &str, owner_human_id: &str) -> Result<(Workspace, StreamEvent)> {
         self.create_local_workspace_inner(name, owner_human_id, true)
     }
 
@@ -66,7 +67,7 @@ impl Store {
         &self,
         name: &str,
         owner_human_id: &str,
-    ) -> Result<Workspace> {
+    ) -> Result<(Workspace, StreamEvent)> {
         self.create_local_workspace_inner(name, owner_human_id, false)
     }
 
@@ -75,7 +76,7 @@ impl Store {
         name: &str,
         owner_human_id: &str,
         activate: bool,
-    ) -> Result<Workspace> {
+    ) -> Result<(Workspace, StreamEvent)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let id = Uuid::new_v4().to_string();
@@ -132,8 +133,7 @@ impl Store {
             owner_human_id.to_string(),
             "human".to_string(),
         );
-        let _ = self.stream_tx.send(event);
-        Ok(workspace)
+        Ok((workspace, event))
     }
 
     pub fn get_active_workspace(&self) -> Result<Option<Workspace>> {

--- a/src/store/workspaces.rs
+++ b/src/store/workspaces.rs
@@ -59,7 +59,11 @@ pub struct WorkspaceCounts {
 }
 
 impl Store {
-    pub fn create_local_workspace(&self, name: &str, owner_human_id: &str) -> Result<(Workspace, StreamEvent)> {
+    pub fn create_local_workspace(
+        &self,
+        name: &str,
+        owner_human_id: &str,
+    ) -> Result<(Workspace, StreamEvent)> {
         self.create_local_workspace_inner(name, owner_human_id, true)
     }
 

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -1,10 +1,8 @@
 mod harness;
 use std::sync::Arc;
 
-use chorus::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
-use chorus::server::build_router_with_services;
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::ReceivedMessage;
 use chorus::store::Store;
@@ -148,14 +146,7 @@ async fn start_chorus_server() -> (String, Arc<Store>) {
         .unwrap();
     join_channel_silent(&store, "general", "testuser", "human");
 
-    let router = build_router_with_services(
-        store.clone(),
-        Arc::new(NoopLifecycle),
-        Arc::new(SystemRuntimeStatusProvider::new(
-            chorus::agent::manager::build_driver_registry(),
-        )) as SharedRuntimeStatusProvider,
-        vec![],
-    );
+    let router = harness::build_router_with_lifecycle(store.clone(), Arc::new(NoopLifecycle));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::Store;
-use harness::{build_router, join_channel_silent};
+use harness::join_channel_silent;
 
-async fn start_test_server() -> (String, Arc<Store>) {
+async fn start_test_server() -> (String, Arc<Store>, Arc<chorus::server::event_bus::EventBus>) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     // Pre-create `#all` so the migration in `ensure_all_channel_inner`
     // (which renames `#general` -> `#all` when no `#all` exists)
@@ -25,13 +25,13 @@ async fn start_test_server() -> (String, Arc<Store>) {
         .create_channel("general", Some("General"), ChannelType::Channel, None)
         .unwrap();
     join_channel_silent(&store, "general", "testuser", "human");
-    let router = build_router(store.clone());
+    let (router, event_bus) = harness::build_router_with_event_bus(store.clone());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("http://{addr}");
     tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    (url, store)
+    (url, store, event_bus)
 }
 
 /// Insert an agent row with a chosen primary key. Used by e2e
@@ -62,7 +62,7 @@ fn seed_agent_with_id(
 /// Test 1: Human sends message, agent receives via HTTP
 #[tokio::test]
 async fn test_human_to_agent_message_flow() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -98,7 +98,7 @@ async fn test_human_to_agent_message_flow() {
 /// Test 2: Agent replies, appears in history
 #[tokio::test]
 async fn test_agent_reply_in_history() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -135,7 +135,7 @@ async fn test_agent_reply_in_history() {
 /// Test 3: Blocking receive wakes on message
 #[tokio::test]
 async fn test_blocking_receive_wakes_on_message() {
-    let (url, store) = start_test_server().await;
+    let (url, store, event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -159,7 +159,7 @@ async fn test_blocking_receive_wakes_on_message() {
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    store
+    let (_, event) = store
         .create_message(CreateMessage {
             channel_name: "general",
             sender_id: "testuser",
@@ -170,6 +170,9 @@ async fn test_blocking_receive_wakes_on_message() {
             run_id: None,
         })
         .unwrap();
+    if let Some(ev) = event {
+        event_bus.publish_stream(ev);
+    }
 
     let resp = tokio::time::timeout(std::time::Duration::from_secs(3), recv_handle)
         .await
@@ -184,7 +187,7 @@ async fn test_blocking_receive_wakes_on_message() {
 /// Test 4: Task board workflow (create, claim, update status, list)
 #[tokio::test]
 async fn test_task_board_e2e() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -252,14 +255,15 @@ async fn test_task_board_e2e() {
 /// Test 5: Workspace listing and file preview flow over HTTP
 #[tokio::test]
 async fn test_workspace_e2e_lists_and_reads_markdown_file() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
     join_channel_silent(&store, "general", "bot1", "agent");
 
-    let workspace_dir = store.agents_dir().join("bot1");
+    let agents_dir = std::env::temp_dir().join("chorus_test").join("agents");
+    let workspace_dir = agents_dir.join("bot1");
     let notes_dir = workspace_dir.join("notes");
     std::fs::create_dir_all(&notes_dir).unwrap();
     std::fs::write(
@@ -325,7 +329,7 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
 /// Test 6: Multi-agent communication
 #[tokio::test]
 async fn test_multi_agent_channel_communication() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "claude_bot", "Claude", "claude", "sonnet");
@@ -377,7 +381,7 @@ async fn test_multi_agent_channel_communication() {
 /// so the UI can deep-link from each row into its child channel.
 #[tokio::test]
 async fn list_tasks_returns_sub_channel_info() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     // Create tasks directly in the store so the creator name is stable across
@@ -409,7 +413,7 @@ async fn list_tasks_returns_sub_channel_info() {
 /// the full `TaskInfo` payload, including its sub-channel fields.
 #[tokio::test]
 async fn get_task_detail_returns_task_and_sub_channel() {
-    let (url, store) = start_test_server().await;
+    let (url, store, _event_bus) = start_test_server().await;
     let client = reqwest::Client::new();
 
     store.ensure_human_with_id("alice", "alice").unwrap();
@@ -447,7 +451,7 @@ async fn get_task_detail_returns_task_and_sub_channel() {
 async fn task_lifecycle_emits_four_events_in_parent_channel() {
     use chorus::store::tasks::TaskStatus;
 
-    let (_url, store) = start_test_server().await;
+    let (_url, store, _event_bus) = start_test_server().await;
     let parent_id = store
         .create_channel("eng", None, ChannelType::Channel, None)
         .unwrap();
@@ -495,7 +499,7 @@ async fn task_lifecycle_emits_four_events_in_parent_channel() {
 /// more than one entry and emits one `created` event per task.
 #[tokio::test]
 async fn batched_create_tasks_emits_one_event_per_task() {
-    let (_url, store) = start_test_server().await;
+    let (_url, store, _event_bus) = start_test_server().await;
     let parent_id = store
         .create_channel("eng2", None, ChannelType::Channel, None)
         .unwrap();
@@ -503,7 +507,7 @@ async fn batched_create_tasks_emits_one_event_per_task() {
     join_channel_silent(&store, "eng2", "bob", "human");
 
     // Three tasks in one call exercises the pending_events Vec with > 1 entry.
-    let created = store
+    let (created, _events) = store
         .create_tasks("eng2", "bob", SenderType::Human, &["a", "b", "c"])
         .unwrap();
     assert_eq!(created.len(), 3);

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -7,7 +7,12 @@ use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::Store;
 use harness::join_channel_silent;
 
-async fn start_test_server() -> (String, Arc<Store>, Arc<chorus::server::event_bus::EventBus>) {
+async fn start_test_server() -> (
+    String,
+    Arc<Store>,
+    Arc<chorus::server::event_bus::EventBus>,
+    tempfile::TempDir,
+) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     // Pre-create `#all` so the migration in `ensure_all_channel_inner`
     // (which renames `#general` -> `#all` when no `#all` exists)
@@ -25,13 +30,18 @@ async fn start_test_server() -> (String, Arc<Store>, Arc<chorus::server::event_b
         .create_channel("general", Some("General"), ChannelType::Channel, None)
         .unwrap();
     join_channel_silent(&store, "general", "testuser", "human");
-    let (router, event_bus) = harness::build_router_with_event_bus(store.clone());
+    // Per-test tempdir so parallel cargo runs don't share `agents/`,
+    // `data/attachments/`, `data/teams/`. Cleaned up via Drop when the
+    // returned `TempDir` goes out of scope at the end of the test.
+    let data_dir = tempfile::tempdir().unwrap();
+    let (router, event_bus) =
+        harness::build_router_with_event_bus_and_dir(store.clone(), data_dir.path().to_path_buf());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("http://{addr}");
     tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    (url, store, event_bus)
+    (url, store, event_bus, data_dir)
 }
 
 /// Insert an agent row with a chosen primary key. Used by e2e
@@ -62,7 +72,7 @@ fn seed_agent_with_id(
 /// Test 1: Human sends message, agent receives via HTTP
 #[tokio::test]
 async fn test_human_to_agent_message_flow() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -98,7 +108,7 @@ async fn test_human_to_agent_message_flow() {
 /// Test 2: Agent replies, appears in history
 #[tokio::test]
 async fn test_agent_reply_in_history() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -135,7 +145,7 @@ async fn test_agent_reply_in_history() {
 /// Test 3: Blocking receive wakes on message
 #[tokio::test]
 async fn test_blocking_receive_wakes_on_message() {
-    let (url, store, event_bus) = start_test_server().await;
+    let (url, store, event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -187,7 +197,7 @@ async fn test_blocking_receive_wakes_on_message() {
 /// Test 4: Task board workflow (create, claim, update status, list)
 #[tokio::test]
 async fn test_task_board_e2e() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -255,14 +265,17 @@ async fn test_task_board_e2e() {
 /// Test 5: Workspace listing and file preview flow over HTTP
 #[tokio::test]
 async fn test_workspace_e2e_lists_and_reads_markdown_file() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
     join_channel_silent(&store, "general", "bot1", "agent");
 
-    let agents_dir = std::env::temp_dir().join("chorus_test").join("agents");
+    // Mirror the path the server reads from: AppState wires `agents_dir`
+    // to `<data_dir>/agents`, which `harness::build_router_with_event_bus_and_dir`
+    // creates from the same TempDir we received.
+    let agents_dir = data_dir.path().join("agents");
     let workspace_dir = agents_dir.join("bot1");
     let notes_dir = workspace_dir.join("notes");
     std::fs::create_dir_all(&notes_dir).unwrap();
@@ -329,7 +342,7 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
 /// Test 6: Multi-agent communication
 #[tokio::test]
 async fn test_multi_agent_channel_communication() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "claude_bot", "Claude", "claude", "sonnet");
@@ -381,7 +394,7 @@ async fn test_multi_agent_channel_communication() {
 /// so the UI can deep-link from each row into its child channel.
 #[tokio::test]
 async fn list_tasks_returns_sub_channel_info() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     // Create tasks directly in the store so the creator name is stable across
@@ -413,7 +426,7 @@ async fn list_tasks_returns_sub_channel_info() {
 /// the full `TaskInfo` payload, including its sub-channel fields.
 #[tokio::test]
 async fn get_task_detail_returns_task_and_sub_channel() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     store.ensure_human_with_id("alice", "alice").unwrap();
@@ -451,7 +464,7 @@ async fn get_task_detail_returns_task_and_sub_channel() {
 async fn task_lifecycle_emits_four_events_in_parent_channel() {
     use chorus::store::tasks::TaskStatus;
 
-    let (_url, store, _event_bus) = start_test_server().await;
+    let (_url, store, _event_bus, _data_dir) = start_test_server().await;
     let parent_id = store
         .create_channel("eng", None, ChannelType::Channel, None)
         .unwrap();
@@ -499,7 +512,7 @@ async fn task_lifecycle_emits_four_events_in_parent_channel() {
 /// more than one entry and emits one `created` event per task.
 #[tokio::test]
 async fn batched_create_tasks_emits_one_event_per_task() {
-    let (_url, store, _event_bus) = start_test_server().await;
+    let (_url, store, _event_bus, _data_dir) = start_test_server().await;
     let parent_id = store
         .create_channel("eng2", None, ChannelType::Channel, None)
         .unwrap();

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -74,10 +74,7 @@ pub fn build_router_with_lifecycle(
     store: Arc<Store>,
     lifecycle: Arc<dyn AgentLifecycle>,
 ) -> Router {
-    let data_dir = std::env::temp_dir().join("chorus_test");
-    let agents_dir = data_dir.join("agents");
-    std::fs::create_dir_all(&agents_dir).ok();
-    build_router_with_lifecycle_and_dir(store, lifecycle, data_dir)
+    build_router_with_lifecycle_and_dir(store, lifecycle, unique_test_data_dir())
 }
 
 pub fn build_router_with_lifecycle_and_dir(
@@ -100,10 +97,14 @@ pub fn build_router_with_lifecycle_and_dir(
     )
 }
 
-pub fn build_router_with_event_bus(
+pub fn build_router_with_event_bus(store: Arc<Store>) -> (Router, Arc<EventBus>) {
+    build_router_with_event_bus_and_dir(store, unique_test_data_dir())
+}
+
+pub fn build_router_with_event_bus_and_dir(
     store: Arc<Store>,
+    data_dir: std::path::PathBuf,
 ) -> (Router, Arc<EventBus>) {
-    let data_dir = std::env::temp_dir().join("chorus_test");
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let event_bus = Arc::new(EventBus::new());
@@ -119,6 +120,20 @@ pub fn build_router_with_event_bus(
         vec![],
     );
     (router, event_bus)
+}
+
+/// Per-call unique tempdir so parallel cargo tests don't collide on
+/// `attachments/`, `agents/`, `teams/` under a shared path. The returned
+/// path lives past the call: `keep()` consumes the `TempDir` wrapper
+/// and disables its Drop cleanup, returning the underlying `PathBuf`.
+/// `$TMPDIR` is reclaimed by the OS. Tests that need explicit cleanup
+/// should use the `_and_dir` variants with their own `tempfile::TempDir`.
+pub fn unique_test_data_dir() -> std::path::PathBuf {
+    tempfile::Builder::new()
+        .prefix("chorus-test-")
+        .tempdir()
+        .expect("create test data dir")
+        .keep()
 }
 
 /// Test helper: silently insert a channel membership row without emitting

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -10,6 +10,7 @@ use chorus::agent::activity_log::ActivityLogResponse;
 use chorus::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
 use chorus::server::build_router_with_services;
+use chorus::server::event_bus::EventBus;
 use chorus::store::messages::ReceivedMessage;
 use chorus::store::Store;
 use rusqlite::params;
@@ -73,14 +74,51 @@ pub fn build_router_with_lifecycle(
     store: Arc<Store>,
     lifecycle: Arc<dyn AgentLifecycle>,
 ) -> Router {
+    let data_dir = std::env::temp_dir().join("chorus_test");
+    let agents_dir = data_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).ok();
+    build_router_with_lifecycle_and_dir(store, lifecycle, data_dir)
+}
+
+pub fn build_router_with_lifecycle_and_dir(
+    store: Arc<Store>,
+    lifecycle: Arc<dyn AgentLifecycle>,
+    data_dir: std::path::PathBuf,
+) -> Router {
+    let agents_dir = data_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).ok();
     build_router_with_services(
         store,
+        Arc::new(EventBus::new()),
+        data_dir,
+        agents_dir,
         lifecycle,
         Arc::new(SystemRuntimeStatusProvider::new(
             chorus::agent::manager::build_driver_registry(),
         )) as SharedRuntimeStatusProvider,
         vec![],
     )
+}
+
+pub fn build_router_with_event_bus(
+    store: Arc<Store>,
+) -> (Router, Arc<EventBus>) {
+    let data_dir = std::env::temp_dir().join("chorus_test");
+    let agents_dir = data_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).ok();
+    let event_bus = Arc::new(EventBus::new());
+    let router = build_router_with_services(
+        store,
+        event_bus.clone(),
+        data_dir,
+        agents_dir,
+        Arc::new(NoopLifecycle),
+        Arc::new(SystemRuntimeStatusProvider::new(
+            chorus::agent::manager::build_driver_registry(),
+        )) as SharedRuntimeStatusProvider,
+        vec![],
+    );
+    (router, event_bus)
 }
 
 /// Test helper: silently insert a channel membership row without emitting

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -84,10 +84,10 @@ use chorus::agent::drivers::{
     AgentKey, AgentSpec, DriverEvent, EventStreamHandle, PromptReq, RuntimeDriver, SessionId,
     SessionIntent,
 };
-use chorus::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
+
 use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
-use chorus::server::build_router_with_services;
+
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::ReceivedMessage;
 use chorus::store::{AgentRecordUpsert, Store};
@@ -166,14 +166,7 @@ async fn start_chorus_server() -> anyhow::Result<(String, Arc<Store>)> {
     store.create_channel("general", Some("General"), ChannelType::Channel, None)?;
     join_channel_silent(&store, "general", "tester", "human");
 
-    let router = build_router_with_services(
-        store.clone(),
-        Arc::new(NoopLifecycle),
-        Arc::new(SystemRuntimeStatusProvider::new(
-            chorus::agent::manager::build_driver_registry(),
-        )) as SharedRuntimeStatusProvider,
-        vec![],
-    );
+    let router = harness::build_router_with_lifecycle(store.clone(), Arc::new(NoopLifecycle));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -77,10 +77,10 @@ use chorus::agent::drivers::gemini::GeminiDriver;
 use chorus::agent::drivers::kimi::KimiDriver;
 use chorus::agent::drivers::opencode::OpencodeDriver;
 use chorus::agent::drivers::{AgentSpec, PromptReq, RuntimeDriver, SessionIntent};
-use chorus::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
+
 use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
-use chorus::server::build_router_with_services;
+
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
 use chorus::store::{AgentRecordUpsert, Store};
@@ -156,14 +156,7 @@ async fn start_chorus_server() -> anyhow::Result<(String, Arc<Store>, String)> {
     store.create_channel("general", Some("General"), ChannelType::Channel, None)?;
     join_channel_silent(&store, "general", &tester.id, "human");
 
-    let router = build_router_with_services(
-        store.clone(),
-        Arc::new(NoopLifecycle),
-        Arc::new(SystemRuntimeStatusProvider::new(
-            chorus::agent::manager::build_driver_registry(),
-        )) as SharedRuntimeStatusProvider,
-        vec![],
-    );
+    let router = harness::build_router_with_lifecycle(store.clone(), Arc::new(NoopLifecycle));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;

--- a/tests/realtime_tests.rs
+++ b/tests/realtime_tests.rs
@@ -7,7 +7,7 @@ use chorus::store::channels::ChannelType;
 use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::Store;
 use futures_util::StreamExt;
-use harness::{build_router, join_channel_silent};
+use harness::join_channel_silent;
 use serde_json::Value;
 use tokio::time::{timeout, Duration};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -17,7 +17,7 @@ struct TestIdentities {
     zoe_id: String,
 }
 
-async fn start_test_server() -> (String, Arc<Store>, TestIdentities) {
+async fn start_test_server() -> (String, Arc<Store>, TestIdentities, Arc<chorus::server::event_bus::EventBus>) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     let alice = store.create_local_human("alice").unwrap();
     let zoe = store.create_local_human("zoe").unwrap();
@@ -35,7 +35,7 @@ async fn start_test_server() -> (String, Arc<Store>, TestIdentities) {
         .create_channel("general", Some("General"), ChannelType::Channel, None)
         .unwrap();
     join_channel_silent(&store, "general", &alice.id, "human");
-    let router = build_router(store.clone());
+    let (router, event_bus) = harness::build_router_with_event_bus(store.clone());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("ws://{addr}");
@@ -48,6 +48,7 @@ async fn start_test_server() -> (String, Arc<Store>, TestIdentities) {
             alice_id: alice.id,
             zoe_id: zoe.id,
         },
+        event_bus,
     )
 }
 
@@ -71,7 +72,7 @@ async fn read_json_frame(
 
 #[tokio::test]
 async fn test_realtime_delivers_message_created_for_joined_channel() {
-    let (base_url, store, ids) = start_test_server().await;
+    let (base_url, store, ids, event_bus) = start_test_server().await;
     let general_id = store.get_channel_by_name("general").unwrap().unwrap().id;
 
     let (mut socket, _) =
@@ -79,7 +80,7 @@ async fn test_realtime_delivers_message_created_for_joined_channel() {
             .await
             .unwrap();
 
-    store
+    let (_, event) = store
         .create_message(CreateMessage {
             channel_name: "general",
             sender_id: &ids.alice_id,
@@ -90,6 +91,9 @@ async fn test_realtime_delivers_message_created_for_joined_channel() {
             run_id: None,
         })
         .unwrap();
+    if let Some(ev) = event {
+        event_bus.publish_stream(ev);
+    }
 
     let frame = read_json_frame(&mut socket).await;
     assert_eq!(frame["type"], "event");
@@ -102,7 +106,7 @@ async fn test_realtime_delivers_message_created_for_joined_channel() {
 
 #[tokio::test]
 async fn test_realtime_skips_non_member_channel() {
-    let (base_url, store, ids) = start_test_server().await;
+    let (base_url, store, ids, event_bus) = start_test_server().await;
     store
         .create_channel("private", Some("Private"), ChannelType::Channel, None)
         .unwrap();
@@ -113,7 +117,7 @@ async fn test_realtime_skips_non_member_channel() {
             .await
             .unwrap();
 
-    store
+    let (_, event) = store
         .create_message(CreateMessage {
             channel_name: "private",
             sender_id: &ids.zoe_id,
@@ -124,6 +128,9 @@ async fn test_realtime_skips_non_member_channel() {
             run_id: None,
         })
         .unwrap();
+    if let Some(ev) = event {
+        event_bus.publish_stream(ev);
+    }
 
     let next = timeout(Duration::from_millis(250), socket.next()).await;
     assert!(
@@ -134,14 +141,14 @@ async fn test_realtime_skips_non_member_channel() {
 
 #[tokio::test]
 async fn test_realtime_member_receives_live_messages_without_subscribe_frame() {
-    let (base_url, store, ids) = start_test_server().await;
+    let (base_url, store, ids, event_bus) = start_test_server().await;
 
     let (mut socket, _) =
         connect_async(format!("{base_url}/api/events/ws?viewer={}", ids.alice_id))
             .await
             .unwrap();
 
-    store
+    let (_, event) = store
         .create_message(CreateMessage {
             channel_name: "general",
             sender_id: &ids.alice_id,
@@ -152,6 +159,9 @@ async fn test_realtime_member_receives_live_messages_without_subscribe_frame() {
             run_id: None,
         })
         .unwrap();
+    if let Some(ev) = event {
+        event_bus.publish_stream(ev);
+    }
 
     let frame = read_json_frame(&mut socket).await;
     assert_eq!(frame["type"], "event");

--- a/tests/realtime_tests.rs
+++ b/tests/realtime_tests.rs
@@ -17,7 +17,12 @@ struct TestIdentities {
     zoe_id: String,
 }
 
-async fn start_test_server() -> (String, Arc<Store>, TestIdentities, Arc<chorus::server::event_bus::EventBus>) {
+async fn start_test_server() -> (
+    String,
+    Arc<Store>,
+    TestIdentities,
+    Arc<chorus::server::event_bus::EventBus>,
+) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     let alice = store.create_local_human("alice").unwrap();
     let zoe = store.create_local_human("zoe").unwrap();

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -9,7 +9,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::agent::AgentRuntime;
 use chorus::server::dto::ChannelInfo;
 use chorus::server::dto::ServerInfo;
-use chorus::server::{build_router_with_services, AgentDetailResponse, HistoryResponse};
+use chorus::server::{AgentDetailResponse, HistoryResponse};
 use chorus::store::channels::ChannelType;
 use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
 use chorus::store::AgentRecordUpsert;
@@ -90,10 +90,15 @@ fn seed_agent_with_id(
 
 fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
     let dir = tempdir().unwrap();
-    let db_path = dir.path().join("chorus.db");
+    let db_path = dir.path().join("data").join("chorus.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     let store = Arc::new(Store::open(db_path.to_str().unwrap()).unwrap());
     seed_default_workspace(&store);
-    let router = build_router(store.clone());
+    let router = harness::build_router_with_lifecycle_and_dir(
+        store.clone(),
+        Arc::new(harness::NoopLifecycle),
+        dir.path().to_path_buf(),
+    );
     (store, router, dir)
 }
 
@@ -347,11 +352,17 @@ fn setup_with_runtime_statuses(
         statuses,
         models_by_runtime,
     });
-    let router = build_router_with_services(
+    let data_dir = std::env::temp_dir().join("chorus_test");
+    let agents_dir = data_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).ok();
+    let router = chorus::server::build_router_with_services(
         store.clone(),
+        Arc::new(chorus::server::event_bus::EventBus::new()),
+        data_dir,
+        agents_dir,
         lifecycle.clone(),
         runtime_status_provider,
-        Vec::new(),
+        vec![],
     );
     (store, router, lifecycle)
 }
@@ -363,11 +374,16 @@ fn setup_with_lifecycle_and_data_dir() -> (
     tempfile::TempDir,
 ) {
     let dir = tempdir().unwrap();
-    let db_path = dir.path().join("chorus.db");
+    let db_path = dir.path().join("data").join("chorus.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     let store = Arc::new(Store::open(db_path.to_str().unwrap()).unwrap());
     seed_default_workspace(&store);
     let lifecycle = Arc::new(MockLifecycle::default());
-    let router = build_router_with_lifecycle(store.clone(), lifecycle.clone());
+    let router = harness::build_router_with_lifecycle_and_dir(
+        store.clone(),
+        lifecycle.clone(),
+        dir.path().to_path_buf(),
+    );
     (store, router, lifecycle, dir)
 }
 
@@ -2132,7 +2148,7 @@ async fn test_upload_uses_configured_data_dir() {
     assert!(
         attachment
             .stored_path
-            .starts_with(dir.path().join("attachments").to_string_lossy().as_ref()),
+            .starts_with(dir.path().join("data").join("attachments").to_string_lossy().as_ref()),
         "attachment should be stored under the configured data dir"
     );
 }
@@ -2297,7 +2313,7 @@ async fn test_create_team_endpoint() {
     assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
     assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
 
-    let teams_root = dir.path().join("teams").join("eng-team");
+    let teams_root = dir.path().join("data").join("teams").join("eng-team");
     assert!(teams_root.join("TEAM.md").exists());
     assert!(teams_root.join("members").join("bot1").exists());
 
@@ -2747,7 +2763,18 @@ async fn test_get_templates_returns_grouped_categories() {
         statuses: vec![],
         models_by_runtime: vec![],
     });
-    let router = build_router_with_services(store, lifecycle, runtime_status_provider, templates);
+    let data_dir = std::env::temp_dir().join("chorus_test");
+    let agents_dir = data_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).ok();
+    let router = chorus::server::build_router_with_services(
+        store,
+        Arc::new(chorus::server::event_bus::EventBus::new()),
+        data_dir,
+        agents_dir,
+        lifecycle,
+        runtime_status_provider,
+        templates,
+    );
 
     let response = router
         .oneshot(
@@ -2851,8 +2878,8 @@ async fn test_create_agent_appends_random_suffix() {
 async fn test_active_workspace_filters_core_resource_lists() {
     let store = Arc::new(Store::open(":memory:").unwrap());
     store.ensure_human_with_id("alice", "alice").unwrap();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
-    let beta = store.create_local_workspace("Beta", "alice").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (beta, _event) = store.create_local_workspace("Beta", "alice").unwrap();
     store.set_active_workspace(&alpha.id).unwrap();
     store
         .create_channel_in_workspace(
@@ -3040,7 +3067,7 @@ async fn test_active_workspace_filters_core_resource_lists() {
 async fn test_create_agent_in_active_workspace_joins_workspace_all() {
     let store = Arc::new(Store::open(":memory:").unwrap());
     store.ensure_human_with_id("alice", "alice").unwrap();
-    let workspace = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (workspace, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
     store.set_active_workspace(&workspace.id).unwrap();
     let app = build_router(store.clone());
 

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -352,7 +352,7 @@ fn setup_with_runtime_statuses(
         statuses,
         models_by_runtime,
     });
-    let data_dir = std::env::temp_dir().join("chorus_test");
+    let data_dir = harness::unique_test_data_dir();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let router = chorus::server::build_router_with_services(
@@ -2146,9 +2146,13 @@ async fn test_upload_uses_configured_data_dir() {
         .expect("attachment record");
 
     assert!(
-        attachment
-            .stored_path
-            .starts_with(dir.path().join("data").join("attachments").to_string_lossy().as_ref()),
+        attachment.stored_path.starts_with(
+            dir.path()
+                .join("data")
+                .join("attachments")
+                .to_string_lossy()
+                .as_ref()
+        ),
         "attachment should be stored under the configured data dir"
     );
 }
@@ -2756,14 +2760,17 @@ async fn test_get_templates_returns_grouped_categories() {
     ];
 
     let dir = tempdir().unwrap();
-    let db_path = dir.path().join("chorus.db");
+    let db_path = dir.path().join("data").join("chorus.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     let store = Arc::new(Store::open(db_path.to_str().unwrap()).unwrap());
     let lifecycle = Arc::new(MockLifecycle::default());
     let runtime_status_provider = Arc::new(MockRuntimeStatusProvider {
         statuses: vec![],
         models_by_runtime: vec![],
     });
-    let data_dir = std::env::temp_dir().join("chorus_test");
+    // Reuse the per-test tempdir for the data root so the templates test
+    // doesn't share filesystem state with parallel cargo runs.
+    let data_dir = dir.path().to_path_buf();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let router = chorus::server::build_router_with_services(

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -132,7 +132,7 @@ fn test_open_old_identity_schema_fails_loudly() {
 fn test_create_local_workspace_sets_owner_and_active_context() {
     let (store, _dir) = make_store();
 
-    let workspace = store.create_local_workspace("Chorus Dev", "alice").unwrap();
+    let (workspace, _event) = store.create_local_workspace("Chorus Dev", "alice").unwrap();
 
     assert_eq!(workspace.name, "Chorus Dev");
     assert_eq!(workspace.slug, "chorus-dev");
@@ -152,7 +152,7 @@ fn test_create_local_workspace_sets_owner_and_active_context() {
 fn test_create_local_workspace_provisions_all_channel() {
     let (store, _dir) = make_store();
 
-    let workspace = store.create_local_workspace("Chorus Dev", "alice").unwrap();
+    let (workspace, _event) = store.create_local_workspace("Chorus Dev", "alice").unwrap();
 
     let channels = store
         .get_channels_by_params(&chorus::store::ChannelListParams {
@@ -211,8 +211,8 @@ fn test_scoped_resource_schema_requires_workspace_id() {
 #[test]
 fn test_workspace_scoped_names_allow_same_channel_name_in_different_workspaces() {
     let (store, _dir) = make_store();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
-    let beta = store.create_local_workspace("Beta", "bob").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (beta, _event) = store.create_local_workspace("Beta", "bob").unwrap();
 
     store
         .create_channel_in_workspace(
@@ -271,8 +271,8 @@ fn test_unknown_workspace_mode_surfaces_error() {
 #[test]
 fn test_workspace_selector_switch_rename_and_slug_collision() {
     let (store, _dir) = make_store();
-    let first = store.create_local_workspace("Acme", "alice").unwrap();
-    let second = store.create_local_workspace("Acme", "alice").unwrap();
+    let (first, _event) = store.create_local_workspace("Acme", "alice").unwrap();
+    let (second, _event) = store.create_local_workspace("Acme", "alice").unwrap();
 
     assert_eq!(first.slug, "acme");
     assert_eq!(second.slug, "acme-1");
@@ -292,8 +292,8 @@ fn test_workspace_selector_switch_rename_and_slug_collision() {
 #[test]
 fn test_workspace_scoped_core_resource_lists() {
     let (store, _dir) = make_store();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
-    let beta = store.create_local_workspace("Beta", "alice").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (beta, _event) = store.create_local_workspace("Beta", "alice").unwrap();
 
     store
         .create_channel_in_workspace(
@@ -374,8 +374,8 @@ fn test_workspace_scoped_core_resource_lists() {
 #[test]
 fn test_workspace_scoped_team_channel_join_uses_workspace_id() {
     let (store, _dir) = make_store();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
-    let beta = store.create_local_workspace("Beta", "alice").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (beta, _event) = store.create_local_workspace("Beta", "alice").unwrap();
 
     let alpha_channel_id = store
         .create_channel_in_workspace(&alpha.id, "ops", None, ChannelType::Team, None)
@@ -426,7 +426,7 @@ fn test_team_with_channel_create_rolls_back_when_channel_insert_fails() {
 #[test]
 fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
     let (store, _dir) = make_store();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
 
     store
         .create_agent_record(&AgentRecordUpsert {
@@ -478,8 +478,8 @@ fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
 #[test]
 fn test_delete_workspace_wipes_scoped_data_and_keeps_other_workspaces() {
     let (store, dir) = make_store();
-    let alpha = store.create_local_workspace("Alpha", "alice").unwrap();
-    let beta = store.create_local_workspace("Beta", "bob").unwrap();
+    let (alpha, _event) = store.create_local_workspace("Alpha", "alice").unwrap();
+    let (beta, _event) = store.create_local_workspace("Beta", "bob").unwrap();
     let alpha_channel_id = store
         .create_channel_in_workspace(&alpha.id, "alpha-general", None, ChannelType::Channel, None)
         .unwrap();
@@ -795,7 +795,7 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     assert!(!msg_id.is_empty());
 
     let bot1_id = store
@@ -827,7 +827,7 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     let msgs = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert_eq!(msgs.len(), 2);
 }
@@ -861,7 +861,7 @@ fn test_agent_does_not_receive_its_own_sent_message() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let unread = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert!(
@@ -893,7 +893,7 @@ fn test_message_history_pagination() {
                 suppress_event: false,
                 run_id: None,
             })
-            .unwrap();
+            .map(|(id, _)| id).unwrap();
     }
 
     let (msgs, has_more) = store.get_history("general", 5, None, None).unwrap();
@@ -926,7 +926,7 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -937,7 +937,7 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let snapshot = store
         .get_history_snapshot("general", "alice", 10, None, None)
@@ -982,7 +982,7 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     let second_top_level = store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -993,7 +993,7 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let state_before = store
         .get_inbox_conversation_state("general", &bot1_id)
@@ -1091,7 +1091,7 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1102,7 +1102,7 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let unread_before = store.get_unread_summary(&bot1_id).unwrap();
     assert_eq!(unread_before.get("general"), Some(&2));
@@ -1142,7 +1142,7 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1153,7 +1153,7 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, 999)
@@ -1184,7 +1184,7 @@ fn test_history_read_cursor_rejects_negative_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, -1)
@@ -1213,7 +1213,7 @@ fn test_history_read_cursor_heals_orphan_above_max_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
     {
@@ -1253,7 +1253,7 @@ fn test_conversation_messages_view_projects_message_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
 
     let conn = store.conn_for_test();
@@ -1390,7 +1390,7 @@ fn test_mark_agent_messages_deleted_marks_history_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     store.mark_agent_messages_deleted("bot1").unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
@@ -1417,7 +1417,7 @@ fn test_create_message_persists_top_level() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].id, message_id);
@@ -1457,7 +1457,7 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1468,7 +1468,7 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let channel_id = store
         .get_channel_by_name("general")
@@ -1516,7 +1516,7 @@ fn test_tasks_crud() {
         })
         .unwrap();
 
-    let tasks = store
+    let (tasks, _events) = store
         .create_tasks(
             "eng",
             &bot1_id,
@@ -1564,14 +1564,14 @@ fn test_task_claim_and_status() {
         .unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["Task A"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
 
-    let results = store
+    let (results, _events) = store
         .update_tasks_claim("eng", &bot1_id, SenderType::Agent, &[1])
         .unwrap();
     assert!(results[0].success);
 
-    let results = store
+    let (results, _events) = store
         .update_tasks_claim("eng", &bot2_id, SenderType::Agent, &[1])
         .unwrap();
     assert!(!results[0].success);
@@ -1899,7 +1899,7 @@ fn test_new_agents_auto_join_all_when_it_exists() {
 #[test]
 fn test_ensure_builtin_channels_repairs_active_workspace_all() {
     let (store, _dir) = make_store();
-    let workspace = store
+    let (workspace, _event) = store
         .create_local_workspace("Chorus Local", "alice")
         .unwrap();
 
@@ -1981,10 +1981,10 @@ fn test_delete_channel_removes_messages_tasks_and_memberships() {
             suppress_event: false,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["ship it"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
 
     store.delete_channel(&channel_id).unwrap();
 
@@ -2048,7 +2048,7 @@ fn test_create_system_message_writes_system_sender_type() {
     join_channel_silent(&store, "general", "alice", "human");
 
     let channel_id = store.get_channel_by_name("general").unwrap().unwrap().id;
-    let msg_id = store
+    let (msg_id, _event) = store
         .create_system_message(&channel_id, "Team assembled: Alpha, Beta.")
         .unwrap();
     assert!(!msg_id.is_empty());
@@ -2090,7 +2090,7 @@ fn test_channel_unread_count_excludes_system_messages() {
             run_id: None,
             suppress_event: false,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let unread_before = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2103,7 +2103,7 @@ fn test_channel_unread_count_excludes_system_messages() {
     let channel_id = store.get_channel_by_name("general").unwrap().unwrap().id;
     store
         .create_system_message(&channel_id, "Team assembled.")
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let unread_after = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2124,11 +2124,13 @@ fn test_create_system_message_emits_system_typed_stream_event() {
     store.ensure_human_with_id("alice", "alice").unwrap();
     join_channel_silent(&store, "general", "alice", "human");
 
-    let mut rx = store.subscribe();
+    let event_bus = chorus::server::event_bus::EventBus::new();
+    let mut rx = event_bus.subscribe();
     let channel_id = store.get_channel_by_name("general").unwrap().unwrap().id;
-    store
+    let (_msg_id, event) = store
         .create_system_message(&channel_id, "Team assembled.")
         .unwrap();
+    event_bus.publish_stream(event);
 
     let event = rx
         .try_recv()
@@ -2160,7 +2162,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
 
     // Human joins — creates system message.
-    let joined = store
+    let (joined, _events) = store
         .join_channel_by_id(&channel.id, "alice", SenderType::Human)
         .unwrap();
     assert!(joined, "first join should return true");
@@ -2185,7 +2187,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
     assert_eq!(alice_payload["target"]["label"], "#general");
 
     // Idempotent re-join — no duplicate system message.
-    let joined_again = store
+    let (joined_again, _events) = store
         .join_channel_by_id(&channel.id, "alice", SenderType::Human)
         .unwrap();
     assert!(!joined_again, "re-join should return false");
@@ -2212,7 +2214,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
             env_vars: &[],
         })
         .unwrap();
-    let bot_joined = store
+    let (bot_joined, _events) = store
         .join_channel_by_id(&channel.id, &bot_id, SenderType::Agent)
         .unwrap();
     assert!(bot_joined, "agent first join should return true");
@@ -2234,7 +2236,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
     store
         .ensure_human_with_id("human_carol_123", "carol")
         .unwrap();
-    let carol_joined = store
+    let (carol_joined, _events) = store
         .join_channel_by_id(&channel.id, "human_carol_123", SenderType::Human)
         .unwrap();
     assert!(carol_joined, "UUID-id human first join should return true");
@@ -2284,7 +2286,7 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
 
     // Human joins after the agent — this writes a `member_joined` payload
     // tagged `audience: "humans"` that the agent should NOT see when it polls.
-    let joined = store
+    let (joined, _events) = store
         .join_channel_by_id(&channel.id, "alice", SenderType::Human)
         .unwrap();
     assert!(joined);
@@ -2302,10 +2304,10 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
             suppress_event: true,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
     store
         .create_tasks("crew", "alice", SenderType::Human, &["ship"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
 
     // Agent receive — must skip the join chip but include alice's ping
     // and the task-event row.
@@ -2462,7 +2464,7 @@ fn create_tasks_emits_task_event_to_parent_channel() {
     store.ensure_human_with_id("bob", "bob").unwrap();
     join_channel_silent(&store, "eng", "bob", "human");
 
-    let result = store
+    let (result, _events) = store
         .create_tasks("eng", "bob", SenderType::Human, &["wire up the bridge"])
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -2512,10 +2514,10 @@ fn claim_task_emits_claimed_event_to_parent_channel() {
 
     store
         .create_tasks("eng", "bob", SenderType::Human, &["t"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .unwrap();
+        .map(|(results, _)| results).unwrap();
 
     let events: Vec<serde_json::Value> = store
         .conn_for_test()
@@ -2551,10 +2553,10 @@ fn unclaim_task_emits_unclaimed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .unwrap();
+        .map(|(results, _)| results).unwrap();
 
     store
         .update_task_unclaim("eng", "alice", SenderType::Human, 1)
@@ -2592,10 +2594,10 @@ fn update_task_status_emits_status_changed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .unwrap();
+        .map(|(tasks, _)| tasks).unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .unwrap();
+        .map(|(results, _)| results).unwrap();
 
     store
         .update_task_status("eng", 1, "alice", SenderType::Human, TaskStatus::InReview)
@@ -2633,10 +2635,10 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
     store.ensure_human_with_id("bob", "bob").unwrap();
     store
         .join_channel_by_id(&sub_id, "alice", SenderType::Human)
-        .unwrap();
+        .map(|(joined, _)| joined).unwrap();
     store
         .join_channel_by_id(&sub_id, "bob", SenderType::Human)
-        .unwrap();
+        .map(|(joined, _)| joined).unwrap();
     // Bob's non-system message is unread for alice (the view excludes system
     // messages, so only human/agent traffic can produce a leak).
     store
@@ -2649,7 +2651,7 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
             suppress_event: true,
             run_id: None,
         })
-        .unwrap();
+        .map(|(id, _)| id).unwrap();
 
     let before = store.get_unread_summary("alice").unwrap();
     assert_eq!(

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -795,7 +795,8 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     assert!(!msg_id.is_empty());
 
     let bot1_id = store
@@ -827,7 +828,8 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let msgs = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert_eq!(msgs.len(), 2);
 }
@@ -861,7 +863,8 @@ fn test_agent_does_not_receive_its_own_sent_message() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert!(
@@ -893,7 +896,8 @@ fn test_message_history_pagination() {
                 suppress_event: false,
                 run_id: None,
             })
-            .map(|(id, _)| id).unwrap();
+            .map(|(id, _)| id)
+            .unwrap();
     }
 
     let (msgs, has_more) = store.get_history("general", 5, None, None).unwrap();
@@ -926,7 +930,8 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -937,7 +942,8 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let snapshot = store
         .get_history_snapshot("general", "alice", 10, None, None)
@@ -982,7 +988,8 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let second_top_level = store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -993,7 +1000,8 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let state_before = store
         .get_inbox_conversation_state("general", &bot1_id)
@@ -1091,7 +1099,8 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1102,7 +1111,8 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_before = store.get_unread_summary(&bot1_id).unwrap();
     assert_eq!(unread_before.get("general"), Some(&2));
@@ -1142,7 +1152,8 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1153,7 +1164,8 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, 999)
@@ -1184,7 +1196,8 @@ fn test_history_read_cursor_rejects_negative_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, -1)
@@ -1213,7 +1226,8 @@ fn test_history_read_cursor_heals_orphan_above_max_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
     {
@@ -1253,7 +1267,8 @@ fn test_conversation_messages_view_projects_message_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
 
     let conn = store.conn_for_test();
@@ -1390,7 +1405,8 @@ fn test_mark_agent_messages_deleted_marks_history_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     store.mark_agent_messages_deleted("bot1").unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
@@ -1417,7 +1433,8 @@ fn test_create_message_persists_top_level() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].id, message_id);
@@ -1457,7 +1474,8 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1468,7 +1486,8 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let channel_id = store
         .get_channel_by_name("general")
@@ -1564,7 +1583,8 @@ fn test_task_claim_and_status() {
         .unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["Task A"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     let (results, _events) = store
         .update_tasks_claim("eng", &bot1_id, SenderType::Agent, &[1])
@@ -1981,10 +2001,12 @@ fn test_delete_channel_removes_messages_tasks_and_memberships() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["ship it"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     store.delete_channel(&channel_id).unwrap();
 
@@ -2090,7 +2112,8 @@ fn test_channel_unread_count_excludes_system_messages() {
             run_id: None,
             suppress_event: false,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_before = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2103,7 +2126,8 @@ fn test_channel_unread_count_excludes_system_messages() {
     let channel_id = store.get_channel_by_name("general").unwrap().unwrap().id;
     store
         .create_system_message(&channel_id, "Team assembled.")
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_after = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2304,10 +2328,12 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
             suppress_event: true,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_tasks("crew", "alice", SenderType::Human, &["ship"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     // Agent receive — must skip the join chip but include alice's ping
     // and the task-event row.
@@ -2514,10 +2540,12 @@ fn claim_task_emits_claimed_event_to_parent_channel() {
 
     store
         .create_tasks("eng", "bob", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     let events: Vec<serde_json::Value> = store
         .conn_for_test()
@@ -2553,10 +2581,12 @@ fn unclaim_task_emits_unclaimed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     store
         .update_task_unclaim("eng", "alice", SenderType::Human, 1)
@@ -2594,10 +2624,12 @@ fn update_task_status_emits_status_changed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     store
         .update_task_status("eng", 1, "alice", SenderType::Human, TaskStatus::InReview)
@@ -2635,10 +2667,12 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
     store.ensure_human_with_id("bob", "bob").unwrap();
     store
         .join_channel_by_id(&sub_id, "alice", SenderType::Human)
-        .map(|(joined, _)| joined).unwrap();
+        .map(|(joined, _)| joined)
+        .unwrap();
     store
         .join_channel_by_id(&sub_id, "bob", SenderType::Human)
-        .map(|(joined, _)| joined).unwrap();
+        .map(|(joined, _)| joined)
+        .unwrap();
     // Bob's non-system message is unread for alice (the view excludes system
     // messages, so only human/agent traffic can produce a leak).
     store
@@ -2651,7 +2685,8 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
             suppress_event: true,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let before = store.get_unread_summary("alice").unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary

Extracts broadcast channels and filesystem paths from `Store` so it becomes a pure SQLite DAO. This enables backend swap (SQLite → Mongo/Supabase) without carrying non-storage concerns.

## Changes

- **New `EventBus`** (`src/server/event_bus.rs`): Owns `stream_tx`/`trace_tx` broadcast channels, decoupled from persistence.
- **Purged `Store` fields**: Removed `stream_tx`, `trace_tx`, `data_dir`, `agents_dir_override`.
- **Return events instead of sending**: Store methods now return `StreamEvent` tuples; callers publish via `EventBus`.
- **Updated `AppState`**: Carries `event_bus`, `data_dir`, `agents_dir`.
- **Updated handlers**: All callers destructure tuples and publish events.
- **Updated `AgentManager::new`**: Takes `trace_tx` explicitly.
- **Test helpers**: Added `build_router_with_lifecycle_and_dir` and `build_router_with_event_bus`.

## Verification

- `cargo test --lib`: 344 passed
- `cargo test --tests`: ~196 integration tests passed
- No compiler warnings
