### PR TITLE
fix(kimi): require context.jsonl for session/load liveness (closes #140)

### DIFF
--- a/src/agent/drivers/acp_native/reader.rs
+++ b/src/agent/drivers/acp_native/reader.rs
@@ -195,18 +195,29 @@ pub(super) async fn handle_response(
         Some(id) => id,
         None => return,
     };
-    let error_msg: Option<String> = msg
-        .get("error")
-        .and_then(|e| e.get("message"))
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .or_else(|| {
-            if msg.get("error").is_some() {
-                Some("unknown ACP error".to_string())
-            } else {
-                None
+    let error_msg: Option<String> = msg.get("error").map(|err| {
+        let message = err
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown ACP error");
+        // Include `data` when present — pydantic-style validators (kimi,
+        // others) ship the actual rejection reason here, and surfacing
+        // only `message` ("Invalid params") drops the diagnostic that
+        // tells us *which* field was wrong. Cap the rendered length so a
+        // huge stack trace can't crowd out other log lines.
+        match err.get("data") {
+            Some(data) => {
+                let rendered = data.to_string();
+                let snippet = if rendered.len() > 1024 {
+                    format!("{}…", &rendered[..1024])
+                } else {
+                    rendered
+                };
+                format!("{message} ({snippet})")
             }
-        });
+            None => message.to_string(),
+        }
+    });
 
     let pending = shared.lock().unwrap().pending.remove(&id);
     let Some(pending) = pending else {

--- a/src/agent/drivers/kimi.rs
+++ b/src/agent/drivers/kimi.rs
@@ -144,16 +144,27 @@ fn spawn_kimi(spec: Arc<AgentSpec>, key: AgentKey) -> SpawnFut {
 // Session-file liveness guard
 // ---------------------------------------------------------------------------
 
-/// Find the kimi session-state file for `session_id`. Kimi stores per-session
-/// state under `~/.kimi/sessions/<workspace_hash>/<session_id>/state.json`,
-/// where `workspace_hash` is a 32-char hex of the working directory. We
-/// don't know the hash here, so glob across all workspace dirs and return
-/// the first match. None means the session is gone and `session/load`
-/// should be replaced with `session/new`.
+/// Find the kimi session file that proves this session can actually be
+/// resumed via `session/load`. Kimi stores per-session state under
+/// `~/.kimi/sessions/<workspace_hash>/<session_id>/`, where
+/// `workspace_hash` is a 32-char hex of the working directory.
 ///
-/// Mirrors the codex/opencode/claude file-existence pattern. Cost is one
-/// `read_dir` of `~/.kimi/sessions/` (typically <few hundred entries) plus
-/// one `is_file` per workspace until we find a match or exhaust.
+/// We must check for **`context.jsonl`** specifically, not `state.json`.
+/// Kimi's `Session.find` (`kimi_cli/session.py`) returns `None` —
+/// surfaced to the client as `{"session_id": "Session not found"}`
+/// inside an `Invalid params` error — when `context.jsonl` is missing,
+/// regardless of any other files in the session directory. `state.json`
+/// is written earlier in the session lifecycle, so checking it
+/// incorrectly says "alive" for sessions that were started but never
+/// completed their first turn (e.g., the trio agent that gets created
+/// and immediately stopped before its first prompt lands). A subsequent
+/// `session/load` then fails with "Invalid params", and the agent
+/// looks broken when the real fix is just to fall back to
+/// `session/new` instead.
+///
+/// Cost is one `read_dir` of `~/.kimi/sessions/` (typically <few
+/// hundred entries) plus one `is_file` per workspace until we find a
+/// match or exhaust.
 fn kimi_session_file(home: &Path, session_id: &str) -> Option<PathBuf> {
     let sessions_dir = home.join(".kimi").join("sessions");
     if !sessions_dir.is_dir() {
@@ -164,7 +175,7 @@ fn kimi_session_file(home: &Path, session_id: &str) -> Option<PathBuf> {
         if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
         }
-        let candidate = entry.path().join(session_id).join("state.json");
+        let candidate = entry.path().join(session_id).join("context.jsonl");
         if candidate.is_file() {
             return Some(candidate);
         }
@@ -295,7 +306,7 @@ mod tests {
     // ---- session-file liveness guard ----
 
     #[test]
-    fn kimi_session_file_finds_state_under_workspace_hash() {
+    fn kimi_session_file_finds_context_under_workspace_hash() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace_hash = "0749a6673832efdcb848ee54b8d3a625";
         let sid = "d6c7d632-ecdd-486a-96b1-df0091c6550d";
@@ -306,11 +317,11 @@ mod tests {
             .join(workspace_hash)
             .join(sid);
         std::fs::create_dir_all(&session_dir).unwrap();
-        let state = session_dir.join("state.json");
-        std::fs::write(&state, b"{}").unwrap();
+        let context = session_dir.join("context.jsonl");
+        std::fs::write(&context, b"").unwrap();
 
-        let found = kimi_session_file(tmp.path(), sid).expect("state.json should be found");
-        assert_eq!(found, state);
+        let found = kimi_session_file(tmp.path(), sid).expect("context.jsonl should be found");
+        assert_eq!(found, context);
     }
 
     #[test]
@@ -324,12 +335,34 @@ mod tests {
         let real_workspace = sessions.join("ffff");
         std::fs::create_dir_all(&real_workspace).unwrap();
         let sid = "real-session-uuid";
-        let state = real_workspace.join(sid).join("state.json");
-        std::fs::create_dir_all(state.parent().unwrap()).unwrap();
-        std::fs::write(&state, b"{}").unwrap();
+        let context = real_workspace.join(sid).join("context.jsonl");
+        std::fs::create_dir_all(context.parent().unwrap()).unwrap();
+        std::fs::write(&context, b"").unwrap();
 
-        let found = kimi_session_file(tmp.path(), sid).expect("state.json should be found");
-        assert_eq!(found, state);
+        let found = kimi_session_file(tmp.path(), sid).expect("context.jsonl should be found");
+        assert_eq!(found, context);
+    }
+
+    #[test]
+    fn kimi_session_file_returns_none_when_only_state_json_exists() {
+        // Regression for the bug fixed by this change: kimi 1.41 rejects
+        // `session/load` for sessions whose `context.jsonl` is missing,
+        // even when other files (like `state.json`) are present. The
+        // liveness probe must mirror kimi's `Session.find` criterion.
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = tmp
+            .path()
+            .join(".kimi")
+            .join("sessions")
+            .join("aabbcc")
+            .join("sid-only-state");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("state.json"), b"{}").unwrap();
+
+        assert!(
+            kimi_session_file(tmp.path(), "sid-only-state").is_none(),
+            "sessions with only state.json (no context.jsonl) must NOT be considered resumable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #140. The trio LLM smoke specs (MSG-001, MSG-002, MSG-004, ACT-002) were failing on \`kimi: session/load failed: Invalid params\` whenever the kimi-runtime bot in the trio had been spawned but stopped before its first turn completed. Root cause was a one-character mismatch between Chorus's liveness probe and kimi's actual resume criterion.

## Root cause

\`src/agent/drivers/kimi.rs::kimi_session_file\` checked for \`state.json\` under \`~/.kimi/sessions/<workspace_hash>/<session_id>/\`. Kimi's own \`Session.find\` (\`kimi_cli/session.py\`) requires \`context.jsonl\` at the same path — \`state.json\` is written earlier in the session lifecycle, so sessions that started but never completed their first turn have \`state.json\` present and \`context.jsonl\` absent.

Our probe said "alive" → driver sent \`session/load\` → kimi's \`_setup_session\` raised \`acp.RequestError.invalid_params({"session_id": "Session not found"})\` → Chorus surfaced just the message (\`Invalid params\`) and the agent failed to start.

## Fix

- \`src/agent/drivers/kimi.rs::kimi_session_file\` now checks \`context.jsonl\`. When absent, the existing fallback at \`handle.rs:183\` correctly switches to \`session/new\`.
- \`src/agent/drivers/acp_native/reader.rs\` widens the JSON-RPC error reporter to include the \`error.data\` payload (capped at 1KB). Without this, *any* Invalid-params response is opaque; surfacing \`data\` is what made this bug diagnosable in the first place.

## Verification

\`\`\`
$ cargo test --lib kimi
test result: ok. 13 passed; 0 failed
$ cargo test
test result: ok across the workspace; no adjacent regressions

$ CHORUS_E2E_LLM=1 npx playwright test \\
    ACT-002 MSG-001 MSG-002 MSG-004 --workers=1 --reporter=list
  ✓  ACT-002 (16.0s)
  ✓  MSG-001  (7.4s)
  ✓  MSG-002  (9.0s)
  ✓  MSG-004 (19.0s)
  4 passed (53.8s)
\`\`\`

Plus a Python probe sending Chorus's exact session/load params to a freshly spawned kimi 1.41 binary confirmed the underlying error before/after — \`{"data":{"session_id":"Session not found"}}\` was the actual rejection reason hidden behind \`Invalid params\`.

A new regression test \`kimi_session_file_returns_none_when_only_state_json_exists\` asserts the exact failure mode this commit closes.

## Test plan

- [ ] CI green (\`cargo test\`, \`cargo clippy\`, \`cargo fmt --check\`)
- [ ] \`cargo test --lib kimi\` 13/13 (includes new regression test)
- [ ] LLM smoke battery: \`CHORUS_E2E_LLM=1 npx playwright test ACT-002 MSG-001 MSG-002 MSG-004\` → 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)