### PR TITLE
fix(tests): per-test data dirs to prevent parallel-run FS contamination

### DIFF
--- a/src/agent/event_forwarder.rs
+++ b/src/agent/event_forwarder.rs
@@ -31,8 +31,8 @@ use crate::agent::drivers::acp_protocol;
 use crate::agent::drivers::{AgentEventItem, DriverEvent, FinishReason, ProcessState};
 use crate::agent::manager::ManagedAgent;
 use crate::agent::trace::{self, AgentTraceStore, TraceEvent, TraceEventKind};
-use crate::store::StreamEvent;
 use crate::store::Store;
+use crate::store::StreamEvent;
 
 /// Extract a short human-readable summary from an ACP tool-call `input`
 /// object. Probes the common argument keys drivers use (`file_path`,

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -45,7 +45,12 @@ pub async fn run(
     // user running the server process.
 
     let server_url = format!("http://localhost:{port}");
-    let mut manager = AgentManager::new(store.clone(), agents_dir.clone(), event_bus.trace_sender(), event_bus.stream_sender());
+    let mut manager = AgentManager::new(
+        store.clone(),
+        agents_dir.clone(),
+        event_bus.trace_sender(),
+        event_bus.stream_sender(),
+    );
 
     // Shared cancellation token — cancelled on Ctrl-C and used to shut down
     // both the main server and the bridge together.

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -486,7 +486,13 @@ fn ensure_setup_workspace(
     if let Some(workspace) = store.get_active_workspace()? {
         return Ok(workspace);
     }
-    store.create_local_workspace(workspace_name, owner_human_id).map(|(w, _)| w)
+    // The dropped StreamEvent here is intentional: `chorus setup` runs as
+    // a one-shot CLI before any server starts, so no EventBus subscriber
+    // exists to receive it. The runtime path through `handle_create_workspace`
+    // does publish; this is the setup-only branch.
+    store
+        .create_local_workspace(workspace_name, owner_human_id)
+        .map(|(w, _)| w)
 }
 
 /// Resolve (or seed) the local human row and write `(id, name)` back to

--- a/src/server/event_bus.rs
+++ b/src/server/event_bus.rs
@@ -45,8 +45,6 @@ impl EventBus {
     pub fn publish_stream(&self, event: StreamEvent) {
         let _ = self.stream_tx.send(event);
     }
-
-
 }
 
 impl Default for EventBus {

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -177,9 +177,7 @@ pub async fn handle_ui_server_info(State(state): State<AppState>) -> ApiResult<s
 pub async fn handle_system_info(State(state): State<AppState>) -> ApiResult<dto::SystemInfo> {
     let data_dir = state.data_dir.to_string_lossy().into_owned();
     let data_dir_path = state.data_dir.clone();
-    let db_size_bytes = std::fs::metadata(state.db_path())
-        .map(|m| m.len())
-        .ok();
+    let db_size_bytes = std::fs::metadata(state.db_path()).map(|m| m.len()).ok();
 
     let config = ChorusConfig::load(&data_dir_path)
         .ok()

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -101,9 +101,10 @@ pub async fn handle_launch_trio(
     // Join the human user to the channel.
     if let Ok(humans) = state.store.get_humans() {
         if let Some(human) = humans.first() {
-            if let Ok((_, events)) = state
-                .store
-                .join_channel(&channel_name, &human.id, SenderType::Human)
+            if let Ok((_, events)) =
+                state
+                    .store
+                    .join_channel(&channel_name, &human.id, SenderType::Human)
             {
                 for event in events {
                     state.event_bus.publish_stream(event);
@@ -168,9 +169,10 @@ pub async fn handle_launch_trio(
         }
 
         // Also join the trio channel (auto-join channels handled above).
-        if let Ok((_, events)) = state
-            .store
-            .join_channel(&channel_name, &result.id, SenderType::Agent)
+        if let Ok((_, events)) =
+            state
+                .store
+                .join_channel(&channel_name, &result.id, SenderType::Agent)
         {
             for event in events {
                 state.event_bus.publish_stream(event);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -76,7 +76,8 @@ pub fn build_router_with_services(
         .ok()
         .flatten()
         .map(|workspace| workspace.id);
-    let (local_human_id, local_human_name) = resolve_local_human_identity(store.as_ref(), &data_dir);
+    let (local_human_id, local_human_name) =
+        resolve_local_human_identity(store.as_ref(), &data_dir);
 
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS

--- a/src/server/transport/realtime.rs
+++ b/src/server/transport/realtime.rs
@@ -40,10 +40,17 @@ pub async fn handle_events_ws(
     }
 
     let event_bus = state.event_bus.clone();
-    Ok(ws.on_upgrade(move |socket| realtime_session(socket, event_bus, state.store.clone(), params.viewer)))
+    Ok(ws.on_upgrade(move |socket| {
+        realtime_session(socket, event_bus, state.store.clone(), params.viewer)
+    }))
 }
 
-async fn realtime_session(mut socket: WebSocket, event_bus: Arc<EventBus>, store: Arc<crate::store::Store>, viewer: String) {
+async fn realtime_session(
+    mut socket: WebSocket,
+    event_bus: Arc<EventBus>,
+    store: Arc<crate::store::Store>,
+    viewer: String,
+) {
     let mut stream_rx = event_bus.subscribe();
     let mut trace_rx = event_bus.subscribe_traces();
 

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -73,7 +73,8 @@ impl Store {
     }
 
     pub fn create_agent_record_with_events(
-        &self, record: &AgentRecordUpsert<'_>,
+        &self,
+        record: &AgentRecordUpsert<'_>,
     ) -> Result<(String, Vec<crate::store::stream::StreamEvent>)> {
         let (workspace_id, id) = {
             let conn = self.conn.lock().unwrap();
@@ -85,7 +86,9 @@ impl Store {
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(&workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+            if let Ok((_, evs)) =
+                self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent)
+            {
                 events.extend(evs);
             }
         }
@@ -97,7 +100,8 @@ impl Store {
         workspace_id: &str,
         record: &AgentRecordUpsert<'_>,
     ) -> Result<String> {
-        let (id, _events) = self.create_agent_record_in_workspace_with_events(workspace_id, record)?;
+        let (id, _events) =
+            self.create_agent_record_in_workspace_with_events(workspace_id, record)?;
         Ok(id)
     }
 
@@ -114,7 +118,9 @@ impl Store {
         if let Ok(Some(all_channel)) =
             self.get_channel_by_workspace_and_name(workspace_id, Self::DEFAULT_SYSTEM_CHANNEL)
         {
-            if let Ok((_, evs)) = self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent) {
+            if let Ok((_, evs)) =
+                self.join_channel_by_id(&all_channel.id, &id, super::SenderType::Agent)
+            {
                 events.extend(evs);
             }
         }

--- a/src/store/messages/posting.rs
+++ b/src/store/messages/posting.rs
@@ -186,7 +186,11 @@ impl Store {
     }
 
     /// Post a server-authored message into a channel.
-    pub fn create_system_message(&self, channel_id: &str, content: &str) -> Result<(String, StreamEvent)> {
+    pub fn create_system_message(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<(String, StreamEvent)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_id_inner(&tx, channel_id)?
@@ -211,7 +215,10 @@ impl Store {
         Ok((message_id, stream_event))
     }
 
-    pub fn create_message(&self, message: CreateMessage<'_>) -> Result<(String, Option<StreamEvent>)> {
+    pub fn create_message(
+        &self,
+        message: CreateMessage<'_>,
+    ) -> Result<(String, Option<StreamEvent>)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
         let channel = Self::get_channel_by_name_inner(&tx, message.channel_name)?
@@ -249,7 +256,11 @@ impl Store {
             inserted.seq,
             serde_json::to_value(payload)?,
         );
-        let event = if message.suppress_event { None } else { Some(stream_event) };
+        let event = if message.suppress_event {
+            None
+        } else {
+            Some(stream_event)
+        };
         Ok((inserted.id, event))
     }
 

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -555,12 +555,8 @@ impl Store {
             Self::create_system_message_tx_with_payload(&tx, &channel, &content, &payload_json)?;
         tx.commit()?;
         drop(conn);
-        let event = posting::system_message_stream_event(
-            &channel,
-            &inserted,
-            &content,
-            Some(payload_json),
-        );
+        let event =
+            posting::system_message_stream_event(&channel, &inserted, &content, Some(payload_json));
         Ok(vec![event])
     }
 
@@ -666,12 +662,8 @@ impl Store {
 
         tx.commit()?;
         drop(conn);
-        let event = posting::system_message_stream_event(
-            &channel,
-            &inserted,
-            &content,
-            Some(payload_json),
-        );
+        let event =
+            posting::system_message_stream_event(&channel, &inserted, &content, Some(payload_json));
         Ok(vec![event])
     }
 }
@@ -967,11 +959,13 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");
@@ -1031,10 +1025,12 @@ mod sub_channel_tests {
         // Advance task 1 through InReview → Done. Task 2 stays in progress.
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let after: Vec<String> = store
             .get_inbox_conversation_notifications(&bob_id)
@@ -1077,10 +1073,12 @@ mod sub_channel_tests {
             .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::InReview)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
         store
             .update_task_status("eng", 1, &bob_id, SenderType::Agent, TaskStatus::Done)
-            .map(|_| ()).unwrap();
+            .map(|_| ())
+            .unwrap();
 
         let (_parent_id, sub_id) = read_task_channel_ids(&store, "eng", 1);
         let sub_id = sub_id.expect("task has sub_channel_id");

--- a/src/store/workspaces.rs
+++ b/src/store/workspaces.rs
@@ -59,7 +59,11 @@ pub struct WorkspaceCounts {
 }
 
 impl Store {
-    pub fn create_local_workspace(&self, name: &str, owner_human_id: &str) -> Result<(Workspace, StreamEvent)> {
+    pub fn create_local_workspace(
+        &self,
+        name: &str,
+        owner_human_id: &str,
+    ) -> Result<(Workspace, StreamEvent)> {
         self.create_local_workspace_inner(name, owner_human_id, true)
     }
 

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -7,7 +7,12 @@ use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::Store;
 use harness::join_channel_silent;
 
-async fn start_test_server() -> (String, Arc<Store>, Arc<chorus::server::event_bus::EventBus>) {
+async fn start_test_server() -> (
+    String,
+    Arc<Store>,
+    Arc<chorus::server::event_bus::EventBus>,
+    tempfile::TempDir,
+) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     // Pre-create `#all` so the migration in `ensure_all_channel_inner`
     // (which renames `#general` -> `#all` when no `#all` exists)
@@ -25,13 +30,18 @@ async fn start_test_server() -> (String, Arc<Store>, Arc<chorus::server::event_b
         .create_channel("general", Some("General"), ChannelType::Channel, None)
         .unwrap();
     join_channel_silent(&store, "general", "testuser", "human");
-    let (router, event_bus) = harness::build_router_with_event_bus(store.clone());
+    // Per-test tempdir so parallel cargo runs don't share `agents/`,
+    // `data/attachments/`, `data/teams/`. Cleaned up via Drop when the
+    // returned `TempDir` goes out of scope at the end of the test.
+    let data_dir = tempfile::tempdir().unwrap();
+    let (router, event_bus) =
+        harness::build_router_with_event_bus_and_dir(store.clone(), data_dir.path().to_path_buf());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("http://{addr}");
     tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    (url, store, event_bus)
+    (url, store, event_bus, data_dir)
 }
 
 /// Insert an agent row with a chosen primary key. Used by e2e
@@ -62,7 +72,7 @@ fn seed_agent_with_id(
 /// Test 1: Human sends message, agent receives via HTTP
 #[tokio::test]
 async fn test_human_to_agent_message_flow() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -98,7 +108,7 @@ async fn test_human_to_agent_message_flow() {
 /// Test 2: Agent replies, appears in history
 #[tokio::test]
 async fn test_agent_reply_in_history() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -135,7 +145,7 @@ async fn test_agent_reply_in_history() {
 /// Test 3: Blocking receive wakes on message
 #[tokio::test]
 async fn test_blocking_receive_wakes_on_message() {
-    let (url, store, event_bus) = start_test_server().await;
+    let (url, store, event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -187,7 +197,7 @@ async fn test_blocking_receive_wakes_on_message() {
 /// Test 4: Task board workflow (create, claim, update status, list)
 #[tokio::test]
 async fn test_task_board_e2e() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
@@ -255,14 +265,17 @@ async fn test_task_board_e2e() {
 /// Test 5: Workspace listing and file preview flow over HTTP
 #[tokio::test]
 async fn test_workspace_e2e_lists_and_reads_markdown_file() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "bot1", "Bot 1", "claude", "sonnet");
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
     join_channel_silent(&store, "general", "bot1", "agent");
 
-    let agents_dir = std::env::temp_dir().join("chorus_test").join("agents");
+    // Mirror the path the server reads from: AppState wires `agents_dir`
+    // to `<data_dir>/agents`, which `harness::build_router_with_event_bus_and_dir`
+    // creates from the same TempDir we received.
+    let agents_dir = data_dir.path().join("agents");
     let workspace_dir = agents_dir.join("bot1");
     let notes_dir = workspace_dir.join("notes");
     std::fs::create_dir_all(&notes_dir).unwrap();
@@ -329,7 +342,7 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
 /// Test 6: Multi-agent communication
 #[tokio::test]
 async fn test_multi_agent_channel_communication() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     seed_agent_with_id(&store, "claude_bot", "Claude", "claude", "sonnet");
@@ -381,7 +394,7 @@ async fn test_multi_agent_channel_communication() {
 /// so the UI can deep-link from each row into its child channel.
 #[tokio::test]
 async fn list_tasks_returns_sub_channel_info() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     // Create tasks directly in the store so the creator name is stable across
@@ -413,7 +426,7 @@ async fn list_tasks_returns_sub_channel_info() {
 /// the full `TaskInfo` payload, including its sub-channel fields.
 #[tokio::test]
 async fn get_task_detail_returns_task_and_sub_channel() {
-    let (url, store, _event_bus) = start_test_server().await;
+    let (url, store, _event_bus, _data_dir) = start_test_server().await;
     let client = reqwest::Client::new();
 
     store.ensure_human_with_id("alice", "alice").unwrap();
@@ -451,7 +464,7 @@ async fn get_task_detail_returns_task_and_sub_channel() {
 async fn task_lifecycle_emits_four_events_in_parent_channel() {
     use chorus::store::tasks::TaskStatus;
 
-    let (_url, store, _event_bus) = start_test_server().await;
+    let (_url, store, _event_bus, _data_dir) = start_test_server().await;
     let parent_id = store
         .create_channel("eng", None, ChannelType::Channel, None)
         .unwrap();
@@ -499,7 +512,7 @@ async fn task_lifecycle_emits_four_events_in_parent_channel() {
 /// more than one entry and emits one `created` event per task.
 #[tokio::test]
 async fn batched_create_tasks_emits_one_event_per_task() {
-    let (_url, store, _event_bus) = start_test_server().await;
+    let (_url, store, _event_bus, _data_dir) = start_test_server().await;
     let parent_id = store
         .create_channel("eng2", None, ChannelType::Channel, None)
         .unwrap();

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -123,22 +123,17 @@ pub fn build_router_with_event_bus_and_dir(
 }
 
 /// Per-call unique tempdir so parallel cargo tests don't collide on
-/// `attachments/`, `agents/`, `teams/` under a shared path. The dir is
-/// leaked (no automatic cleanup) because callers don't carry a TempDir
-/// guard; `$TMPDIR` is reclaimed by the OS. Tests that need explicit
-/// cleanup should use the `_and_dir` variants with their own
-/// `tempfile::TempDir`.
+/// `attachments/`, `agents/`, `teams/` under a shared path. The returned
+/// path lives past the call: `keep()` consumes the `TempDir` wrapper
+/// and disables its Drop cleanup, returning the underlying `PathBuf`.
+/// `$TMPDIR` is reclaimed by the OS. Tests that need explicit cleanup
+/// should use the `_and_dir` variants with their own `tempfile::TempDir`.
 pub fn unique_test_data_dir() -> std::path::PathBuf {
-    let dir = tempfile::Builder::new()
+    tempfile::Builder::new()
         .prefix("chorus-test-")
         .tempdir()
-        .expect("create test data dir");
-    let path = dir.path().to_path_buf();
-    // Suppress Drop so the tempdir survives past this function. The OS
-    // reclaims `$TMPDIR` entries; tests run for seconds, fixtures don't
-    // accumulate meaningfully.
-    std::mem::forget(dir);
-    path
+        .expect("create test data dir")
+        .keep()
 }
 
 /// Test helper: silently insert a channel membership row without emitting

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -74,10 +74,7 @@ pub fn build_router_with_lifecycle(
     store: Arc<Store>,
     lifecycle: Arc<dyn AgentLifecycle>,
 ) -> Router {
-    let data_dir = std::env::temp_dir().join("chorus_test");
-    let agents_dir = data_dir.join("agents");
-    std::fs::create_dir_all(&agents_dir).ok();
-    build_router_with_lifecycle_and_dir(store, lifecycle, data_dir)
+    build_router_with_lifecycle_and_dir(store, lifecycle, unique_test_data_dir())
 }
 
 pub fn build_router_with_lifecycle_and_dir(
@@ -100,10 +97,14 @@ pub fn build_router_with_lifecycle_and_dir(
     )
 }
 
-pub fn build_router_with_event_bus(
+pub fn build_router_with_event_bus(store: Arc<Store>) -> (Router, Arc<EventBus>) {
+    build_router_with_event_bus_and_dir(store, unique_test_data_dir())
+}
+
+pub fn build_router_with_event_bus_and_dir(
     store: Arc<Store>,
+    data_dir: std::path::PathBuf,
 ) -> (Router, Arc<EventBus>) {
-    let data_dir = std::env::temp_dir().join("chorus_test");
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let event_bus = Arc::new(EventBus::new());
@@ -119,6 +120,25 @@ pub fn build_router_with_event_bus(
         vec![],
     );
     (router, event_bus)
+}
+
+/// Per-call unique tempdir so parallel cargo tests don't collide on
+/// `attachments/`, `agents/`, `teams/` under a shared path. The dir is
+/// leaked (no automatic cleanup) because callers don't carry a TempDir
+/// guard; `$TMPDIR` is reclaimed by the OS. Tests that need explicit
+/// cleanup should use the `_and_dir` variants with their own
+/// `tempfile::TempDir`.
+pub fn unique_test_data_dir() -> std::path::PathBuf {
+    let dir = tempfile::Builder::new()
+        .prefix("chorus-test-")
+        .tempdir()
+        .expect("create test data dir");
+    let path = dir.path().to_path_buf();
+    // Suppress Drop so the tempdir survives past this function. The OS
+    // reclaims `$TMPDIR` entries; tests run for seconds, fixtures don't
+    // accumulate meaningfully.
+    std::mem::forget(dir);
+    path
 }
 
 /// Test helper: silently insert a channel membership row without emitting

--- a/tests/realtime_tests.rs
+++ b/tests/realtime_tests.rs
@@ -17,7 +17,12 @@ struct TestIdentities {
     zoe_id: String,
 }
 
-async fn start_test_server() -> (String, Arc<Store>, TestIdentities, Arc<chorus::server::event_bus::EventBus>) {
+async fn start_test_server() -> (
+    String,
+    Arc<Store>,
+    TestIdentities,
+    Arc<chorus::server::event_bus::EventBus>,
+) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     let alice = store.create_local_human("alice").unwrap();
     let zoe = store.create_local_human("zoe").unwrap();

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -352,7 +352,7 @@ fn setup_with_runtime_statuses(
         statuses,
         models_by_runtime,
     });
-    let data_dir = std::env::temp_dir().join("chorus_test");
+    let data_dir = harness::unique_test_data_dir();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let router = chorus::server::build_router_with_services(
@@ -2146,9 +2146,13 @@ async fn test_upload_uses_configured_data_dir() {
         .expect("attachment record");
 
     assert!(
-        attachment
-            .stored_path
-            .starts_with(dir.path().join("data").join("attachments").to_string_lossy().as_ref()),
+        attachment.stored_path.starts_with(
+            dir.path()
+                .join("data")
+                .join("attachments")
+                .to_string_lossy()
+                .as_ref()
+        ),
         "attachment should be stored under the configured data dir"
     );
 }
@@ -2756,14 +2760,17 @@ async fn test_get_templates_returns_grouped_categories() {
     ];
 
     let dir = tempdir().unwrap();
-    let db_path = dir.path().join("chorus.db");
+    let db_path = dir.path().join("data").join("chorus.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
     let store = Arc::new(Store::open(db_path.to_str().unwrap()).unwrap());
     let lifecycle = Arc::new(MockLifecycle::default());
     let runtime_status_provider = Arc::new(MockRuntimeStatusProvider {
         statuses: vec![],
         models_by_runtime: vec![],
     });
-    let data_dir = std::env::temp_dir().join("chorus_test");
+    // Reuse the per-test tempdir for the data root so the templates test
+    // doesn't share filesystem state with parallel cargo runs.
+    let data_dir = dir.path().to_path_buf();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
     let router = chorus::server::build_router_with_services(

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -795,7 +795,8 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     assert!(!msg_id.is_empty());
 
     let bot1_id = store
@@ -827,7 +828,8 @@ fn test_send_and_receive_messages() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let msgs = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert_eq!(msgs.len(), 2);
 }
@@ -861,7 +863,8 @@ fn test_agent_does_not_receive_its_own_sent_message() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread = store.get_messages_for_agent_id(&bot1_id, false).unwrap();
     assert!(
@@ -893,7 +896,8 @@ fn test_message_history_pagination() {
                 suppress_event: false,
                 run_id: None,
             })
-            .map(|(id, _)| id).unwrap();
+            .map(|(id, _)| id)
+            .unwrap();
     }
 
     let (msgs, has_more) = store.get_history("general", 5, None, None).unwrap();
@@ -926,7 +930,8 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -937,7 +942,8 @@ fn test_history_snapshot_returns_messages_and_read_cursor() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let snapshot = store
         .get_history_snapshot("general", "alice", 10, None, None)
@@ -982,7 +988,8 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let second_top_level = store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -993,7 +1000,8 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let state_before = store
         .get_inbox_conversation_state("general", &bot1_id)
@@ -1091,7 +1099,8 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1102,7 +1111,8 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_before = store.get_unread_summary(&bot1_id).unwrap();
     assert_eq!(unread_before.get("general"), Some(&2));
@@ -1142,7 +1152,8 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1153,7 +1164,8 @@ fn test_history_read_cursor_rejects_seq_above_max() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, 999)
@@ -1184,7 +1196,8 @@ fn test_history_read_cursor_rejects_negative_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let err = store
         .set_history_read_cursor("general", "alice", SenderType::Human, -1)
@@ -1213,7 +1226,8 @@ fn test_history_read_cursor_heals_orphan_above_max_seq() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
     {
@@ -1253,7 +1267,8 @@ fn test_conversation_messages_view_projects_message_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let channel = store.get_channel_by_name("general").unwrap().unwrap();
 
     let conn = store.conn_for_test();
@@ -1390,7 +1405,8 @@ fn test_mark_agent_messages_deleted_marks_history_rows() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     store.mark_agent_messages_deleted("bot1").unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
@@ -1417,7 +1433,8 @@ fn test_create_message_persists_top_level() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     let (history, _) = store.get_history("general", 10, None, None).unwrap();
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].id, message_id);
@@ -1457,7 +1474,8 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_message(CreateMessage {
             channel_name: "general",
@@ -1468,7 +1486,8 @@ fn test_unread_excludes_own_messages_for_sender() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let channel_id = store
         .get_channel_by_name("general")
@@ -1564,7 +1583,8 @@ fn test_task_claim_and_status() {
         .unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["Task A"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     let (results, _events) = store
         .update_tasks_claim("eng", &bot1_id, SenderType::Agent, &[1])
@@ -1981,10 +2001,12 @@ fn test_delete_channel_removes_messages_tasks_and_memberships() {
             suppress_event: false,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_tasks("eng", &bot1_id, SenderType::Agent, &["ship it"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     store.delete_channel(&channel_id).unwrap();
 
@@ -2090,7 +2112,8 @@ fn test_channel_unread_count_excludes_system_messages() {
             run_id: None,
             suppress_event: false,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_before = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2103,7 +2126,8 @@ fn test_channel_unread_count_excludes_system_messages() {
     let channel_id = store.get_channel_by_name("general").unwrap().unwrap().id;
     store
         .create_system_message(&channel_id, "Team assembled.")
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let unread_after = store.get_unread_summary("alice").unwrap();
     assert_eq!(
@@ -2304,10 +2328,12 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
             suppress_event: true,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
     store
         .create_tasks("crew", "alice", SenderType::Human, &["ship"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
 
     // Agent receive — must skip the join chip but include alice's ping
     // and the task-event row.
@@ -2514,10 +2540,12 @@ fn claim_task_emits_claimed_event_to_parent_channel() {
 
     store
         .create_tasks("eng", "bob", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     let events: Vec<serde_json::Value> = store
         .conn_for_test()
@@ -2553,10 +2581,12 @@ fn unclaim_task_emits_unclaimed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     store
         .update_task_unclaim("eng", "alice", SenderType::Human, 1)
@@ -2594,10 +2624,12 @@ fn update_task_status_emits_status_changed_event() {
     join_channel_silent(&store, "eng", "alice", "human");
     store
         .create_tasks("eng", "alice", SenderType::Human, &["t"])
-        .map(|(tasks, _)| tasks).unwrap();
+        .map(|(tasks, _)| tasks)
+        .unwrap();
     store
         .update_tasks_claim("eng", "alice", SenderType::Human, &[1])
-        .map(|(results, _)| results).unwrap();
+        .map(|(results, _)| results)
+        .unwrap();
 
     store
         .update_task_status("eng", 1, "alice", SenderType::Human, TaskStatus::InReview)
@@ -2635,10 +2667,12 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
     store.ensure_human_with_id("bob", "bob").unwrap();
     store
         .join_channel_by_id(&sub_id, "alice", SenderType::Human)
-        .map(|(joined, _)| joined).unwrap();
+        .map(|(joined, _)| joined)
+        .unwrap();
     store
         .join_channel_by_id(&sub_id, "bob", SenderType::Human)
-        .map(|(joined, _)| joined).unwrap();
+        .map(|(joined, _)| joined)
+        .unwrap();
     // Bob's non-system message is unread for alice (the view excludes system
     // messages, so only human/agent traffic can produce a leak).
     store
@@ -2651,7 +2685,8 @@ fn get_unread_summary_excludes_archived_task_sub_channels() {
             suppress_event: true,
             run_id: None,
         })
-        .map(|(id, _)| id).unwrap();
+        .map(|(id, _)| id)
+        .unwrap();
 
     let before = store.get_unread_summary("alice").unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary

Stacks on top of #135 to fix the test-isolation regression I flagged in [my review](https://github.com/Fullstop000/Chorus/pull/135#pullrequestreview-…) (P1 finding) and document an intentional event drop in setup.

Three call sites hardcoded `std::env::temp_dir().join(\"chorus_test\")` as the test data dir, so cargo's parallel test runner shared `agents/`, `data/attachments/`, and `data/teams/` across every test. Old code (pre-DAO split) derived a unique `chorus-memory-<uuid>` per `Store::open(\":memory:\")`; the refactor moved that path into `AppState` without preserving isolation.

## Changes

**Test isolation (the actual fix):**
- `tests/harness/mod.rs`: add `unique_test_data_dir()` (per-call leaked tempdir) and a new `build_router_with_event_bus_and_dir(store, dir)` variant. The two no-arg helpers route through it.
- `tests/e2e_tests.rs`: `start_test_server` now creates and returns its own `TempDir`. The workspace test reads the agents path from the returned dir instead of hardcoding `chorus_test/agents`.
- `tests/server_tests.rs`: replace the two inline `chorus_test` constants with `harness::unique_test_data_dir()` and a per-test `tempdir()` for the templates test.

**Documentation:**
- `cli/setup.rs::ensure_setup_workspace`: comment explaining the dropped `StreamEvent` is correct here — `chorus setup` runs before any subscriber exists. Prevents the next refactor from \"fixing\" it incorrectly.

**Bundled `cargo fmt`:**
- 13 pre-existing files on `refactor/store-dao-separation` are unformatted, which would fail CI's `cargo fmt --check` gate. Bundling fmt here so this PR is mergeable; the original PR will pick up the formatting when this lands into it.

## Verification

- ✅ 344 lib tests pass
- ✅ 211 integration tests pass across 17 suites
- ✅ `cargo clippy --tests --lib -- -D warnings` clean
- ✅ `cargo fmt --check` clean

## Test plan

- [x] `cargo test --tests` passes locally
- [x] `cargo clippy --tests --lib -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] CI green on this branch
- [ ] Spot-check: `cargo test --test e2e_tests test_workspace_e2e` reads from the per-test tempdir, not `\$TMPDIR/chorus_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)