### PR TITLE
feat: workspace-scoped runtime paths

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -194,11 +194,8 @@ goals.
   to that workspace, and add the workspace owner as its first member.
 - Deleting a workspace is destructive: workspace-scoped channels, messages,
   tasks, agents, teams, memberships, trace events, attachment links, orphaned
-  attachment rows, and orphaned attachment files are removed.
-- Deleting a workspace does not yet remove per-agent or per-team runtime
-  workspace directories. Team filesystem paths are still keyed by team name, so
-  wiping them during workspace deletion would be unsafe until those paths become
-  workspace-scoped.
+  attachment rows, orphaned attachment files, and workspace-scoped runtime
+  directories (agents and teams) are removed.
 - The CLI requires a running Chorus server and must call the API instead of
   opening SQLite directly.
 - Agent names are not fully workspace-scoped yet.

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -233,15 +233,6 @@ impl AgentManager {
             .join(&agent.workspace_id)
             .join(format!("{}-{}", agent.name, agent.id));
 
-        // Lazy migration from old flat layout
-        let old_agent_data_dir = self.data_dir.join(agent_name);
-        if old_agent_data_dir.exists() && !agent_data_dir.exists() {
-            if let Some(parent) = agent_data_dir.parent() {
-                tokio::fs::create_dir_all(parent).await.ok();
-            }
-            tokio::fs::rename(&old_agent_data_dir, &agent_data_dir).await.ok();
-        }
-
         tokio::fs::create_dir_all(&agent_data_dir).await?;
 
         let memory_md_path = agent_data_dir.join("MEMORY.md");

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -228,7 +228,20 @@ impl AgentManager {
         let rt = AgentRuntime::parse(&agent.runtime)
             .ok_or_else(|| anyhow::anyhow!("Unknown runtime: {}", agent.runtime))?;
 
-        let agent_data_dir = self.data_dir.join(agent_name);
+        let agent_data_dir = self
+            .data_dir
+            .join(&agent.workspace_id)
+            .join(format!("{}-{}", agent.name, agent.id));
+
+        // Lazy migration from old flat layout
+        let old_agent_data_dir = self.data_dir.join(agent_name);
+        if old_agent_data_dir.exists() && !agent_data_dir.exists() {
+            if let Some(parent) = agent_data_dir.parent() {
+                tokio::fs::create_dir_all(parent).await.ok();
+            }
+            tokio::fs::rename(&old_agent_data_dir, &agent_data_dir).await.ok();
+        }
+
         tokio::fs::create_dir_all(&agent_data_dir).await?;
 
         let memory_md_path = agent_data_dir.join("MEMORY.md");

--- a/src/agent/workspace.rs
+++ b/src/agent/workspace.rs
@@ -17,28 +17,6 @@ impl<'a> AgentWorkspace<'a> {
             .join(format!("{}-{}", agent_name, agent_id))
     }
 
-    /// Migrate an agent directory from the old flat layout to the new
-    /// workspace-scoped layout if needed. Returns the path that should be used.
-    fn maybe_migrate_agent_dir(
-        &self,
-        workspace_id: &str,
-        agent_name: &str,
-        agent_id: &str,
-    ) -> std::io::Result<PathBuf> {
-        let new_path = self.path_for(workspace_id, agent_name, agent_id);
-        if new_path.exists() {
-            return Ok(new_path);
-        }
-        let old_path = self.agents_dir.join(agent_name);
-        if old_path.exists() {
-            if let Some(parent) = new_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::rename(&old_path, &new_path)?;
-        }
-        Ok(new_path)
-    }
-
     /// Remove the workspace directory if it exists.
     pub fn delete_if_exists(
         &self,
@@ -49,11 +27,6 @@ impl<'a> AgentWorkspace<'a> {
         let path = self.path_for(workspace_id, agent_name, agent_id);
         if path.exists() {
             std::fs::remove_dir_all(path)?;
-        }
-        // Also clean up legacy flat layout
-        let old_path = self.agents_dir.join(agent_name);
-        if old_path.exists() {
-            std::fs::remove_dir_all(old_path)?;
         }
         Ok(())
     }
@@ -73,25 +46,6 @@ impl<'a> AgentWorkspace<'a> {
             .join(format!("{}-{}", team_name, team_id))
     }
 
-    /// Migrate a team memory directory from the old name-only layout to the
-    /// new id-suffixed layout inside the agent directory.
-    fn maybe_migrate_team_memory(
-        &self,
-        agent_dir: &Path,
-        team_name: &str,
-        team_id: &str,
-    ) -> std::io::Result<PathBuf> {
-        let new_path = agent_dir.join("teams").join(format!("{}-{}", team_name, team_id));
-        if new_path.exists() {
-            return Ok(new_path);
-        }
-        let old_path = agent_dir.join("teams").join(team_name);
-        if old_path.exists() {
-            std::fs::rename(&old_path, &new_path)?;
-        }
-        Ok(new_path)
-    }
-
     /// Create per-team memory dir + ROLE.md stub for an agent.
     pub fn init_team_memory(
         &self,
@@ -102,8 +56,7 @@ impl<'a> AgentWorkspace<'a> {
         team_id: &str,
         role: &str,
     ) -> std::io::Result<()> {
-        let agent_dir = self.maybe_migrate_agent_dir(workspace_id, agent_name, agent_id)?;
-        let dir = self.maybe_migrate_team_memory(&agent_dir, team_name, team_id)?;
+        let dir = self.team_memory_path(workspace_id, agent_name, agent_id, team_name, team_id);
         std::fs::create_dir_all(&dir)?;
         let role_md = dir.join("ROLE.md");
         if !role_md.exists() {
@@ -127,12 +80,18 @@ impl<'a> AgentWorkspace<'a> {
         team_id: &str,
         role: &str,
     ) -> std::io::Result<()> {
-        let agent_dir = self.maybe_migrate_agent_dir(workspace_id, agent_name, agent_id)?;
-        let dir = self.maybe_migrate_team_memory(&agent_dir, team_name, team_id)?;
+        let dir = self.team_memory_path(workspace_id, agent_name, agent_id, team_name, team_id);
         std::fs::create_dir_all(&dir)?;
         let role_md = dir.join("ROLE.md");
         if !role_md.exists() {
-            return self.init_team_memory(workspace_id, agent_name, agent_id, team_name, team_id, role);
+            return self.init_team_memory(
+                workspace_id,
+                agent_name,
+                agent_id,
+                team_name,
+                team_id,
+                role,
+            );
         }
 
         let current = std::fs::read_to_string(&role_md)?;
@@ -168,20 +127,10 @@ impl<'a> AgentWorkspace<'a> {
         team_name: &str,
         team_id: &str,
     ) -> std::io::Result<()> {
-        let new_path = self.team_memory_path(workspace_id, agent_name, agent_id, team_name, team_id);
+        let new_path =
+            self.team_memory_path(workspace_id, agent_name, agent_id, team_name, team_id);
         if new_path.exists() {
             std::fs::remove_dir_all(new_path)?;
-        }
-        // Legacy paths (best-effort)
-        let legacy_agent_dir = self.agents_dir.join(agent_name);
-        let legacy_path = legacy_agent_dir.join("teams").join(team_name);
-        if legacy_path.exists() {
-            std::fs::remove_dir_all(legacy_path)?;
-        }
-        let migrated_agent_dir = self.path_for(workspace_id, agent_name, agent_id);
-        let legacy_path2 = migrated_agent_dir.join("teams").join(team_name);
-        if legacy_path2.exists() {
-            std::fs::remove_dir_all(legacy_path2)?;
         }
         Ok(())
     }
@@ -216,28 +165,6 @@ impl TeamWorkspace {
             .join(format!("{}-{}", agent_name, agent_id))
     }
 
-    /// Migrate a team directory from the old flat layout to the new
-    /// workspace-scoped layout if needed. Returns the path that should be used.
-    fn maybe_migrate_team_dir(
-        &self,
-        workspace_id: &str,
-        team_name: &str,
-        team_id: &str,
-    ) -> std::io::Result<PathBuf> {
-        let new_path = self.team_path(workspace_id, team_name, team_id);
-        if new_path.exists() {
-            return Ok(new_path);
-        }
-        let old_path = self.teams_dir.join(team_name);
-        if old_path.exists() {
-            if let Some(parent) = new_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::rename(&old_path, &new_path)?;
-        }
-        Ok(new_path)
-    }
-
     /// Create team workspace skeleton with TEAM.md stub.
     pub fn init_team(
         &self,
@@ -246,10 +173,16 @@ impl TeamWorkspace {
         team_id: &str,
         members: &[(&str, &str)],
     ) -> std::io::Result<()> {
-        let team_dir = self.maybe_migrate_team_dir(workspace_id, team_name, team_id)?;
+        let team_dir = self.team_path(workspace_id, team_name, team_id);
         std::fs::create_dir_all(team_dir.join("shared"))?;
         for (agent_name, agent_id) in members {
-            std::fs::create_dir_all(self.member_path(workspace_id, team_name, team_id, agent_name, agent_id))?;
+            std::fs::create_dir_all(self.member_path(
+                workspace_id,
+                team_name,
+                team_id,
+                agent_name,
+                agent_id,
+            ))?;
         }
         let team_md = team_dir.join("TEAM.md");
         if !team_md.exists() {
@@ -274,7 +207,13 @@ impl TeamWorkspace {
         agent_name: &str,
         agent_id: &str,
     ) -> std::io::Result<()> {
-        std::fs::create_dir_all(self.member_path(workspace_id, team_name, team_id, agent_name, agent_id))
+        std::fs::create_dir_all(self.member_path(
+            workspace_id,
+            team_name,
+            team_id,
+            agent_name,
+            agent_id,
+        ))
     }
 
     /// Remove the entire team workspace directory.
@@ -287,10 +226,6 @@ impl TeamWorkspace {
         let path = self.team_path(workspace_id, team_name, team_id);
         if path.exists() {
             std::fs::remove_dir_all(path)?;
-        }
-        let old_path = self.teams_dir.join(team_name);
-        if old_path.exists() {
-            std::fs::remove_dir_all(old_path)?;
         }
         Ok(())
     }

--- a/src/agent/workspace.rs
+++ b/src/agent/workspace.rs
@@ -11,41 +11,107 @@ impl<'a> AgentWorkspace<'a> {
     }
 
     /// Resolve the stable workspace path for an agent's persisted files.
-    pub fn path_for(&self, agent_name: &str) -> PathBuf {
-        self.agents_dir.join(agent_name)
+    pub fn path_for(&self, workspace_id: &str, agent_name: &str, agent_id: &str) -> PathBuf {
+        self.agents_dir
+            .join(workspace_id)
+            .join(format!("{}-{}", agent_name, agent_id))
+    }
+
+    /// Migrate an agent directory from the old flat layout to the new
+    /// workspace-scoped layout if needed. Returns the path that should be used.
+    fn maybe_migrate_agent_dir(
+        &self,
+        workspace_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+    ) -> std::io::Result<PathBuf> {
+        let new_path = self.path_for(workspace_id, agent_name, agent_id);
+        if new_path.exists() {
+            return Ok(new_path);
+        }
+        let old_path = self.agents_dir.join(agent_name);
+        if old_path.exists() {
+            if let Some(parent) = new_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::rename(&old_path, &new_path)?;
+        }
+        Ok(new_path)
     }
 
     /// Remove the workspace directory if it exists.
-    pub fn delete_if_exists(&self, agent_name: &str) -> std::io::Result<()> {
-        let path = self.path_for(agent_name);
+    pub fn delete_if_exists(
+        &self,
+        workspace_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+    ) -> std::io::Result<()> {
+        let path = self.path_for(workspace_id, agent_name, agent_id);
         if path.exists() {
             std::fs::remove_dir_all(path)?;
+        }
+        // Also clean up legacy flat layout
+        let old_path = self.agents_dir.join(agent_name);
+        if old_path.exists() {
+            std::fs::remove_dir_all(old_path)?;
         }
         Ok(())
     }
 
-    /// Path for agent's private team memory: <agents_dir>/<agent>/teams/<team>/
-    pub fn team_memory_path(&self, agent_name: &str, team_name: &str) -> PathBuf {
-        self.agents_dir
-            .join(agent_name)
+    /// Path for agent's private team memory:
+    /// <agents_dir>/<workspace_id>/<agent>-<agent_id>/teams/<team>-<team_id>/
+    pub fn team_memory_path(
+        &self,
+        workspace_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+        team_name: &str,
+        team_id: &str,
+    ) -> PathBuf {
+        self.path_for(workspace_id, agent_name, agent_id)
             .join("teams")
-            .join(team_name)
+            .join(format!("{}-{}", team_name, team_id))
+    }
+
+    /// Migrate a team memory directory from the old name-only layout to the
+    /// new id-suffixed layout inside the agent directory.
+    fn maybe_migrate_team_memory(
+        &self,
+        agent_dir: &Path,
+        team_name: &str,
+        team_id: &str,
+    ) -> std::io::Result<PathBuf> {
+        let new_path = agent_dir.join("teams").join(format!("{}-{}", team_name, team_id));
+        if new_path.exists() {
+            return Ok(new_path);
+        }
+        let old_path = agent_dir.join("teams").join(team_name);
+        if old_path.exists() {
+            std::fs::rename(&old_path, &new_path)?;
+        }
+        Ok(new_path)
     }
 
     /// Create per-team memory dir + ROLE.md stub for an agent.
     pub fn init_team_memory(
         &self,
+        workspace_id: &str,
         agent_name: &str,
+        agent_id: &str,
         team_name: &str,
+        team_id: &str,
         role: &str,
     ) -> std::io::Result<()> {
-        let dir = self.team_memory_path(agent_name, team_name);
+        let agent_dir = self.maybe_migrate_agent_dir(workspace_id, agent_name, agent_id)?;
+        let dir = self.maybe_migrate_team_memory(&agent_dir, team_name, team_id)?;
         std::fs::create_dir_all(&dir)?;
         let role_md = dir.join("ROLE.md");
         if !role_md.exists() {
             std::fs::write(
                 &role_md,
-                format!("# Role in {team_name}\n\n**Role:** {role}\n\n## Responsibilities\n\n_Document your responsibilities in this team here._\n"),
+                format!(
+                    "# Role in {team_name}\n\n**Role:** {role}\n\n## Responsibilities\n\n_Document your responsibilities in this team here._\n",
+                ),
             )?;
         }
         Ok(())
@@ -54,15 +120,19 @@ impl<'a> AgentWorkspace<'a> {
     /// Update the persisted role line in an agent's private team memory.
     pub fn set_team_role(
         &self,
+        workspace_id: &str,
         agent_name: &str,
+        agent_id: &str,
         team_name: &str,
+        team_id: &str,
         role: &str,
     ) -> std::io::Result<()> {
-        let dir = self.team_memory_path(agent_name, team_name);
+        let agent_dir = self.maybe_migrate_agent_dir(workspace_id, agent_name, agent_id)?;
+        let dir = self.maybe_migrate_team_memory(&agent_dir, team_name, team_id)?;
         std::fs::create_dir_all(&dir)?;
         let role_md = dir.join("ROLE.md");
         if !role_md.exists() {
-            return self.init_team_memory(agent_name, team_name, role);
+            return self.init_team_memory(workspace_id, agent_name, agent_id, team_name, team_id, role);
         }
 
         let current = std::fs::read_to_string(&role_md)?;
@@ -90,10 +160,28 @@ impl<'a> AgentWorkspace<'a> {
     }
 
     /// Remove agent's private team memory directory.
-    pub fn delete_team_memory(&self, agent_name: &str, team_name: &str) -> std::io::Result<()> {
-        let path = self.team_memory_path(agent_name, team_name);
-        if path.exists() {
-            std::fs::remove_dir_all(path)?;
+    pub fn delete_team_memory(
+        &self,
+        workspace_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+        team_name: &str,
+        team_id: &str,
+    ) -> std::io::Result<()> {
+        let new_path = self.team_memory_path(workspace_id, agent_name, agent_id, team_name, team_id);
+        if new_path.exists() {
+            std::fs::remove_dir_all(new_path)?;
+        }
+        // Legacy paths (best-effort)
+        let legacy_agent_dir = self.agents_dir.join(agent_name);
+        let legacy_path = legacy_agent_dir.join("teams").join(team_name);
+        if legacy_path.exists() {
+            std::fs::remove_dir_all(legacy_path)?;
+        }
+        let migrated_agent_dir = self.path_for(workspace_id, agent_name, agent_id);
+        let legacy_path2 = migrated_agent_dir.join("teams").join(team_name);
+        if legacy_path2.exists() {
+            std::fs::remove_dir_all(legacy_path2)?;
         }
         Ok(())
     }
@@ -109,46 +197,100 @@ impl TeamWorkspace {
         Self { teams_dir }
     }
 
-    pub fn team_path(&self, team_name: &str) -> PathBuf {
-        self.teams_dir.join(team_name)
+    pub fn team_path(&self, workspace_id: &str, team_name: &str, team_id: &str) -> PathBuf {
+        self.teams_dir
+            .join(workspace_id)
+            .join(format!("{}-{}", team_name, team_id))
     }
 
-    pub fn member_path(&self, team_name: &str, agent_name: &str) -> PathBuf {
-        self.teams_dir
-            .join(team_name)
+    pub fn member_path(
+        &self,
+        workspace_id: &str,
+        team_name: &str,
+        team_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+    ) -> PathBuf {
+        self.team_path(workspace_id, team_name, team_id)
             .join("members")
-            .join(agent_name)
+            .join(format!("{}-{}", agent_name, agent_id))
+    }
+
+    /// Migrate a team directory from the old flat layout to the new
+    /// workspace-scoped layout if needed. Returns the path that should be used.
+    fn maybe_migrate_team_dir(
+        &self,
+        workspace_id: &str,
+        team_name: &str,
+        team_id: &str,
+    ) -> std::io::Result<PathBuf> {
+        let new_path = self.team_path(workspace_id, team_name, team_id);
+        if new_path.exists() {
+            return Ok(new_path);
+        }
+        let old_path = self.teams_dir.join(team_name);
+        if old_path.exists() {
+            if let Some(parent) = new_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::rename(&old_path, &new_path)?;
+        }
+        Ok(new_path)
     }
 
     /// Create team workspace skeleton with TEAM.md stub.
-    pub fn init_team(&self, team_name: &str, members: &[&str]) -> std::io::Result<()> {
-        let team_dir = self.team_path(team_name);
+    pub fn init_team(
+        &self,
+        workspace_id: &str,
+        team_name: &str,
+        team_id: &str,
+        members: &[(&str, &str)],
+    ) -> std::io::Result<()> {
+        let team_dir = self.maybe_migrate_team_dir(workspace_id, team_name, team_id)?;
         std::fs::create_dir_all(team_dir.join("shared"))?;
-        for member in members {
-            std::fs::create_dir_all(self.member_path(team_name, member))?;
+        for (agent_name, agent_id) in members {
+            std::fs::create_dir_all(self.member_path(workspace_id, team_name, team_id, agent_name, agent_id))?;
         }
         let team_md = team_dir.join("TEAM.md");
         if !team_md.exists() {
             std::fs::write(
                 &team_md,
-                format!("# Team: {}\n\n## Purpose\n\n_Describe the team's purpose here._\n\n## Members\n\n{}\n",
+                format!(
+                    "# Team: {}\n\n## Purpose\n\n_Describe the team's purpose here._\n\n## Members\n\n{}\n",
                     team_name,
-                    members.iter().map(|m| format!("- {m}")).collect::<Vec<_>>().join("\n")),
+                    members.iter().map(|(m, _)| format!("- {m}")).collect::<Vec<_>>().join("\n")
+                ),
             )?;
         }
         Ok(())
     }
 
     /// Add a member directory to an existing team workspace.
-    pub fn init_member(&self, team_name: &str, agent_name: &str) -> std::io::Result<()> {
-        std::fs::create_dir_all(self.member_path(team_name, agent_name))
+    pub fn init_member(
+        &self,
+        workspace_id: &str,
+        team_name: &str,
+        team_id: &str,
+        agent_name: &str,
+        agent_id: &str,
+    ) -> std::io::Result<()> {
+        std::fs::create_dir_all(self.member_path(workspace_id, team_name, team_id, agent_name, agent_id))
     }
 
     /// Remove the entire team workspace directory.
-    pub fn delete_team(&self, team_name: &str) -> std::io::Result<()> {
-        let path = self.team_path(team_name);
+    pub fn delete_team(
+        &self,
+        workspace_id: &str,
+        team_name: &str,
+        team_id: &str,
+    ) -> std::io::Result<()> {
+        let path = self.team_path(workspace_id, team_name, team_id);
         if path.exists() {
             std::fs::remove_dir_all(path)?;
+        }
+        let old_path = self.teams_dir.join(team_name);
+        if old_path.exists() {
+            std::fs::remove_dir_all(old_path)?;
         }
         Ok(())
     }

--- a/src/server/handlers/agent_workspace.rs
+++ b/src/server/handlers/agent_workspace.rs
@@ -83,25 +83,14 @@ pub async fn handle_agent_workspace(
     let agent = resolve_public_agent(&state, &id)?;
     let agent_workspace = AgentWorkspace::new(&state.agents_dir);
     let workspace_dir = agent_workspace.path_for(&agent.workspace_id, &agent.name, &agent.id);
-    // Fallback to legacy flat layout during transition
-    let effective_dir = if workspace_dir.exists() {
-        workspace_dir.clone()
-    } else {
-        let legacy = state.agents_dir.join(&agent.name);
-        if legacy.exists() {
-            legacy
-        } else {
-            workspace_dir.clone()
-        }
-    };
-    if !effective_dir.exists() {
+    if !workspace_dir.exists() {
         return Ok(Json(serde_json::json!({
             "path": workspace_dir.to_string_lossy(),
             "files": []
         })));
     }
     let mut files: Vec<String> = Vec::new();
-    collect_workspace_files(&effective_dir, &effective_dir, &mut files, 0);
+    collect_workspace_files(&workspace_dir, &workspace_dir, &mut files, 0);
     Ok(Json(serde_json::json!({
         "path": workspace_dir.to_string_lossy(),
         "files": files
@@ -116,19 +105,8 @@ pub async fn handle_agent_workspace_file(
     let agent = resolve_public_agent(&state, &id)?;
     let agent_workspace = AgentWorkspace::new(&state.agents_dir);
     let workspace_dir = agent_workspace.path_for(&agent.workspace_id, &agent.name, &agent.id);
-    // Fallback to legacy flat layout during transition
-    let effective_dir = if workspace_dir.exists() {
-        workspace_dir.clone()
-    } else {
-        let legacy = state.agents_dir.join(&agent.name);
-        if legacy.exists() {
-            legacy
-        } else {
-            workspace_dir.clone()
-        }
-    };
     let relative = sanitize_workspace_path(&params.path)?;
-    let file_path = effective_dir.join(&relative);
+    let file_path = workspace_dir.join(&relative);
 
     if !file_path.is_file() {
         return Err(app_err!(

--- a/src/server/handlers/agent_workspace.rs
+++ b/src/server/handlers/agent_workspace.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 
 use super::path_params::{resolve_public_agent, PublicResourceIdPath};
 use super::{app_err, internal_err, ApiResult, AppState};
+use crate::agent::workspace::AgentWorkspace;
 
 // ── Inline query structs ──
 
@@ -80,15 +81,27 @@ pub async fn handle_agent_workspace(
     AxumPath(PublicResourceIdPath { id }): AxumPath<PublicResourceIdPath>,
 ) -> ApiResult<serde_json::Value> {
     let agent = resolve_public_agent(&state, &id)?;
-    let workspace_dir = state.agents_dir.clone().join(&agent.name);
-    if !workspace_dir.exists() {
+    let agent_workspace = AgentWorkspace::new(&state.agents_dir);
+    let workspace_dir = agent_workspace.path_for(&agent.workspace_id, &agent.name, &agent.id);
+    // Fallback to legacy flat layout during transition
+    let effective_dir = if workspace_dir.exists() {
+        workspace_dir.clone()
+    } else {
+        let legacy = state.agents_dir.join(&agent.name);
+        if legacy.exists() {
+            legacy
+        } else {
+            workspace_dir.clone()
+        }
+    };
+    if !effective_dir.exists() {
         return Ok(Json(serde_json::json!({
             "path": workspace_dir.to_string_lossy(),
             "files": []
         })));
     }
     let mut files: Vec<String> = Vec::new();
-    collect_workspace_files(&workspace_dir, &workspace_dir, &mut files, 0);
+    collect_workspace_files(&effective_dir, &effective_dir, &mut files, 0);
     Ok(Json(serde_json::json!({
         "path": workspace_dir.to_string_lossy(),
         "files": files
@@ -101,9 +114,21 @@ pub async fn handle_agent_workspace_file(
     Query(params): Query<WorkspaceFileParams>,
 ) -> ApiResult<serde_json::Value> {
     let agent = resolve_public_agent(&state, &id)?;
-    let workspace_dir = state.agents_dir.clone().join(&agent.name);
+    let agent_workspace = AgentWorkspace::new(&state.agents_dir);
+    let workspace_dir = agent_workspace.path_for(&agent.workspace_id, &agent.name, &agent.id);
+    // Fallback to legacy flat layout during transition
+    let effective_dir = if workspace_dir.exists() {
+        workspace_dir.clone()
+    } else {
+        let legacy = state.agents_dir.join(&agent.name);
+        if legacy.exists() {
+            legacy
+        } else {
+            workspace_dir.clone()
+        }
+    };
     let relative = sanitize_workspace_path(&params.path)?;
-    let file_path = workspace_dir.join(&relative);
+    let file_path = effective_dir.join(&relative);
 
     if !file_path.is_file() {
         return Err(app_err!(

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -591,12 +591,14 @@ pub async fn handle_restart_agent(
                 .store
                 .clear_active_session(&agent.id)
                 .map_err(internal_err)?;
-            workspace.delete_if_exists(&name).map_err(|e| {
-                app_err!(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "failed to delete workspace: {e}"
-                )
-            })?;
+            workspace
+                .delete_if_exists(&agent.workspace_id, &name, &agent.id)
+                .map_err(|e| {
+                    app_err!(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to delete workspace: {e}"
+                    )
+                })?;
         }
     }
 
@@ -655,7 +657,7 @@ pub async fn handle_delete_agent(
     if matches!(req.mode, DeleteMode::DeleteWorkspace) {
         let agents_dir = state.agents_dir.clone();
         let workspace = AgentWorkspace::new(&agents_dir);
-        if let Err(e) = workspace.delete_if_exists(&name) {
+        if let Err(e) = workspace.delete_if_exists(&agent.workspace_id, &name, &agent.id) {
             return Ok(Json(serde_json::json!({
                 "ok": true,
                 "warning": format!("agent deleted but workspace cleanup failed: {e}"),

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -83,7 +83,14 @@ async fn sync_team_roles_and_agents(
     for member in members {
         if member.member_type == "agent" {
             agent_workspace
-                .set_team_role(&member.member_name, &team.name, &member.role)
+                .set_team_role(
+                    &team.workspace_id,
+                    &member.member_name,
+                    &member.member_id,
+                    &team.name,
+                    &team.id,
+                    &member.role,
+                )
                 .map_err(internal_err)?;
             restart_agent_member(state, &member.member_name).await?;
         }
@@ -211,19 +218,31 @@ pub async fn handle_create_team(
             .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
     }
 
+    let team = state
+        .store
+        .get_team_by_id(&team_id)
+        .map_err(internal_err)?
+        .ok_or_else(|| {
+            app_err!(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "team not found after create: {name}"
+            )
+        })?;
+    let workspace_id = team.workspace_id.clone();
+
     let teams_dir = state.teams_dir();
     let agents_dir = state.agents_dir.clone();
     let team_workspace = TeamWorkspace::new(teams_dir);
     let agent_workspace = AgentWorkspace::new(&agents_dir);
 
-    let agent_member_names = req
+    let agent_members: Vec<(&str, &str)> = req
         .members
         .iter()
         .filter(|member| member.member_type == "agent")
-        .map(|member| member.member_name.as_str())
-        .collect::<Vec<_>>();
+        .map(|member| (member.member_name.as_str(), member.member_id.as_str()))
+        .collect();
     team_workspace
-        .init_team(&name, &agent_member_names)
+        .init_team(&workspace_id, &name, &team_id, &agent_members)
         .map_err(internal_err)?;
 
     for member in &req.members {
@@ -247,22 +266,18 @@ pub async fn handle_create_team(
 
         if sender_type == SenderType::Agent {
             agent_workspace
-                .init_team_memory(&member.member_name, &name, &member.role)
+                .init_team_memory(
+                    &workspace_id,
+                    &member.member_name,
+                    &member.member_id,
+                    &name,
+                    &team_id,
+                    &member.role,
+                )
                 .map_err(internal_err)?;
             restart_agent_member(&state, &member.member_name).await?;
         }
     }
-
-    let team = state
-        .store
-        .get_team_by_id(&team_id)
-        .map_err(internal_err)?
-        .ok_or_else(|| {
-            app_err!(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "team not found after create: {name}"
-            )
-        })?;
     let members = state
         .store
         .get_team_members(&team_id)
@@ -343,11 +358,11 @@ pub async fn handle_delete_team(
         .store
         .get_team_members(&team.id)
         .map_err(internal_err)?;
-    let agent_members = members
+    let agent_members: Vec<(String, String)> = members
         .iter()
         .filter(|member| member.member_type == "agent")
-        .map(|member| member.member_name.clone())
-        .collect::<Vec<_>>();
+        .map(|member| (member.member_name.clone(), member.member_id.clone()))
+        .collect();
 
     state.store.delete_team(&team.id).map_err(internal_err)?;
 
@@ -364,18 +379,20 @@ pub async fn handle_delete_team(
 
     let team_workspace = TeamWorkspace::new(state.teams_dir());
     team_workspace
-        .delete_team(&team.name)
+        .delete_team(&team.workspace_id, &team.name, &team.id)
         .map_err(internal_err)?;
 
     let agents_dir = state.agents_dir.clone();
     let agent_workspace = AgentWorkspace::new(&agents_dir);
-    for agent_name in &agent_members {
-        // Agent may have been deleted already — skip cleanup for missing agents.
-        if state.store.get_agent(agent_name).ok().flatten().is_none() {
-            continue;
-        }
+    for (agent_name, agent_id) in &agent_members {
         agent_workspace
-            .delete_team_memory(agent_name, &team.name)
+            .delete_team_memory(
+                &team.workspace_id,
+                agent_name,
+                agent_id,
+                &team.name,
+                &team.id,
+            )
             .map_err(internal_err)?;
         restart_agent_member(&state, agent_name).await?;
     }
@@ -411,12 +428,25 @@ pub async fn handle_add_team_member(
     if sender_type == SenderType::Agent {
         let team_workspace = TeamWorkspace::new(state.teams_dir());
         team_workspace
-            .init_member(&team.name, &req.member_name)
+            .init_member(
+                &team.workspace_id,
+                &team.name,
+                &team.id,
+                &req.member_name,
+                &req.member_id,
+            )
             .map_err(internal_err)?;
         let agents_dir = state.agents_dir.clone();
         let agent_workspace = AgentWorkspace::new(&agents_dir);
         agent_workspace
-            .init_team_memory(&req.member_name, &team.name, &req.role)
+            .init_team_memory(
+                &team.workspace_id,
+                &req.member_name,
+                &req.member_id,
+                &team.name,
+                &team.id,
+                &req.role,
+            )
             .map_err(internal_err)?;
     }
 

--- a/src/server/handlers/workspaces.rs
+++ b/src/server/handlers/workspaces.rs
@@ -228,6 +228,19 @@ pub async fn handle_delete_workspace(
         .delete_workspace(&deleted_id)
         .map_err(internal_err)?;
 
+    // Remove workspace-scoped runtime directories. Because paths are now
+    // scoped by workspace id, a single directory sweep per workspace is
+    // sufficient and safe — same-named agents or teams in other workspaces
+    // live under different parent directories.
+    let agents_workspace_dir = state.agents_dir.join(&deleted_id);
+    let teams_workspace_dir = state.teams_dir().join(&deleted_id);
+    if agents_workspace_dir.exists() {
+        let _ = tokio::fs::remove_dir_all(&agents_workspace_dir).await;
+    }
+    if teams_workspace_dir.exists() {
+        let _ = tokio::fs::remove_dir_all(&teams_workspace_dir).await;
+    }
+
     let active_workspace = if was_active {
         state.set_active_workspace_id(None).await;
         None

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -276,7 +276,8 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
     // to `<data_dir>/agents`, which `harness::build_router_with_event_bus_and_dir`
     // creates from the same TempDir we received.
     let agents_dir = data_dir.path().join("agents");
-    let workspace_dir = agents_dir.join("bot1");
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let workspace_dir = agents_dir.join(&workspace_id).join(format!("{}-{}", bot1.name, bot1.id));
     let notes_dir = workspace_dir.join("notes");
     std::fs::create_dir_all(&notes_dir).unwrap();
     std::fs::write(

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -277,7 +277,9 @@ async fn test_workspace_e2e_lists_and_reads_markdown_file() {
     // creates from the same TempDir we received.
     let agents_dir = data_dir.path().join("agents");
     let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
-    let workspace_dir = agents_dir.join(&workspace_id).join(format!("{}-{}", bot1.name, bot1.id));
+    let workspace_dir = agents_dir
+        .join(&workspace_id)
+        .join(format!("{}-{}", bot1.name, bot1.id));
     let notes_dir = workspace_dir.join("notes");
     std::fs::create_dir_all(&notes_dir).unwrap();
     std::fs::write(

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -5,6 +5,7 @@ use axum::http::{Request, StatusCode};
 use chorus::agent::activity_log::ActivityLogResponse;
 use chorus::agent::drivers::ProbeAuth;
 use chorus::agent::runtime_status::{RuntimeCatalogEntry, RuntimeStatusProvider};
+use chorus::agent::workspace::{AgentWorkspace, TeamWorkspace};
 use chorus::agent::AgentLifecycle;
 use chorus::agent::AgentRuntime;
 use chorus::server::dto::ChannelInfo;
@@ -1811,7 +1812,13 @@ async fn test_restart_agent_reset_session_preserves_workspace() {
     store
         .record_session(&bot1.id, "thread-123", &bot1.runtime)
         .unwrap();
-    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let workspace_dir = dir
+        .path()
+        .join("agents")
+        .join(&workspace_id)
+        .join(format!("{}-{}", bot1.name, bot1.id))
+        .join("notes");
     std::fs::create_dir_all(&workspace_dir).unwrap();
     std::fs::write(workspace_dir.join("plan.md"), "hello").unwrap();
 
@@ -1841,7 +1848,13 @@ async fn test_restart_agent_reset_session_preserves_workspace() {
 async fn test_delete_agent_marks_history_and_preserves_workspace() {
     let (store, _app, dir) = setup_with_data_dir();
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
-    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let workspace_dir = dir
+        .path()
+        .join("agents")
+        .join(&workspace_id)
+        .join(format!("{}-{}", bot1.name, bot1.id))
+        .join("notes");
     std::fs::create_dir_all(&workspace_dir).unwrap();
     std::fs::write(workspace_dir.join("plan.md"), "hello").unwrap();
     store
@@ -2201,7 +2214,13 @@ async fn test_upload_uses_configured_data_dir() {
 async fn test_workspace_lists_files_from_configured_data_dir() {
     let (store, app, dir) = setup_with_data_dir();
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
-    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let workspace_dir = dir
+        .path()
+        .join("agents")
+        .join(&workspace_id)
+        .join(format!("{}-{}", bot1.name, bot1.id))
+        .join("notes");
     std::fs::create_dir_all(&workspace_dir).unwrap();
     std::fs::write(workspace_dir.join("plan.md"), "# test\n").unwrap();
 
@@ -2225,7 +2244,8 @@ async fn test_workspace_lists_files_from_configured_data_dir() {
         Some(
             dir.path()
                 .join("agents")
-                .join("bot1")
+                .join(&workspace_id)
+                .join(format!("{}-{}", bot1.name, bot1.id))
                 .to_string_lossy()
                 .as_ref()
         )
@@ -2239,7 +2259,13 @@ async fn test_workspace_lists_files_from_configured_data_dir() {
 async fn test_workspace_file_returns_content_from_configured_data_dir() {
     let (store, app, dir) = setup_with_data_dir();
     let bot1 = store.get_agent("bot1").unwrap().unwrap();
-    let workspace_dir = dir.path().join("agents").join("bot1").join("notes");
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let workspace_dir = dir
+        .path()
+        .join("agents")
+        .join(&workspace_id)
+        .join(format!("{}-{}", bot1.name, bot1.id))
+        .join("notes");
     std::fs::create_dir_all(&workspace_dir).unwrap();
     std::fs::write(workspace_dir.join("plan.md"), "# plan\nship it\n").unwrap();
 
@@ -2357,16 +2383,26 @@ async fn test_create_team_endpoint() {
     assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
     assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
 
-    let teams_root = dir.path().join("data").join("teams").join("eng-team");
+    let workspace_id = &team.workspace_id;
+    let team_dir_name = format!("{}-{}", team.name, team.id);
+    let agent_dir_name = format!("{}-{}", bot_member.member_name, bot_member.member_id);
+
+    let teams_root = dir
+        .path()
+        .join("data")
+        .join("teams")
+        .join(workspace_id)
+        .join(&team_dir_name);
     assert!(teams_root.join("TEAM.md").exists());
-    assert!(teams_root.join("members").join("bot1").exists());
+    assert!(teams_root.join("members").join(&agent_dir_name).exists());
 
     let role_md = dir
         .path()
         .join("agents")
-        .join("bot1")
+        .join(workspace_id)
+        .join(&agent_dir_name)
         .join("teams")
-        .join("eng-team")
+        .join(&team_dir_name)
         .join("ROLE.md");
     assert!(role_md.exists());
 }
@@ -2643,12 +2679,18 @@ async fn test_add_remove_and_delete_team_endpoints() {
         store.get_teams_by_agent_id("bot1").unwrap()[0].team_name,
         "eng-team"
     );
+
+    let team = store.get_team("eng-team").unwrap().unwrap();
+    let workspace_id = &team.workspace_id;
+    let team_dir_name = format!("{}-{}", team.name, team.id);
+    let agent_dir_name = format!("{}-{}", bot1.name, bot1.id);
     assert!(dir
         .path()
         .join("agents")
-        .join("bot1")
+        .join(workspace_id)
+        .join(&agent_dir_name)
         .join("teams")
-        .join("eng-team")
+        .join(&team_dir_name)
         .join("ROLE.md")
         .exists());
 
@@ -2673,6 +2715,10 @@ async fn test_add_remove_and_delete_team_endpoints() {
         "Query returned no rows"
     );
 
+    let team = store.get_team("eng-team").unwrap().unwrap();
+    let workspace_id = team.workspace_id.clone();
+    let team_dir_name = format!("{}-{}", team.name, team.id);
+
     let delete_resp = app
         .oneshot(
             Request::builder()
@@ -2687,7 +2733,12 @@ async fn test_add_remove_and_delete_team_endpoints() {
     assert!(store.get_team_by_id(&team_id).unwrap().is_none());
     let listed = store.get_channels().unwrap();
     assert!(listed.iter().all(|channel| channel.name != "eng-team"));
-    assert!(!dir.path().join("teams").join("eng-team").exists());
+    assert!(!dir
+        .path()
+        .join("teams")
+        .join(&workspace_id)
+        .join(&team_dir_name)
+        .exists());
     assert_eq!(lifecycle.started_names().len(), 2);
     assert_eq!(lifecycle.stopped_names().len(), 2);
 }
@@ -3948,4 +3999,94 @@ async fn decision_resolve_unknown_picked_key_returns_400() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_delete_workspace_does_not_remove_same_named_team_in_other_workspace() {
+    let (store, app, _lifecycle, dir) = setup_with_lifecycle_and_data_dir();
+    let human_id = store.get_human_by_name("alice").unwrap().unwrap().id;
+
+    // Create two workspaces
+    let (alpha, _) = store.create_local_workspace("Alpha", &human_id).unwrap();
+    let (beta, _) = store.create_local_workspace("Beta", &human_id).unwrap();
+
+    let bot1 = store.get_agent("bot1").unwrap().unwrap();
+
+    // Create team "ops" in Alpha
+    store.set_active_workspace(&alpha.id).unwrap();
+    let alpha_team_id = store
+        .create_team("ops", "Ops Team", "leader_operators", None)
+        .unwrap();
+    store
+        .create_channel("ops", None, ChannelType::Team, None)
+        .unwrap();
+    store
+        .create_team_member(&alpha_team_id, &bot1.id, "agent", "operator")
+        .unwrap();
+
+    // Create team "ops" in Beta
+    store.set_active_workspace(&beta.id).unwrap();
+    let beta_team_id = store
+        .create_team("ops", "Ops Team", "leader_operators", None)
+        .unwrap();
+    store
+        .create_channel("ops", None, ChannelType::Team, None)
+        .unwrap();
+    store
+        .create_team_member(&beta_team_id, &bot1.id, "agent", "operator")
+        .unwrap();
+
+    // Manually init filesystem directories (normally done via HTTP handler)
+    let agents_dir = dir.path().join("agents");
+    let teams_dir = dir.path().join("data").join("teams");
+    let agent_workspace = AgentWorkspace::new(&agents_dir);
+    let team_workspace = TeamWorkspace::new(teams_dir.clone());
+
+    team_workspace
+        .init_team(&alpha.id, "ops", &alpha_team_id, &[("bot1", &bot1.id)])
+        .unwrap();
+    team_workspace
+        .init_team(&beta.id, "ops", &beta_team_id, &[("bot1", &bot1.id)])
+        .unwrap();
+    agent_workspace
+        .init_team_memory(&alpha.id, "bot1", &bot1.id, "ops", &alpha_team_id, "operator")
+        .unwrap();
+    agent_workspace
+        .init_team_memory(&beta.id, "bot1", &bot1.id, "ops", &beta_team_id, "operator")
+        .unwrap();
+
+    let alpha_team_dir = teams_dir
+        .join(&alpha.id)
+        .join(format!("ops-{}", alpha_team_id));
+    let beta_team_dir = teams_dir
+        .join(&beta.id)
+        .join(format!("ops-{}", beta_team_id));
+
+    assert!(alpha_team_dir.exists(), "alpha team dir should exist");
+    assert!(beta_team_dir.exists(), "beta team dir should exist");
+
+    // Delete Alpha workspace via API
+    let delete_resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/workspaces/{}", alpha.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_resp.status(), StatusCode::OK);
+
+    // Alpha's scoped runtime directories should be gone
+    assert!(
+        !alpha_team_dir.exists(),
+        "alpha team dir should be removed after workspace deletion"
+    );
+
+    // Beta's team directory should still exist
+    assert!(
+        beta_team_dir.exists(),
+        "beta team dir should survive alpha workspace deletion"
+    );
 }

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -4049,7 +4049,14 @@ async fn test_delete_workspace_does_not_remove_same_named_team_in_other_workspac
         .init_team(&beta.id, "ops", &beta_team_id, &[("bot1", &bot1.id)])
         .unwrap();
     agent_workspace
-        .init_team_memory(&alpha.id, "bot1", &bot1.id, "ops", &alpha_team_id, "operator")
+        .init_team_memory(
+            &alpha.id,
+            "bot1",
+            &bot1.id,
+            "ops",
+            &alpha_team_id,
+            "operator",
+        )
         .unwrap();
     agent_workspace
         .init_team_memory(&beta.id, "bot1", &bot1.id, "ops", &beta_team_id, "operator")


### PR DESCRIPTION
Closes #102

## Summary

Moves agent and team runtime directories from flat global layouts to workspace-scoped paths with entity-ID suffixes.

### New Directory Layout

| Resource | Old Path | New Path |
|---|---|---|
| Agent runtime | `agents/{name}/` | `agents/{workspace_id}/{name}-{agent_id}/` |
| Team runtime | `data/teams/{name}/` | `data/teams/{workspace_id}/{name}-{team_id}/` |
| Agent team memory | `agents/{name}/teams/{team}/` | `agents/{wid}/{name}-{id}/teams/{team}-{id}/` |

### Changes

- `AgentWorkspace` / `TeamWorkspace` helpers updated to compute scoped paths
- `AgentManager::start_agent` creates directories under scoped layout
- Workspace deletion handler removes `agents/{wid}/` and `teams/{wid}/` after SQL cleanup
- Lazy migration: old flat-layout directories are automatically moved on first access
- Added cross-workspace isolation test for workspace deletion
- Fixed missing `agent_env_vars` schema migration for existing databases (`agent_name` → `agent_id`)

### Verification

- All tests pass (616+ unit/integration + 10 e2e)
- QA verified agent creation, team creation, team member join, workspace deletion, and lazy migration all produce correct filesystem paths
