### PR TITLE
refactor(lifecycle): start_agent takes &Agent

### DIFF
--- a/src/agent/lifecycle.rs
+++ b/src/agent/lifecycle.rs
@@ -4,11 +4,15 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::agent::activity_log::ActivityLogResponse;
+use crate::store::agents::Agent;
 use crate::store::messages::ReceivedMessage;
 
 pub trait AgentLifecycle: Send + Sync {
-    /// Start (or wake) an agent process by name. Resolves the agent
-    /// record from the store and dispatches to the id-keyed runtime.
+    /// Start (or wake) an agent process. Takes `&Agent` so the caller is
+    /// forced to hold the full record — this prevents "pass name where id
+    /// was expected" bugs at compile time, and consolidates the previous
+    /// dual entry points (`start_agent(name)` and `start_agent_from_record`)
+    /// into one signature.
     ///
     /// `wake_message` carries the unread message that triggered this start, if
     /// any. `init_directive`, when `Some`, is delivered as the first prompt
@@ -18,7 +22,7 @@ pub trait AgentLifecycle: Send + Sync {
     /// paths so existing behavior is unchanged.
     fn start_agent<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent: &'a Agent,
         wake_message: Option<ReceivedMessage>,
         init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -156,48 +156,23 @@ impl AgentManager {
     /// Start an agent process. Creates the workspace, writes `MEMORY.md`, and
     /// optionally threads through the message that caused the wake-up.
     ///
-    /// The core lifecycle (open_session + run) is now spawned as a background
+    /// Takes `&Agent` directly. The platform's HTTP path and the bridge's
+    /// reconcile path both arrive here with the full record in scope:
+    /// the platform loaded it via `store.get_agent(name)` to validate the
+    /// request, and the bridge constructs it from the wire `bridge.target`
+    /// payload. Forcing `&Agent` at the trait boundary collapses the two
+    /// previous entry points (`start_agent(name)` + `start_agent_from_record`)
+    /// and makes "pass name where id was expected" a compile error.
+    ///
+    /// The core lifecycle (open_session + run) is spawned as a background
     /// task so the caller (HTTP handler, message-delivery wake) returns
     /// immediately. `pre_starting` guards the window between insertion and
     /// the background task reaching `Starting`. Background mutations verify
-    /// handle identity via `Arc::ptr_eq` to avoid touching a newer agent that
-    /// reused the same name.
-    ///
-    /// Resolves `agent_name` against the store and dispatches the rest by id.
-    /// Most call sites already hold an agent record and should call
-    /// [`start_agent_from_record`] directly.
+    /// handle identity via `Arc::ptr_eq` to avoid touching a newer agent
+    /// that reused the same id.
     pub async fn start_agent(
         &self,
-        agent_name: &str,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> anyhow::Result<()> {
-        let agent = self
-            .store
-            .get_agent(agent_name)?
-            .ok_or_else(|| anyhow::anyhow!("Agent not found: {agent_name}"))?;
-        self.start_agent_inner(agent, wake_message, init_directive)
-            .await
-    }
-
-    /// Start an agent from a fully-materialized [`crate::store::agents::Agent`]
-    /// record without re-reading the store. Used by the bridge client so the
-    /// `bridge.target` payload can drive `start_agent` directly without first
-    /// going through SQLite as a cache. The resume path still reads
-    /// `agent_sessions` (keyed by `agent.id`); that table FKs to `agents(id)`
-    /// today, so the caller is responsible for ensuring the corresponding
-    /// row exists in the store. See #145 for the path to dropping that.
-    pub async fn start_agent_from_record(
-        &self,
-        agent: crate::store::agents::Agent,
-        init_directive: Option<String>,
-    ) -> anyhow::Result<()> {
-        self.start_agent_inner(agent, None, init_directive).await
-    }
-
-    async fn start_agent_inner(
-        &self,
-        agent: crate::store::agents::Agent,
+        agent: &crate::store::agents::Agent,
         wake_message: Option<ReceivedMessage>,
         init_directive: Option<String>,
     ) -> anyhow::Result<()> {
@@ -512,13 +487,13 @@ impl AgentManager {
 
         // Asleep / not-yet-running / mid-startup: deliver the envelope as
         // the init directive so it lands on the agent's first prompt turn.
-        // Look up the full record by id and dispatch via start_agent_inner —
-        // the bridge / platform both have the row keyed by id at this point.
+        // Look up the full record by id and dispatch via start_agent — the
+        // bridge / platform both have the row keyed by id at this point.
         let agent = self
             .store
             .get_agent_by_id(agent_id, true)?
             .ok_or_else(|| anyhow::anyhow!("Agent not found by id: {agent_id}"))?;
-        self.start_agent_inner(agent, None, Some(envelope)).await
+        self.start_agent(&agent, None, Some(envelope)).await
     }
 
     /// Deliver a wakeup notification to agent stdin.
@@ -754,13 +729,13 @@ fn build_start_prompt(
 impl AgentLifecycle for AgentManager {
     fn start_agent<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent: &'a crate::store::agents::Agent,
         wake_message: Option<ReceivedMessage>,
         init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(AgentManager::start_agent(
             self,
-            agent_name,
+            agent,
             wake_message,
             init_directive,
         ))
@@ -930,11 +905,12 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
-        let result = manager.start_agent("v2bot", None, None).await;
+        let result = manager.start_agent(&agent, None, None).await;
 
         assert!(result.is_ok(), "start_agent should succeed: {result:?}");
 
@@ -958,11 +934,12 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None, None).await.unwrap();
+        manager.start_agent(&agent, None, None).await.unwrap();
 
         // First stop should succeed.
         let r1 = manager.stop_agent(&agent_id).await;
@@ -984,11 +961,12 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store.clone(), dir.path());
 
-        manager.start_agent("v2bot", None, None).await.unwrap();
+        manager.start_agent(&agent, None, None).await.unwrap();
 
         manager.sleep_agent(&agent_id).await.unwrap();
 
@@ -1010,14 +988,15 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None, None).await.unwrap();
+        manager.start_agent(&agent, None, None).await.unwrap();
 
         // Second start should be a no-op (returns Ok).
-        let r2 = manager.start_agent("v2bot", None, None).await;
+        let r2 = manager.start_agent(&agent, None, None).await;
 
         assert!(r2.is_ok(), "duplicate start should be no-op: {r2:?}");
 
@@ -1029,11 +1008,12 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
-        manager.start_agent("v2bot", None, None).await.unwrap();
+        manager.start_agent(&agent, None, None).await.unwrap();
 
         let result = manager.notify_agent(&agent_id).await;
         assert!(result.is_ok(), "notify should succeed: {result:?}");
@@ -1135,7 +1115,8 @@ mod tests {
                 env_vars: &[],
             })
             .unwrap();
-        let agent_id = store.get_agent("recovery-bot").unwrap().unwrap().id;
+        let agent = store.get_agent("recovery-bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
@@ -1158,7 +1139,7 @@ mod tests {
 
         // Before the fix this returned Ok(()) immediately (contains_key hit).
         // After the fix it must evict and restart.
-        let result = manager.start_agent("recovery-bot", None, None).await;
+        let result = manager.start_agent(&agent, None, None).await;
         assert!(
             result.is_ok(),
             "start_agent should succeed after evicting a Failed handle: {result:?}",
@@ -1209,7 +1190,8 @@ mod tests {
                 env_vars: &[],
             })
             .unwrap();
-        let agent_id = store.get_agent("live-bot").unwrap().unwrap().id;
+        let agent = store.get_agent("live-bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
 
         let manager = make_test_manager(store, dir.path());
 
@@ -1224,7 +1206,7 @@ mod tests {
             .inject_session_for_test(agent_id.clone(), "live-bot", Box::new(active_handle))
             .await;
 
-        let result = manager.start_agent("live-bot", None, None).await;
+        let result = manager.start_agent(&agent, None, None).await;
         assert!(
             result.is_ok(),
             "start_agent on an Active agent should be Ok: {result:?}",
@@ -1254,7 +1236,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let store = Arc::new(Store::open(dir.path().join("chorus.db").to_str().unwrap()).unwrap());
         insert_codex_agent(&store);
-        let agent_id = store.get_agent("v2bot").unwrap().unwrap().id;
+        let agent = store.get_agent("v2bot").unwrap().unwrap();
+        let agent_id = agent.id.clone();
         let manager = make_test_manager(store, dir.path());
 
         let (events, event_tx) = EventFanOut::new();
@@ -1274,7 +1257,7 @@ mod tests {
             );
         }
 
-        let result = manager.start_agent("v2bot", None, None).await;
+        let result = manager.start_agent(&agent, None, None).await;
         assert!(
             result.is_ok(),
             "start_agent should skip eviction when pre_starting is set: {result:?}"

--- a/src/bridge/client/reconcile.rs
+++ b/src/bridge/client/reconcile.rs
@@ -34,8 +34,8 @@ pub struct ReconcileOutcome {
 /// Materialise an `AgentTargetIn` (wire payload) into an `Agent` (store
 /// row shape) without touching SQLite. The non-wire fields (`workspace_id`,
 /// `created_at`, `machine_id`) are filled with placeholders since the
-/// bridge does not consume them — `start_agent_from_record` reads only
-/// the fields the runtime spec needs.
+/// bridge does not consume them — `start_agent` reads only the fields
+/// the runtime spec needs.
 pub(super) fn target_to_agent(target: &AgentTargetIn) -> Agent {
     Agent {
         id: target.agent_id.clone(),
@@ -107,7 +107,7 @@ pub async fn apply(
         }
         let agent = target_to_agent(target);
         match manager
-            .start_agent_from_record(agent, target.init_directive.clone())
+            .start_agent(&agent, None, target.init_directive.clone())
             .await
         {
             Ok(()) => {

--- a/src/bridge/client/ws.rs
+++ b/src/bridge/client/ws.rs
@@ -533,7 +533,7 @@ async fn handle_chat(ctx: &SessionCtx, payload: ChatMessageReceived) {
             // Wake the agent. The cached target was captured above so the
             // manager doesn't need to re-read the store.
             let agent = super::reconcile::target_to_agent(&target_clone);
-            let r = ctx.manager.start_agent_from_record(agent, None).await;
+            let r = ctx.manager.start_agent(&agent, None, None).await;
             if r.is_ok() {
                 let pid = ctx.counter.allocate(agent_id).await;
                 send_agent_state(&ctx.state_tx, agent_id, "started", pid).await;

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -432,16 +432,24 @@ pub(crate) async fn create_and_start_agent(
             "create_and_start_agent: bridge-hosted, skipping platform-side start"
         );
         None
-    } else if let Err(err) = state
-        .lifecycle
-        .start_agent(&name, None, intro_directive)
-        .await
-    {
-        let error_detail = format_anyhow_error(&err);
-        warn!(agent = %name, error = %error_detail, "agent created but failed to start");
-        Some(format!("{err}"))
     } else {
-        None
+        // Reload with env_vars hydrated — the runtime spec inside `start_agent`
+        // reads them off the record we hand in.
+        let agent = state
+            .store
+            .get_agent_by_id(&id, true)?
+            .ok_or_else(|| anyhow::anyhow!("agent vanished after create: {id}"))?;
+        if let Err(err) = state
+            .lifecycle
+            .start_agent(&agent, None, intro_directive)
+            .await
+        {
+            let error_detail = format_anyhow_error(&err);
+            warn!(agent = %name, error = %error_detail, "agent created but failed to start");
+            Some(format!("{err}"))
+        } else {
+            None
+        }
     };
     Ok(CreateAgentResult {
         name,
@@ -534,7 +542,10 @@ pub async fn handle_update_agent(
             .stop_agent(&agent_id)
             .await
             .map_err(internal_err)?;
-        if let Err(err) = state.lifecycle.start_agent(&name, None, None).await {
+        // Reload after the update so spec changes (env_vars, model, runtime)
+        // take effect on the restart.
+        let refreshed = resolve_public_agent_with_env(&state, &existing.id)?;
+        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
             return Err(app_err!(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "agent updated but restart failed: {err}"
@@ -591,7 +602,10 @@ pub async fn handle_restart_agent(
     }
 
     if !bridge_hosted {
-        if let Err(err) = state.lifecycle.start_agent(&name, None, None).await {
+        // Reload after RestartMode::ResetSession / FullReset so the start
+        // sees post-clear state for env_vars/spec lookups.
+        let refreshed = resolve_public_agent_with_env(&state, &agent.id)?;
+        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
             return Err(app_err!(
                 AppErrorCode::AgentRestartFailed,
                 "restart failed: {err}"
@@ -657,23 +671,25 @@ pub async fn handle_agent_start(
     State(state): State<AppState>,
     Path(PublicResourceIdPath { id }): Path<PublicResourceIdPath>,
 ) -> ApiResult<serde_json::Value> {
-    let agent = resolve_public_agent(&state, &id)?;
-    let name = agent.name;
-    let _transition = acquire_transition(&state, &name)?;
+    // Hydrate env_vars: start_agent now reads the spec directly off the
+    // record we pass in, so the lookup happens here rather than inside
+    // the manager.
+    let agent = resolve_public_agent_with_env(&state, &id)?;
+    let _transition = acquire_transition(&state, &agent.name)?;
     if agent.machine_id.is_some() {
         // Bridge-hosted: the bridge already keeps the runtime alive per
         // target. Re-broadcast so any reconnected bridge picks it up.
-        info!(agent = %name, "agent is bridge-hosted; refreshing target");
+        info!(agent = %agent.name, "agent is bridge-hosted; refreshing target");
         broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
         return Ok(Json(serde_json::json!({ "ok": true })));
     }
-    info!(agent = %name, "starting agent");
+    info!(agent = %agent.name, "starting agent");
     state
         .lifecycle
-        .start_agent(&name, None, None)
+        .start_agent(&agent, None, None)
         .await
         .map_err(internal_err)?;
-    info!(agent = %name, "agent started");
+    info!(agent = %agent.name, "agent started");
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -868,7 +868,7 @@ pub(crate) async fn deliver_message_to_agents(
                     .get_received_message_for_agent_name(&recipient_name, message_id)?;
                 state
                     .lifecycle
-                    .start_agent(&recipient_name, wake_message, None)
+                    .start_agent(&agent, wake_message, None)
                     .await?
             }
         }

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -102,13 +102,11 @@ async fn restart_agent_member(
     state: &AppState,
     agent_name: &str,
 ) -> Result<(), (axum::http::StatusCode, Json<super::ErrorResponse>)> {
-    let bridge_hosted = state
-        .store
-        .get_agent(agent_name)
-        .map_err(internal_err)?
-        .and_then(|a| a.machine_id)
-        .is_some();
-    if bridge_hosted {
+    let agent = match state.store.get_agent(agent_name).map_err(internal_err)? {
+        Some(a) => a,
+        None => return Ok(()),
+    };
+    if agent.machine_id.is_some() {
         crate::server::transport::bridge_ws::broadcast_target_update(
             state.store.as_ref(),
             state.bridge_registry.as_ref(),
@@ -117,12 +115,12 @@ async fn restart_agent_member(
     }
     state
         .lifecycle
-        .stop_agent(agent_name)
+        .stop_agent(&agent.id)
         .await
         .map_err(internal_err)?;
     state
         .lifecycle
-        .start_agent(agent_name, None, None)
+        .start_agent(&agent, None, None)
         .await
         .map_err(internal_err)?;
     Ok(())

--- a/tests/agent_status_derivation_tests.rs
+++ b/tests/agent_status_derivation_tests.rs
@@ -33,39 +33,40 @@ struct MockLifecycle {
 impl AgentLifecycle for MockLifecycle {
     fn start_agent<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent: &'a chorus::store::agents::Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        let id = agent.id.clone();
         Box::pin(async move {
-            self.running.lock().unwrap().insert(agent_name.to_string());
+            self.running.lock().unwrap().insert(id);
             Ok(())
         })
     }
 
     fn notify_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent_id: &'a str,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }
 
     fn stop_agent<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent_id: &'a str,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async move {
-            self.running.lock().unwrap().remove(agent_name);
+            self.running.lock().unwrap().remove(agent_id);
             Ok(())
         })
     }
 
     fn process_state<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent_id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Option<chorus::agent::drivers::ProcessState>> + Send + 'a>>
     {
-        let is_running = self.running.lock().unwrap().contains(agent_name);
+        let is_running = self.running.lock().unwrap().contains(agent_id);
         Box::pin(async move {
             if is_running {
                 Some(chorus::agent::drivers::ProcessState::Active {

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -74,7 +74,7 @@ struct NoopLifecycle;
 impl AgentLifecycle for NoopLifecycle {
     fn start_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent: &'a chorus::store::agents::Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -12,6 +12,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::server::bridge_auth::BridgeAuth;
 use chorus::server::event_bus::EventBus;
 use chorus::server::{build_router_with_services, build_router_with_services_and_auth};
+use chorus::store::agents::Agent;
 use chorus::store::messages::ReceivedMessage;
 use chorus::store::Store;
 use rusqlite::params;
@@ -21,7 +22,7 @@ pub struct NoopLifecycle;
 impl AgentLifecycle for NoopLifecycle {
     fn start_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent: &'a Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -107,7 +107,7 @@ struct NoopLifecycle;
 impl AgentLifecycle for NoopLifecycle {
     fn start_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent: &'a chorus::store::agents::Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -97,7 +97,7 @@ struct NoopLifecycle;
 impl AgentLifecycle for NoopLifecycle {
     fn start_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent: &'a chorus::store::agents::Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -225,17 +225,17 @@ impl MockLifecycle {
 impl AgentLifecycle for MockLifecycle {
     fn start_agent<'a>(
         &'a self,
-        agent_name: &'a str,
+        agent: &'a chorus::store::agents::Agent,
         wake_message: Option<ReceivedMessage>,
         init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        let name = agent.name.clone();
         Box::pin(async move {
-            self.started.lock().unwrap().push((
-                agent_name.to_string(),
-                wake_message,
-                init_directive,
-            ));
-            self.running.lock().unwrap().insert(agent_name.to_string());
+            self.started
+                .lock()
+                .unwrap()
+                .push((name.clone(), wake_message, init_directive));
+            self.running.lock().unwrap().insert(name);
             Ok(())
         })
     }
@@ -317,7 +317,7 @@ impl AgentLifecycle for MockLifecycle {
 impl AgentLifecycle for FailStartLifecycle {
     fn start_agent<'a>(
         &'a self,
-        _agent_name: &'a str,
+        _agent: &'a chorus::store::agents::Agent,
         _wake_message: Option<ReceivedMessage>,
         _init_directive: Option<String>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {


### PR DESCRIPTION
## Summary

- `AgentLifecycle::start_agent` flips from `agent_name: &str` to `agent: &Agent`. Forces callers to hold the full record at compile time, eliminating the "pass name where id was expected" bug class for this method (the same class /qa caught in #147).
- `start_agent_from_record` removed. The two entry points were doing the same thing through different signatures; one canonical call site now.
- `start_agent_inner` folded back into `start_agent` (the helper existed only to share code between the two entry points).
- `resume_with_prompt`'s asleep-path loads the record by id and dispatches via the new `start_agent(&agent, ...)`.

## Why this and not flipping the rest of the trait too

The user pointed at four methods in the trait that "still pass agent_name": `start_agent`, `get_activity_log_data`, `active_run_id`, `run_channel_id`. The first is genuinely id-keyed internally but had a leftover name signature (this PR). The other three wrap stores that are still name-keyed and feed a wire `TraceEvent.agent_name` field consumed by the UI — flipping them is a coordinated server+UI change. Tracked as PR B follow-up.

The other already-id-keyed methods (`stop_agent`, `notify_agent`, `process_state`) stay as `&str` for now. They could also flip to `&Agent` for full consistency, but the bridge fast paths (`agent_state_pusher`, reconcile stop loop) only have agent_id in scope and would need to materialize records on every poll — small but unwanted churn. Keeping them as `&str id` and limiting the type-safety win to `start_agent` (where the record is genuinely needed for the spec) keeps this PR focused.

## Caller updates

| Site | Change |
| --- | --- |
| `handlers/agents.rs::handle_create_agent` (via `create_and_start_agent`) | reload after insert with env_vars hydrated |
| `handlers/agents.rs::handle_update_agent` | reload after update so spec changes apply on restart |
| `handlers/agents.rs::handle_restart_agent` | reload after `ResetSession`/`FullReset` |
| `handlers/agents.rs::handle_agent_start` | use `resolve_public_agent_with_env` instead of name lookup |
| `handlers/messages.rs` deliver-to-agent | pass already-loaded `&agent` |
| `handlers/teams.rs::restart_agent_member` | one store lookup, reuse for stop+start |
| `bridge/client/reconcile.rs` | pass `&agent` built from cached target |
| `bridge/client/ws.rs::handle_chat` | same |

## Test plan

- [x] `cargo test` (600+ tests) — green
- [x] `cargo clippy --tests --all-targets -- -D warnings` — clean
- [x] `qa/cases/playwright` smoke (21 specs incl. LFC-001) — green
  - MSG-006 flaked once under parallel run, passed on retry — same flake we hit on #147; not introduced by this change
- [x] BRG-001/002/003 (`cargo test --test bridge_serve_tests`) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)