### PR TITLE
Phase 1: always-set machine_id; backfill NULL rows

### DIFF
--- a/docs/plan/collapse-dual-runtime-path.md
+++ b/docs/plan/collapse-dual-runtime-path.md
@@ -1,0 +1,209 @@
+# Collapse the dual runtime path — every agent bridge-owned
+
+Tracking issue: [#149](https://github.com/Fullstop000/Chorus/issues/149).
+Built on: [#147](https://github.com/Fullstop000/Chorus/pull/147) (id-keyed AgentManager).
+
+---
+
+## Goal
+
+`chorus serve` stops being a runtime owner. Every agent — local or remote —
+is owned by a bridge client that reconciles desired state from
+`bridge.target` frames. The platform's only job becomes: persist agents,
+broadcast targets, route chats. Handlers no longer branch on
+`agent.machine_id.is_some()`.
+
+Outcome: one ownership rule ("every agent has exactly one owner: a bridge
+client"), one start/stop code path, the wrong-key-to-lifecycle bug class
+(#147) becomes structurally impossible because handlers don't call
+lifecycle methods.
+
+## Non-goals
+
+- Cross-machine deployments. Single-machine `chorus serve` stays the
+  default; the in-process bridge client is what powers it.
+- Reworking the bridge wire protocol. We re-use `bridge.target`,
+  `chat.message.received`, `agent.state` as-is.
+- Replacing `AgentManager`. It moves under bridge ownership unchanged.
+- Tearing out the activity-log / trace observability surface. That
+  stays where it is — only the lifecycle methods move.
+
+## End state
+
+```
+                      ┌───────────────────┐
+   chorus serve  ───► │ HTTP server       │  store + broadcast_target_update
+                      └────────┬──────────┘
+                               │ ws://127.0.0.1:<port>/api/bridge/ws
+                      ┌────────▼──────────┐
+                      │ in-proc bridge    │  reconcile → AgentManager
+                      │ client            │  (the only AgentManager in serve)
+                      └────────┬──────────┘
+                               │ stdio / acp / mcp
+                          [ agents ]
+```
+
+Bridge clients are interchangeable: the in-process one boots inside
+`chorus serve`, remote ones boot from `chorus bridge`. Both speak the
+same WS frames against the same `/api/bridge/ws` endpoint.
+
+## Phases
+
+Each phase is a separately mergeable PR that keeps the tree green.
+
+### Phase 1 — `local_machine_id` is real
+
+**Why first:** the rest of the plan depends on every agent row having
+a non-NULL `machine_id`. Doing this without the runtime flip lets us
+land the migration and the config plumbing without touching handlers.
+
+- `ChorusConfig::machine_id` becomes mandatory; serve generates one on
+  first run and writes it to `config.toml` (we already write `machine_id`
+  there optionally — flip it to required + auto-fill).
+- Migration at startup: `UPDATE agents SET machine_id = ?1 WHERE
+  machine_id IS NULL` keyed by the local id.
+- Handler `create_and_start_agent`: when the request omits `machine_id`,
+  fill with `state.local_machine_id`. Behavior unchanged — local agents
+  still take the `start_agent` branch — but every row now has a value.
+
+Verification: `cargo test`, manual smoke (create agent, restart serve,
+verify rows have machine_id).
+
+### Phase 2 — In-process bridge client wired into `chorus serve`
+
+**Why:** prove the bridge client can drive lifecycle for the local
+machine before we ask handlers to trust it.
+
+- `chorus serve` spawns a bridge client (`run_bridge_client`) on
+  startup with `local_machine_id`, dialing its own
+  `ws://127.0.0.1:<port>/api/bridge/ws`.
+- `AgentManager` ownership moves: the platform's `AppState.lifecycle`
+  still points at the same manager instance for now (so the dual path
+  still works), but the bridge client gets a *handle* to that same
+  manager rather than constructing a second one. One manager, two
+  callers, both id-keyed.
+- Boot order: bridge client must be ready to receive `bridge.target`
+  before HTTP accepts external traffic, otherwise the first
+  `POST /api/agents` broadcasts to nobody. Either (a) start the HTTP
+  server, then have the bridge client connect, then run a one-shot
+  initial reconcile by re-broadcasting all current agents; or (b)
+  delay accepting external requests until the bridge client emits
+  `bridge.hello`. Going with (a) — simpler, same final state.
+
+Verification: with the bridge client live, manually trigger an agent
+create and confirm `bridge.target` reaches the in-process client and
+`agent.state{started}` comes back. Existing tests still pass because
+handlers still use the direct path.
+
+### Phase 3 — Handlers stop calling lifecycle methods
+
+**This is the load-bearing flip.** Six call sites in `agents.rs`, one
+in `messages.rs::deliver_message_to_agents`, one in `decisions.rs`.
+
+- Drop the `if params.machine_id.is_some() { skip } else { start }`
+  shape. Always: insert/update row → `broadcast_target_update`. Never
+  call `lifecycle.start_agent` / `stop_agent` / `notify_agent` from
+  the handler.
+- `deliver_message_to_agents`: remove the `machine_id.is_some()`
+  early-continue. Always emit `chat.message.received` for any agent
+  with subscribers — the bridge client decides whether to wake.
+- `resume_with_prompt`: the tight-loop synchronous case becomes
+  asynchronous. Persist the envelope as a pending `init_directive`
+  on the `agents` row (new column, or piggyback on an existing
+  per-agent state field). Bridge client picks it up on next
+  reconcile and either pipes to live session or starts the agent
+  with that directive. The decision handler returns 202 Accepted;
+  UI watches the realtime stream for confirmation.
+
+HTTP API contract change: `POST /api/agents` returns 202 with
+`status: "pending"` instead of 200/`start_error`. UI updates required
+in same PR. (If we want to stage this, we can keep returning 200 with
+no `start_error` field while the UI catches up — flip to 202 in a
+follow-up.)
+
+Verification: full Playwright smoke (`qa/cases/playwright`), MSG-001
+through MSG-006 with real LLMs (CHORUS_E2E_LLM=1), the same set we ran
+for #147. Add a dedicated Playwright case that verifies the agent
+lifecycle path under network drop of the bridge client.
+
+### Phase 4 — `AgentLifecycle` trait shrinks to observability
+
+- Trait keeps: `get_activity_log_data`, `get_all_agent_activity_states`,
+  `active_run_id`, `set_run_channel`, `run_channel_id`,
+  `process_state` (read-only inspection).
+- Trait drops: `start_agent`, `stop_agent`, `notify_agent`,
+  `resume_with_prompt`. These move to bridge-client-internal APIs.
+- `AppState.lifecycle` becomes `AppState.observability` (or splits in
+  two). Handlers only use it to render activity feeds and runtime
+  status badges.
+- `MockLifecycle` in tests becomes `MockObservability`; tests that
+  verified "lifecycle.start_agent was called" become "verify a
+  `bridge.target` was broadcast with the expected agent". Largest
+  test refactor of the plan — but mechanical.
+
+Verification: `cargo test`, `cargo test --test e2e_tests`, `cd ui &&
+npm run test`.
+
+### Phase 5 — Cleanup
+
+- Delete the `if machine_id.is_some()` dead code paths and their
+  comments.
+- Delete `AppState.transitioning_agents` if the bridge client now owns
+  per-agent transition serialization (it already does via the WS frame
+  ordering — we just need to confirm the same `CONFLICT` UX still works
+  for double-clicks; if not, keep the guard).
+- Update `docs/BRIDGE_MIGRATION.md` and `docs/plan/bridge-platform-protocol.md`
+  to mark this work done and document "the in-process bridge client is
+  not a special case, it's the only client `chorus serve` ships with".
+
+## Decisions to lock before phase 1
+
+These are the questions whose answers shape the plan. I have leanings,
+none are settled.
+
+| Decision | Lean | Why |
+|---|---|---|
+| In-process bridge client speaks WS to localhost vs. in-memory channel | **WS** | Free integration coverage on every `chorus serve`; the WS hop is loopback so cost is negligible. Issue #149 explicitly recommends this. |
+| `resume_with_prompt` — persist as pending `init_directive` column vs. broadcast a one-shot frame | **Column** | Survives bridge client reconnect; doesn't require a new frame type; matches existing `init_directive` shape on creation. |
+| `POST /api/agents` 200/`start_error` → 202/`pending` in same PR or staged | **Same PR (Phase 3)** | The UI is in the same repo; staging adds shim code that immediately becomes dead. Easier to land + revert as one unit. |
+| `local_machine_id` source — generate fresh UUID vs. derive from hostname | **Generate UUID, persist in config.toml** | Hostname collisions across machines (laptops named `mbp.local`) would be silent and weird; UUID is unambiguous. |
+| Migrate NULL machine_id rows in place vs. require manual reset | **In place at startup** | Existing dev DBs would otherwise need explicit attention; the migration is a single UPDATE keyed off the local id. |
+
+## Risks
+
+- **Boot order race.** First request after start must not broadcast to
+  a missing client. Mitigated by initial reconcile after bridge client
+  connects (Phase 2 design).
+- **Test surface.** ~30+ tests use `MockLifecycle`. Phase 4 is the bulk
+  of the test refactor; if we discover a class of test that resists the
+  flip, we may need an in-test "synthetic bridge" helper.
+- **Decision flow latency.** Today `resume_with_prompt` is synchronous;
+  the bridge round-trip adds ~5–20ms typical, more under contention. UX
+  on `Resolve` button changes from instant to "spinner for a beat".
+  Acceptable, but worth verifying with QA.
+- **`stop_agent` ordering.** Today the handler stops the agent then
+  deletes the row. Under the new flow we delete the row, broadcast,
+  bridge client stops it. If the platform crashes between row delete
+  and broadcast, the bridge client never learns to stop — orphaned
+  process. Mitigation: bridge client treats "running but not in target"
+  as stop signal on every reconcile (already true in `reconcile.rs`).
+
+## Success criteria
+
+- Zero call sites of `lifecycle.start_agent` / `stop_agent` /
+  `notify_agent` / `resume_with_prompt` in `src/server/handlers/`.
+- Zero `if machine_id.is_some()` branches in `src/server/handlers/`.
+- `agents.machine_id` is `NOT NULL` (schema-enforced).
+- Full Playwright smoke + LLM-gated MSG suite green on a single PR
+  representing the merged phases.
+- `chorus bridge` (the standalone binary) and `chorus serve` (the
+  in-process one) share 100% of their lifecycle code path.
+
+## What this is not committing to yet
+
+- The exact PR boundaries between phases — phases are the natural
+  break points but we may bundle 4+5 together if the test refactor is
+  small.
+- The exact `AppState.lifecycle` rename or split. Phase 4 will reveal
+  whether one trait or two reads better.
+- Whether `AppState.transitioning_agents` survives. Decided in Phase 5.

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -267,11 +267,16 @@ pub async fn handle_create_agent(
     let env_vars = normalize_agent_env_vars(&req.env_vars)?;
 
     // Create the agent record, join auto-join channels, and start it.
-    let machine_id_trimmed = req
+    // Default an omitted/blank machine_id to the local installation's id
+    // so every row has a non-NULL owner. Phase 2's in-process bridge
+    // client picks these up by matching on `local_machine_id`.
+    let machine_id_resolved: String = req
         .machine_id
         .as_deref()
         .map(str::trim)
-        .filter(|s| !s.is_empty());
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| state.local_machine_id.clone());
     let result = create_and_start_agent(
         &state,
         &CreateAgentParams {
@@ -282,7 +287,7 @@ pub async fn handle_create_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: machine_id_trimmed,
+            machine_id: Some(&machine_id_resolved),
             env_vars: &env_vars,
         },
     )
@@ -420,11 +425,12 @@ pub(crate) async fn create_and_start_agent(
             ch = crate::store::Store::DEFAULT_SYSTEM_CHANNEL,
         )
     });
-    // Bridge-hosted agents (`machine_id` set) are started by the remote
-    // bridge after the platform pushes a `bridge.target` update. The
-    // platform must NOT spawn them locally — doing so causes dual-runtime
-    // contention on the same agent session.
-    let start_error = if params.machine_id.is_some() {
+    // Bridge-hosted = `machine_id` differs from the local installation's id.
+    // Those agents are started by a remote bridge after the platform pushes
+    // a `bridge.target` update; the platform must NOT spawn them locally,
+    // or both runtimes contend on the same ACP session.
+    let bridge_hosted = params.machine_id != Some(state.local_machine_id.as_str());
+    let start_error = if bridge_hosted {
         info!(
             agent = %name,
             machine_id = %params.machine_id.unwrap_or(""),
@@ -507,11 +513,18 @@ pub async fn handle_update_agent(
         || existing.reasoning_effort != reasoning_effort
         || existing.env_vars != env_vars;
 
-    let machine_id_trimmed = req
+    // Preserve the existing owner when the request omits `machineId`.
+    // Without this, every PATCH would clobber `machine_id` to NULL — a
+    // bridge-hosted agent renamed via the UI (which doesn't echo
+    // `machineId` back) would silently lose its owner.
+    let machine_id_resolved: String = req
         .machine_id
         .as_deref()
         .map(str::trim)
-        .filter(|s| !s.is_empty());
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| existing.machine_id.clone())
+        .unwrap_or_else(|| state.local_machine_id.clone());
     state
         .store
         .update_agent_record(&AgentRecordUpsert {
@@ -522,7 +535,7 @@ pub async fn handle_update_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: machine_id_trimmed,
+            machine_id: Some(&machine_id_resolved),
             env_vars: &env_vars,
         })
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
@@ -533,8 +546,12 @@ pub async fn handle_update_agent(
 
     // Bridge-hosted agents are restarted by the remote bridge when it
     // receives the broadcast target update below. The platform does not
-    // own the runtime process and must not call start/stop.
-    let bridge_hosted = machine_id_trimmed.is_some();
+    // own the runtime process and must not call start/stop. "Bridge-hosted"
+    // here means "owned by a non-local machine_id"; agents with
+    // machine_id == local_machine_id still go through the platform's
+    // in-process AgentManager until Phase 2 swaps it for the in-process
+    // bridge client.
+    let bridge_hosted = machine_id_resolved != state.local_machine_id;
     if was_running && requires_restart && !bridge_hosted {
         state
             .lifecycle
@@ -569,7 +586,10 @@ pub async fn handle_restart_agent(
     let agents_dir = state.agents_dir.clone();
     let workspace = AgentWorkspace::new(&agents_dir);
 
-    let bridge_hosted = agent.machine_id.is_some();
+    let bridge_hosted = agent
+        .machine_id
+        .as_deref()
+        .is_some_and(|m| m != state.local_machine_id.as_str());
     if !bridge_hosted {
         state
             .lifecycle
@@ -634,7 +654,11 @@ pub async fn handle_delete_agent(
     // the next `bridge.target` (broadcast below after the row delete) drops
     // the agent from the desired set. Calling stop_agent here is a no-op
     // locally but adds noise to the activity log.
-    if agent.machine_id.is_none() {
+    let bridge_hosted = agent
+        .machine_id
+        .as_deref()
+        .is_some_and(|m| m != state.local_machine_id.as_str());
+    if !bridge_hosted {
         state
             .lifecycle
             .stop_agent(&agent.id)
@@ -675,7 +699,11 @@ pub async fn handle_agent_start(
     // the manager.
     let agent = resolve_public_agent_with_env(&state, &id)?;
     let _transition = acquire_transition(&state, &agent.id)?;
-    if agent.machine_id.is_some() {
+    let bridge_hosted = agent
+        .machine_id
+        .as_deref()
+        .is_some_and(|m| m != state.local_machine_id.as_str());
+    if bridge_hosted {
         // Bridge-hosted: the bridge already keeps the runtime alive per
         // target. Re-broadcast so any reconnected bridge picks it up.
         info!(agent = %agent.name, "agent is bridge-hosted; refreshing target");
@@ -699,7 +727,11 @@ pub async fn handle_agent_stop(
     let agent = resolve_public_agent(&state, &id)?;
     let name = agent.name.clone();
     let _transition = acquire_transition(&state, &agent.id)?;
-    if agent.machine_id.is_some() {
+    let bridge_hosted = agent
+        .machine_id
+        .as_deref()
+        .is_some_and(|m| m != state.local_machine_id.as_str());
+    if bridge_hosted {
         // Bridge-hosted: platform doesn't own the runtime. There's no
         // explicit "stop a single bridge-hosted agent" frame yet, so this
         // becomes a no-op until we add an `agent.stop` directive in the

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -833,8 +833,15 @@ pub(crate) async fn deliver_message_to_agents(
         };
         // Bridge-hosted agents are woken by the remote bridge after it
         // receives `chat.message.received` via `forward_chat_event_to_bridges`;
-        // the platform must not spawn them locally.
-        if agent.machine_id.is_some() {
+        // the platform must not spawn them locally. "Bridge-hosted" =
+        // owned by some other machine_id; the local installation's own
+        // agents (machine_id == local_machine_id) still go through the
+        // platform's in-process AgentManager until Phase 2 swaps the path.
+        if agent
+            .machine_id
+            .as_deref()
+            .is_some_and(|m| m != state.local_machine_id.as_str())
+        {
             continue;
         }
         // Associate the channel with the agent's trace run before notifying/starting.

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -56,6 +56,10 @@ pub struct AppState {
     pub active_workspace_id: Arc<RwLock<Option<String>>>,
     pub local_human_id: String,
     pub local_human_name: String,
+    /// Stable identifier for this installation. Every agent created on
+    /// `chorus serve` without an explicit `machine_id` defaults to this
+    /// value, so the in-process bridge client (Phase 2) can claim them.
+    pub local_machine_id: String,
     pub lifecycle: Arc<dyn AgentLifecycle>,
     pub runtime_status_provider: SharedRuntimeStatusProvider,
     pub transitioning_agents: Arc<Mutex<HashSet<String>>>,

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -106,7 +106,11 @@ async fn restart_agent_member(
         Some(a) => a,
         None => return Ok(()),
     };
-    if agent.machine_id.is_some() {
+    let bridge_hosted = agent
+        .machine_id
+        .as_deref()
+        .is_some_and(|m| m != state.local_machine_id.as_str());
+    if bridge_hosted {
         crate::server::transport::bridge_ws::broadcast_target_update(
             state.store.as_ref(),
             state.bridge_registry.as_ref(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -115,6 +115,15 @@ pub fn build_router_with_services_and_auth(
         .map(|workspace| workspace.id);
     let (local_human_id, local_human_name) =
         resolve_local_human_identity(store.as_ref(), &data_dir);
+    let local_machine_id = resolve_local_machine_id(&data_dir);
+
+    // Backfill rows that pre-date the always-set-machine_id invariant.
+    // After this UPDATE every agent owned by `chorus serve` has a non-NULL
+    // `machine_id` equal to `local_machine_id`. Rows already pinned to a
+    // remote bridge keep their value; only NULLs are touched.
+    if let Err(err) = store.backfill_null_machine_ids(&local_machine_id) {
+        tracing::warn!(err = %err, "backfill_null_machine_ids failed; agent rows may have NULL machine_id");
+    }
 
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS
@@ -134,6 +143,7 @@ pub fn build_router_with_services_and_auth(
         active_workspace_id: Arc::new(RwLock::new(active_workspace_id)),
         local_human_id,
         local_human_name,
+        local_machine_id,
         lifecycle,
         runtime_status_provider,
         transitioning_agents: Arc::new(Mutex::new(HashSet::new())),
@@ -360,4 +370,25 @@ fn resolve_local_human_identity(store: &Store, data_dir: &std::path::Path) -> (S
             panic!("unable to resolve persisted local human identity: {err}");
         }
     }
+}
+
+/// Resolve the local installation's `machine_id`, generating and persisting
+/// one to `config.toml` on first call. Every agent created on this server
+/// inherits this id when the request omits `machine_id`, so the bridge
+/// client knows to pick it up. Persistence makes the id stable across
+/// restarts; without persistence, every restart would re-orphan every
+/// local agent's `machine_id`.
+fn resolve_local_machine_id(data_dir: &std::path::Path) -> String {
+    let mut cfg = ChorusConfig::load(data_dir)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    if let Some(id) = cfg.machine_id.clone() {
+        return id;
+    }
+    let id = cfg.ensure_machine_id().to_string();
+    if let Err(err) = cfg.save(data_dir) {
+        tracing::warn!(err = %err, "failed to persist generated machine_id; will regenerate on next restart");
+    }
+    id
 }

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -191,6 +191,20 @@ impl Store {
         Ok(())
     }
 
+    /// Set every NULL `machine_id` to `local_machine_id`. Called once at
+    /// startup so rows that pre-date the always-set-machine_id invariant
+    /// get owned by the local installation. Idempotent: rows already
+    /// pinned to a remote bridge keep their value; only NULLs are touched.
+    /// Returns the number of rows updated.
+    pub fn backfill_null_machine_ids(&self, local_machine_id: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE agents SET machine_id = ?1 WHERE machine_id IS NULL",
+            params![local_machine_id],
+        )?;
+        Ok(updated)
+    }
+
     pub fn delete_agent_record(&self, name: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let agent_id: Option<String> = conn


### PR DESCRIPTION
## Summary

Phase 1 of collapsing the dual runtime path ([#149](https://github.com/Fullstop000/Chorus/issues/149)). Every agent row now has a non-NULL `machine_id`, defaulting to the local installation's id when the request omits it. **Behavior is unchanged** — this is a setup PR for Phase 2's in-process bridge client.

- New: `ChorusConfig::machine_id` auto-generates a UUID on first run and persists to `config.toml`.
- New: `Store::backfill_null_machine_ids` runs once at startup.
- New: `AppState.local_machine_id`; `handle_create_agent` defaults to it, `handle_update_agent` preserves the existing value when omitted.
- Changed: six `is_some()` / `is_none()` "bridge-hosted" checks across `agents.rs`, `messages.rs`, `teams.rs` flip to "machine_id != local" semantics so platform-local agents (now non-NULL) still take the local path.

The full plan for phases 2-5 lives at [`docs/plan/collapse-dual-runtime-path.md`](https://github.com/Fullstop000/Chorus/blob/feat/phase-1-local-machine-id/docs/plan/collapse-dual-runtime-path.md).

## Test plan

- [x] `cargo test` — 615 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Playwright smoke (CHORUS_E2E_LLM=0, 4 workers) — pre-existing parallel flakes only
- [x] LLM-gated MSG suite (MSG-001 / MSG-002 / MSG-004 / MSG-006) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)