### PR TITLE
Phase 4: shrink AgentLifecycle to observability; restart_seq protocol

### DIFF
--- a/src/agent/lifecycle.rs
+++ b/src/agent/lifecycle.rs
@@ -1,48 +1,21 @@
-//! Runtime lifecycle operations the HTTP server can trigger for agents.
+//! Runtime observability the HTTP server reads for activity feeds and
+//! status badges. After the dual-runtime collapse (#149), the bridge
+//! client owns runtime lifecycle entirely; the platform's only role is
+//! to *observe* — `process_state` for status, `get_activity_log_data` /
+//! `get_all_agent_activity_states` for the activity feed,
+//! `active_run_id` / `set_run_channel` / `run_channel_id` for trace
+//! routing. Start/stop/notify/resume moved to the bridge client and
+//! left this trait for good.
 
 use std::future::Future;
 use std::pin::Pin;
 
 use crate::agent::activity_log::ActivityLogResponse;
-use crate::store::agents::Agent;
-use crate::store::messages::ReceivedMessage;
 
 pub trait AgentLifecycle: Send + Sync {
-    /// Start (or wake) an agent process. Takes `&Agent` so the caller is
-    /// forced to hold the full record — this prevents "pass name where id
-    /// was expected" bugs at compile time, and consolidates the previous
-    /// dual entry points (`start_agent(name)` and `start_agent_from_record`)
-    /// into one signature.
-    ///
-    /// `wake_message` carries the unread message that triggered this start, if
-    /// any. `init_directive`, when `Some`, is delivered as the first prompt
-    /// verbatim, overriding the auto-generated greeting/wake/resume prompt.
-    /// Used by the agent-creation path to ask a brand-new agent to introduce
-    /// itself; left `None` for restart, manual-start, and message-driven wake
-    /// paths so existing behavior is unchanged.
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
-    /// Deliver a wakeup notification keyed by `agent_id`.
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
-    /// Stop a managed agent process keyed by `agent_id`.
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
     /// Returns the runtime `ProcessState` for `agent_id` if a managed
     /// process exists, else `None`. Single source of truth for runtime
-    /// liveness; replaces every read of the persisted `agents.status`
-    /// column from this phase onward.
+    /// liveness; the persisted `agents.status` column is gone.
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -77,26 +50,5 @@ pub trait AgentLifecycle: Send + Sync {
         _agent_id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>> {
         Box::pin(async { None })
-    }
-
-    /// Deliver a self-contained envelope to the agent so it can act on a
-    /// human's pick. Routes to the live session's prompt channel when the
-    /// agent is `Active`; otherwise starts the agent with the envelope as
-    /// the `init_directive` so the same payload arrives on first turn.
-    ///
-    /// The envelope is built by the decision handler and contains the
-    /// original headline + question, the picked option's full label and
-    /// body, and any human note. The agent treats it as a new prompt and
-    /// continues its work without needing to re-read history.
-    fn resume_with_prompt<'a>(
-        &'a self,
-        _agent_id: &'a str,
-        _envelope: String,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async {
-            Err(anyhow::anyhow!(
-                "resume_with_prompt not implemented on this AgentLifecycle"
-            ))
-        })
     }
 }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -732,34 +732,6 @@ fn build_start_prompt(
 }
 
 impl AgentLifecycle for AgentManager {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a crate::store::agents::Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::start_agent(
-            self,
-            agent,
-            wake_message,
-            init_directive,
-        ))
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::notify_agent(self, agent_id))
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::stop_agent(self, agent_id))
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -795,14 +767,6 @@ impl AgentLifecycle for AgentManager {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
         let channel = self.trace_store.run_channel_id(agent_id);
         Box::pin(async move { channel })
-    }
-
-    fn resume_with_prompt<'a>(
-        &'a self,
-        agent_id: &'a str,
-        envelope: String,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::resume_with_prompt(self, agent_id, envelope))
     }
 }
 

--- a/src/bridge/client/reconcile.rs
+++ b/src/bridge/client/reconcile.rs
@@ -7,7 +7,7 @@
 //! `forget_sessions_for_agent` is called on stop to drop resume cursors
 //! since FK cascade no longer fires (the bridge runs with FK off, #145).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -49,6 +49,8 @@ pub(super) fn target_to_agent(target: &AgentTargetIn) -> Agent {
         reasoning_effort: target.reasoning_effort.clone(),
         machine_id: None,
         paused: target.paused,
+        restart_seq: target.restart_seq,
+        pending_init_directive: target.init_directive.clone(),
         env_vars: target
             .env_vars
             .iter()
@@ -67,6 +69,7 @@ pub async fn apply(
     store: &Store,
     manager: &AgentManager,
     targets_cache: &Arc<Mutex<TargetCache>>,
+    restart_seen: &Arc<Mutex<HashMap<String, i64>>>,
     targets: Vec<AgentTargetIn>,
 ) -> anyhow::Result<ReconcileOutcome> {
     let mut desired: HashSet<String> = HashSet::new();
@@ -100,11 +103,15 @@ pub async fn apply(
     let running = manager.get_running_agent_ids().await;
     let running_set: HashSet<String> = running.iter().cloned().collect();
 
-    // 3. Walk the desired set: paused targets must be stopped if running,
-    //    everything else must be started if not running. Without this
-    //    paused-aware branch, a `chorus agent stop` (which leaves the
-    //    row in the desired set with `paused=true`) would auto-restart
-    //    on the next reconcile.
+    // 3. Walk the desired set:
+    //    - paused targets must be stopped if running.
+    //    - non-paused targets whose `restart_seq` climbed above the
+    //      last-applied value must be stopped+started (delivering the
+    //      `init_directive` if the platform queued one).
+    //    - non-paused targets that aren't running must be started.
+    //    Without the restart-seq branch, the platform couldn't ask the
+    //    bridge to re-launch a runtime after a spec change or decision
+    //    resume — those lived on the now-gone direct lifecycle calls.
     for target in &targets {
         let already_running = running_set.contains(&target.agent_id);
         if target.paused {
@@ -118,7 +125,17 @@ pub async fn apply(
             }
             continue;
         }
-        if already_running {
+        let last_applied = {
+            let seen = restart_seen.lock().await;
+            seen.get(&target.agent_id).copied().unwrap_or(0)
+        };
+        let needs_restart = target.restart_seq > last_applied && already_running;
+        if needs_restart {
+            if let Err(e) = manager.stop_agent(&target.agent_id).await {
+                tracing::warn!(agent_id = %target.agent_id, err = %e, "stop_agent failed during restart-seq reconcile");
+            }
+        }
+        if !needs_restart && already_running {
             continue;
         }
         let agent = target_to_agent(target);
@@ -130,6 +147,8 @@ pub async fn apply(
                 started.push(AgentTransition {
                     agent_id: target.agent_id.clone(),
                 });
+                let mut seen = restart_seen.lock().await;
+                seen.insert(target.agent_id.clone(), target.restart_seq);
             }
             Err(e) => {
                 tracing::error!(agent = %target.name, agent_id = %target.agent_id, err = %e, "start_agent failed during reconcile");

--- a/src/bridge/client/ws.rs
+++ b/src/bridge/client/ws.rs
@@ -461,22 +461,21 @@ async fn handle_target(ctx: &SessionCtx, target: BridgeTargetIn) {
     let target_agents = target.target_agents;
     let known_platform_ids: Vec<String> =
         target_agents.iter().map(|a| a.agent_id.clone()).collect();
-    let outcome =
-        match reconcile::apply(
-            &ctx.store,
-            &ctx.manager,
-            &ctx.targets,
-            &ctx.restart_seen,
-            target_agents,
-        )
-        .await
-        {
-            Ok(o) => o,
-            Err(e) => {
-                tracing::error!(err = %e, "bridge: reconcile failed");
-                return;
-            }
-        };
+    let outcome = match reconcile::apply(
+        &ctx.store,
+        &ctx.manager,
+        &ctx.targets,
+        &ctx.restart_seen,
+        target_agents,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::error!(err = %e, "bridge: reconcile failed");
+            return;
+        }
+    };
 
     // Replay any chats that arrived before this reconcile populated the
     // targets cache. We only drain entries for platform_ids that are now

--- a/src/bridge/client/ws.rs
+++ b/src/bridge/client/ws.rs
@@ -141,6 +141,11 @@ struct SessionCtx {
     pending_chats: PendingChats,
     targets: Arc<Mutex<TargetCache>>,
     state_tx: tokio::sync::mpsc::Sender<String>,
+    /// Per-agent last-applied `restart_seq`. The bridge consumes a
+    /// restart when the platform-supplied value climbs above what's
+    /// here. Lives on the session so it survives reconnects without
+    /// re-launching every agent on every hello.
+    restart_seen: Arc<Mutex<std::collections::HashMap<String, i64>>>,
 }
 
 // ── Outbound frame helpers ────────────────────────────────────────────────
@@ -231,6 +236,7 @@ pub async fn run_ws_client_loop(
     let counter = Arc::new(InstanceCounter::default());
     let pending_chats: PendingChats = Arc::new(Mutex::new(HashMap::new()));
     let targets = Arc::new(Mutex::new(TargetCache::default()));
+    let restart_seen = Arc::new(Mutex::new(HashMap::<String, i64>::new()));
 
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
     loop {
@@ -252,6 +258,7 @@ pub async fn run_ws_client_loop(
             counter.clone(),
             pending_chats.clone(),
             targets.clone(),
+            restart_seen.clone(),
             shutdown.clone(),
         )
         .await
@@ -278,6 +285,7 @@ async fn run_one_session(
     counter: Arc<InstanceCounter>,
     pending_chats: PendingChats,
     targets: Arc<Mutex<TargetCache>>,
+    restart_seen: Arc<Mutex<std::collections::HashMap<String, i64>>>,
     shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     // The session-level state (counter, pending_chats, targets) is owned by
@@ -326,6 +334,7 @@ async fn run_one_session(
         pending_chats,
         targets,
         state_tx,
+        restart_seen,
     };
 
     // 3. Spawn the agent.state pusher task.
@@ -453,7 +462,15 @@ async fn handle_target(ctx: &SessionCtx, target: BridgeTargetIn) {
     let known_platform_ids: Vec<String> =
         target_agents.iter().map(|a| a.agent_id.clone()).collect();
     let outcome =
-        match reconcile::apply(&ctx.store, &ctx.manager, &ctx.targets, target_agents).await {
+        match reconcile::apply(
+            &ctx.store,
+            &ctx.manager,
+            &ctx.targets,
+            &ctx.restart_seen,
+            target_agents,
+        )
+        .await
+        {
             Ok(o) => o,
             Err(e) => {
                 tracing::error!(err = %e, "bridge: reconcile failed");

--- a/src/bridge/protocol.rs
+++ b/src/bridge/protocol.rs
@@ -142,6 +142,13 @@ pub struct AgentTarget {
     /// never emit this field.
     #[serde(default)]
     pub paused: bool,
+    /// Monotonic counter the platform bumps when the runtime needs to
+    /// stop+start (spec change, manual restart, decision resume). The
+    /// bridge tracks the last-applied value per agent in memory and
+    /// re-launches when this climbs. Defaults to `0` so older platforms
+    /// (which never emit it) implicitly request "no restart needed".
+    #[serde(default)]
+    pub restart_seq: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -512,30 +512,19 @@ pub async fn handle_update_agent(
     let ps = state.lifecycle.process_state(&agent_id).await;
     let was_running = crate::agent::process_status::derive_status(ps.as_ref())
         != crate::agent::process_status::Status::Asleep;
+    let _ = machine_id_resolved;
 
-    // Bridge-hosted agents are restarted by the remote bridge when it
-    // receives the broadcast target update below. The platform does not
-    // own the runtime process and must not call start/stop. "Bridge-hosted"
-    // here means "owned by a non-local machine_id"; agents with
-    // machine_id == local_machine_id still go through the platform's
-    // in-process AgentManager until Phase 2 swaps it for the in-process
-    // bridge client.
-    let bridge_hosted = machine_id_resolved != state.local_machine_id;
-    if was_running && requires_restart && !bridge_hosted {
+    // Spec-affecting updates need the runtime to relaunch with the new
+    // values. Bumping `restart_seq` signals the owning bridge — in-proc
+    // for `chorus serve`, remote for `chorus bridge` — to stop+start
+    // the runtime via reconcile. Same effect the old direct
+    // `lifecycle.stop_agent` + `start_agent` had, routed through the
+    // single bridge protocol.
+    if requires_restart {
         state
-            .lifecycle
-            .stop_agent(&agent_id)
-            .await
+            .store
+            .bump_restart_seq(&agent_id)
             .map_err(internal_err)?;
-        // Reload after the update so spec changes (env_vars, model, runtime)
-        // take effect on the restart.
-        let refreshed = resolve_public_agent_with_env(&state, &existing.id)?;
-        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
-            return Err(app_err!(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "agent updated but restart failed: {err}"
-            ));
-        }
     }
     broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
     Ok(Json(serde_json::json!({
@@ -554,18 +543,6 @@ pub async fn handle_restart_agent(
     let _transition = acquire_transition(&state, &agent.id)?;
     let agents_dir = state.agents_dir.clone();
     let workspace = AgentWorkspace::new(&agents_dir);
-
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if !bridge_hosted {
-        state
-            .lifecycle
-            .stop_agent(&agent.id)
-            .await
-            .map_err(internal_err)?;
-    }
 
     match req.mode {
         RestartMode::Restart => {}
@@ -591,20 +568,14 @@ pub async fn handle_restart_agent(
         }
     }
 
-    if !bridge_hosted {
-        // Reload after RestartMode::ResetSession / FullReset so the start
-        // sees post-clear state for env_vars/spec lookups.
-        let refreshed = resolve_public_agent_with_env(&state, &agent.id)?;
-        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
-            return Err(app_err!(
-                AppErrorCode::AgentRestartFailed,
-                "restart failed: {err}"
-            ));
-        }
-    } else {
-        // Push fresh target so the bridge stops/starts the runtime locally.
-        broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
-    }
+    // Bump `restart_seq` and broadcast — the bridge sees the new value
+    // on its next target frame and stops+starts the runtime through
+    // reconcile. Replaces the platform's old direct lifecycle calls.
+    state
+        .store
+        .bump_restart_seq(&agent.id)
+        .map_err(internal_err)?;
+    broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
     Ok(Json(serde_json::json!({
         "ok": true,
         "mode": req.mode,

--- a/src/server/handlers/decisions.rs
+++ b/src/server/handlers/decisions.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use super::AppState;
 use crate::server::error::{app_err, ApiResult};
+use crate::server::transport::bridge_ws::broadcast_target_update;
 use crate::store::{DecisionRow, DecisionStatus};
 
 // ── Internal: agent emits a decision ──────────────────────────────────────
@@ -310,38 +311,59 @@ pub async fn handle_resolve_decision(
 
     let envelope = build_resume_envelope(&payload, picked, body.note.as_deref());
 
+    // Persist the envelope as `pending_init_directive` and bump
+    // `restart_seq`. The owning bridge — in-proc for `chorus serve`,
+    // remote for `chorus bridge` — picks both up on the next target
+    // frame, stops the runtime, and starts it with the envelope as the
+    // init prompt. Replaces the synchronous
+    // `lifecycle.resume_with_prompt` call.
+    //
+    // Loss of the synchronous "delivered to agent" guarantee is the
+    // tradeoff for collapsing the dual runtime path (#149). The
+    // platform now confirms persistence; the bridge client confirms
+    // delivery via its own start_agent path. If a future sync-style
+    // confirmation is needed, an `agent.directive_consumed` ack frame
+    // can be added without changing this handler.
     if let Err(e) = state
-        .lifecycle
-        .resume_with_prompt(&agent.id, envelope)
-        .await
+        .store
+        .set_pending_init_directive(&agent.id, Some(&envelope))
     {
-        // Roll back the resolve so the human's pick isn't silently lost.
         warn!(
             agent = %agent.name,
             agent_id = %agent.id,
             decision_id = %decision_id,
             error = %e,
-            "resume_with_prompt failed; reverting decision to open"
+            "set_pending_init_directive failed; reverting decision to open"
         );
         if let Err(revert_err) = state.store.revert_decision_to_open(&decision_id) {
             warn!(
                 decision_id = %decision_id,
                 error = %revert_err,
-                "failed to revert decision after resume failure"
+                "failed to revert decision after directive persistence failure"
             );
         }
         return Err(app_err!(
             StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to deliver pick to agent: {e}"
+            "failed to queue pick for agent: {e}"
         ));
     }
+    if let Err(e) = state.store.bump_restart_seq(&agent.id) {
+        warn!(
+            agent = %agent.name,
+            agent_id = %agent.id,
+            decision_id = %decision_id,
+            error = %e,
+            "bump_restart_seq failed after queueing directive; agent may not pick up the envelope"
+        );
+    }
+    broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
 
     info!(
         target: "chorus_decision",
         decision_id = %decision_id,
         agent = %agent.name,
         picked = %body.picked_key,
-        "decision resolved + envelope delivered"
+        "decision resolved + envelope queued for bridge delivery"
     );
 
     Ok(Json(ResolveDecisionResponse {

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -101,10 +101,9 @@ async fn sync_team_roles_and_agents(
 
 /// Restart an agent so its system prompt is rebuilt from the latest team state.
 ///
-/// For bridge-hosted agents (`agents.machine_id` set), the platform does not
-/// own the runtime; it broadcasts a fresh `bridge.target` instead so the
-/// remote bridge can stop/start the local process. Calling `start_agent`
-/// here would cause dual-runtime contention.
+/// Bumps `restart_seq` and broadcasts a fresh target — the owning
+/// bridge stops+starts the runtime via reconcile. The platform never
+/// touches the runtime process directly.
 async fn restart_agent_member(
     state: &AppState,
     agent_name: &str,
@@ -113,27 +112,14 @@ async fn restart_agent_member(
         Some(a) => a,
         None => return Ok(()),
     };
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if bridge_hosted {
-        crate::server::transport::bridge_ws::broadcast_target_update(
-            state.store.as_ref(),
-            state.bridge_registry.as_ref(),
-        );
-        return Ok(());
-    }
     state
-        .lifecycle
-        .stop_agent(&agent.id)
-        .await
+        .store
+        .bump_restart_seq(&agent.id)
         .map_err(internal_err)?;
-    state
-        .lifecycle
-        .start_agent(&agent, None, None)
-        .await
-        .map_err(internal_err)?;
+    crate::server::transport::bridge_ws::broadcast_target_update(
+        state.store.as_ref(),
+        state.bridge_registry.as_ref(),
+    );
     Ok(())
 }
 

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -61,9 +61,13 @@ fn agent_to_target(a: Agent) -> AgentTarget {
                 value: e.value,
             })
             .collect(),
-        init_directive: None,
+        // Propagate the persisted decision-resume envelope as the
+        // bridge-protocol init_directive. Bridge consumes it on the
+        // restart-seq-driven re-launch.
+        init_directive: a.pending_init_directive,
         pending_prompt: None,
         paused: a.paused,
+        restart_seq: a.restart_seq,
     }
 }
 

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -41,6 +41,24 @@ pub struct Agent {
     /// reconcile.
     #[serde(default)]
     pub paused: bool,
+    /// Monotonic counter the platform bumps when the bridge needs to
+    /// stop+start the runtime (spec change, manual restart, decision
+    /// resume). The bridge client tracks the last-applied value per
+    /// agent in memory and re-launches the runtime when the value
+    /// climbs. Replaces the platform's old `lifecycle.start_agent` /
+    /// `stop_agent` direct calls.
+    #[serde(default)]
+    pub restart_seq: i64,
+    /// One-shot envelope delivered as the first prompt on the next
+    /// restart-driven start. Used by `handle_resolve_decision` so the
+    /// human's pick reaches the agent without a synchronous
+    /// `resume_with_prompt` call from the platform. The bridge client
+    /// consumes it on apply and (eventually) acks back so the platform
+    /// can clear the column; today we leave it set, since each new
+    /// directive overwrites the previous and `restart_seq` is what
+    /// drives delivery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_init_directive: Option<String>,
     /// Injected environment variables (ordered by `position`).
     pub env_vars: Vec<AgentEnvVar>,
     /// Row creation time.
@@ -198,6 +216,40 @@ impl Store {
         Ok(())
     }
 
+    /// Bump `agents.restart_seq` for one agent. The bridge client
+    /// tracks the last-applied value per agent in memory and re-launches
+    /// the runtime when it climbs. Used by `handle_update_agent` (on
+    /// spec change), `handle_restart_agent`, and team membership
+    /// changes — every place that used to call `lifecycle.stop_agent`
+    /// + `lifecycle.start_agent` directly.
+    pub fn bump_restart_seq(&self, agent_id: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE agents SET restart_seq = restart_seq + 1 WHERE id = ?1",
+            params![agent_id],
+        )?;
+        Ok(updated)
+    }
+
+    /// Persist a one-shot envelope as `pending_init_directive`. The
+    /// bridge consumes it on the next `restart_seq`-driven re-launch.
+    /// Used by `handle_resolve_decision` so a human's pick is delivered
+    /// to the agent without a synchronous `resume_with_prompt` call
+    /// from the platform. Pair with `bump_restart_seq` to actually
+    /// trigger consumption.
+    pub fn set_pending_init_directive(
+        &self,
+        agent_id: &str,
+        directive: Option<&str>,
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE agents SET pending_init_directive = ?1 WHERE id = ?2",
+            params![directive, agent_id],
+        )?;
+        Ok(updated)
+    }
+
     /// Toggle the `paused` flag for one agent (keyed by id). Called by
     /// the start/stop handlers so the bridge client's reconcile can
     /// honor the soft-stop without removing the row from the desired
@@ -267,7 +319,7 @@ impl Store {
                 None => return Ok(Vec::new()),
             },
         };
-        let sql = "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, created_at
+        let sql = "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, restart_seq, pending_init_directive, created_at
                    FROM agents WHERE workspace_id = ?1 ORDER BY name";
         let rows = conn
             .prepare(sql)?
@@ -280,7 +332,7 @@ impl Store {
     pub fn get_agent(&self, name: &str) -> Result<Option<Agent>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, created_at FROM agents WHERE name = ?1",
+            "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, restart_seq, pending_init_directive, created_at FROM agents WHERE name = ?1",
         )?;
         let mut rows = stmt.query_map(params![name], Self::agent_from_row)?;
         let mut agent = rows.next().transpose()?;
@@ -293,7 +345,7 @@ impl Store {
     pub fn get_agent_by_id(&self, id: &str, hydrate_env: bool) -> Result<Option<Agent>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, created_at FROM agents WHERE id = ?1",
+            "SELECT id, workspace_id, name, display_name, description, system_prompt, runtime, model, reasoning_effort, machine_id, paused, restart_seq, pending_init_directive, created_at FROM agents WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], Self::agent_from_row)?;
         let mut agent = rows.next().transpose()?;
@@ -361,7 +413,7 @@ impl Store {
     }
 
     fn agent_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Agent> {
-        let created_at = row.get::<_, String>(11)?;
+        let created_at = row.get::<_, String>(13)?;
         let paused: i64 = row.get(10)?;
         Ok(Agent {
             id: row.get(0)?,
@@ -375,6 +427,8 @@ impl Store {
             reasoning_effort: row.get(8)?,
             machine_id: row.get(9)?,
             paused: paused != 0,
+            restart_seq: row.get(11)?,
+            pending_init_directive: row.get(12)?,
             env_vars: Vec::new(),
             created_at: parse_datetime(&created_at),
         })

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -121,6 +121,27 @@ impl Store {
                 if msg.contains("duplicate column name") => {}
             Err(e) => return Err(e.into()),
         }
+        // `restart_seq` and `pending_init_directive` arrived with the
+        // bridge-driven restart/resume protocol (#149 phase 4). Same
+        // idempotent ALTER pattern.
+        match conn.execute(
+            "ALTER TABLE agents ADD COLUMN restart_seq INTEGER NOT NULL DEFAULT 0",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+                if msg.contains("duplicate column name") => {}
+            Err(e) => return Err(e.into()),
+        }
+        match conn.execute(
+            "ALTER TABLE agents ADD COLUMN pending_init_directive TEXT",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+                if msg.contains("duplicate column name") => {}
+            Err(e) => return Err(e.into()),
+        }
         // Migrate agent_env_vars from agent_name FK to agent_id FK.
         // SQLite has no ALTER TABLE DROP COLUMN, so we recreate the table.
         if Self::schema_column_exists(conn, "agent_env_vars", "agent_name")? {

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -107,6 +107,8 @@ CREATE TABLE IF NOT EXISTS agents (
     reasoning_effort TEXT, -- The reasoning effort configuration
     machine_id TEXT, -- Owner. Some(machine_id) = bound to that bridge; NULL = platform-local. Every agent has one owner.
     paused INTEGER NOT NULL DEFAULT 0, -- Soft-stop: 1 = bridge client should keep this agent stopped even though it's still in the desired set; 0 = run normally. Set by handle_agent_stop, cleared by handle_agent_start.
+    restart_seq INTEGER NOT NULL DEFAULT 0, -- Monotonic counter bumped by handlers that need the bridge to stop+start the runtime (spec change, manual restart, decision resume). Bridge client tracks last-applied per agent and triggers a restart on bump.
+    pending_init_directive TEXT, -- One-shot envelope delivered as the first prompt on the next restart_seq bump. Used by handle_resolve_decision so a human's pick reaches the agent without a synchronous lifecycle call from the platform.
     created_at TEXT NOT NULL DEFAULT (datetime('now')) -- When the agent was created
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_workspace_name

--- a/tests/agent_status_derivation_tests.rs
+++ b/tests/agent_status_derivation_tests.rs
@@ -10,7 +10,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use chorus::agent::AgentLifecycle;
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{ReceivedMessage, SenderType};
+use chorus::store::messages::SenderType;
 use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
 use harness::build_router_with_lifecycle;
@@ -31,36 +31,6 @@ struct MockLifecycle {
 }
 
 impl AgentLifecycle for MockLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let id = agent.id.clone();
-        Box::pin(async move {
-            self.running.lock().unwrap().insert(id);
-            Ok(())
-        })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async move {
-            self.running.lock().unwrap().remove(agent_id);
-            Ok(())
-        })
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::ReceivedMessage;
+// removed: ReceivedMessage no longer needed after AgentLifecycle trait shrink
 use chorus::store::Store;
 use harness::join_channel_silent;
 
@@ -72,29 +72,6 @@ async fn start_bridge_with_server(
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -12,37 +12,12 @@ use chorus::agent::AgentLifecycle;
 use chorus::server::bridge_auth::BridgeAuth;
 use chorus::server::event_bus::EventBus;
 use chorus::server::{build_router_with_services, build_router_with_services_and_auth};
-use chorus::store::agents::Agent;
-use chorus::store::messages::ReceivedMessage;
 use chorus::store::Store;
 use rusqlite::params;
 
 pub struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -89,7 +89,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::ReceivedMessage;
+// removed: ReceivedMessage no longer needed after AgentLifecycle trait shrink
 use chorus::store::{AgentRecordUpsert, Store};
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
@@ -105,29 +105,6 @@ use tokio::time::timeout;
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -82,7 +82,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
+use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::{AgentRecordUpsert, Store};
 
 // ---------------------------------------------------------------------------
@@ -95,29 +95,6 @@ use chorus::store::{AgentRecordUpsert, Store};
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -187,7 +187,6 @@ impl MockLifecycle {
             .unwrap()
             .insert(agent_name.to_string(), channel_id.to_string());
     }
-
 }
 
 impl AgentLifecycle for MockLifecycle {
@@ -228,7 +227,6 @@ impl AgentLifecycle for MockLifecycle {
         let id = self.run_channels.lock().unwrap().get(agent_name).cloned();
         Box::pin(async move { id })
     }
-
 }
 
 impl AgentLifecycle for FailStartLifecycle {

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -12,7 +12,7 @@ use chorus::server::dto::ChannelInfo;
 use chorus::server::dto::ServerInfo;
 use chorus::server::{AgentDetailResponse, HistoryResponse};
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
+use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
 use harness::{build_router, build_router_with_lifecycle, join_channel_silent};
@@ -105,24 +105,16 @@ fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
 
 /// One observed `start_agent` invocation: `(agent_name, wake_message, init_directive)`.
 /// Tests assert against the recorded sequence to pin call-site behavior.
-type StartedCall = (String, Option<ReceivedMessage>, Option<String>);
-
 #[derive(Default)]
 struct MockLifecycle {
-    started: Mutex<Vec<StartedCall>>,
-    stopped: Mutex<Vec<String>>,
-    notified: Mutex<Vec<String>>,
     activity_logs: ActivityLogMap,
-    /// Tracks which agents are currently "running" so that process_state,
-    /// start_agent, and stop_agent share one source of truth. Keyed by
-    /// agent name internally so existing tests can use `mark_running(name)`
-    /// without knowing the agent's id; trait calls that arrive by id are
-    /// translated through `store` below before lookup.
+    /// Tracks which agents are currently "running" so that
+    /// `process_state` returns Active for them. Tests use
+    /// `mark_running(name)` to simulate a live runtime without
+    /// spinning up a real `AgentManager`. Keyed by agent name; trait
+    /// calls that arrive by id are translated through `store` below
+    /// before lookup.
     running: Mutex<HashSet<String>>,
-    /// Records every (agent_name, envelope) pair delivered via
-    /// `resume_with_prompt`. Decision-inbox round-trip tests assert the
-    /// envelope reached the agent.
-    resumed_with: Mutex<Vec<(String, String)>>,
     /// Per-agent channel id returned by `run_channel_id`. Tests preset
     /// this to simulate the trace_store's "current channel for current
     /// run" record without spinning a real AgentManager.
@@ -130,8 +122,7 @@ struct MockLifecycle {
     /// Optional store reference used to translate `agent_id` (the new
     /// keying after #142) back into `agent_name` so internal recording
     /// stays name-keyed for assertion compatibility. Wire this via
-    /// `set_store` in setup helpers; trait methods fall through to
-    /// raw-string semantics when absent.
+    /// `set_store` in setup helpers.
     store: Mutex<Option<Arc<Store>>>,
 }
 
@@ -180,27 +171,6 @@ impl MockLifecycle {
         key.to_string()
     }
 
-    fn started_names(&self) -> Vec<String> {
-        self.started
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(name, _, _)| name.clone())
-            .collect()
-    }
-
-    fn notified_names(&self) -> Vec<String> {
-        self.notified.lock().unwrap().clone()
-    }
-
-    fn started_calls(&self) -> Vec<StartedCall> {
-        self.started.lock().unwrap().clone()
-    }
-
-    fn stopped_names(&self) -> Vec<String> {
-        self.stopped.lock().unwrap().clone()
-    }
-
     /// Simulate an already-running managed process. Subsequent
     /// `process_state` calls will return `Active` for this agent,
     /// mirroring what the real manager would report when a process
@@ -218,52 +188,9 @@ impl MockLifecycle {
             .insert(agent_name.to_string(), channel_id.to_string());
     }
 
-    fn resumed_calls(&self) -> Vec<(String, String)> {
-        self.resumed_with.lock().unwrap().clone()
-    }
 }
 
 impl AgentLifecycle for MockLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a chorus::store::agents::Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = agent.name.clone();
-        Box::pin(async move {
-            self.started
-                .lock()
-                .unwrap()
-                .push((name.clone(), wake_message, init_directive));
-            self.running.lock().unwrap().insert(name);
-            Ok(())
-        })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.notified.lock().unwrap().push(name);
-            Ok(())
-        })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.stopped.lock().unwrap().push(name.clone());
-            self.running.lock().unwrap().remove(&name);
-            Ok(())
-        })
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -302,43 +229,9 @@ impl AgentLifecycle for MockLifecycle {
         Box::pin(async move { id })
     }
 
-    fn resume_with_prompt<'a>(
-        &'a self,
-        agent_id: &'a str,
-        envelope: String,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.resumed_with.lock().unwrap().push((name, envelope));
-            Ok(())
-        })
-    }
 }
 
 impl AgentLifecycle for FailStartLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Err(anyhow::anyhow!("runtime unavailable")) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn process_state<'a>(
         &'a self,
         _agent_name: &'a str,
@@ -1546,10 +1439,11 @@ async fn test_create_kimi_agent_via_api() {
     assert_eq!(agent.runtime, "kimi");
     assert_eq!(agent.model, "kimi-code/kimi-for-coding");
     assert_eq!(agent.reasoning_effort, None);
-    assert!(
-        lifecycle.started_names().is_empty(),
-        "platform must not call lifecycle.start_agent at create time anymore"
-    );
+    // The platform no longer calls `lifecycle.start_agent` at create
+    // time — coverage of that invariant moved to the trait shape itself
+    // (the trait is now observability-only; there's no `start_agent`
+    // method to call).
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -1609,8 +1503,16 @@ async fn test_get_and_update_agent_via_api() {
     assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // After the dual-runtime collapse (#149), the platform doesn't
+    // call lifecycle.start_agent / stop_agent on PATCH. It bumps
+    // `restart_seq` and broadcasts; the bridge stops+starts the
+    // runtime via reconcile.
+    assert!(
+        agent.restart_seq > 0,
+        "spec change should bump restart_seq, got {}",
+        agent.restart_seq
+    );
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -1663,8 +1565,13 @@ async fn test_update_agent_to_kimi_clears_reasoning_effort() {
     assert_eq!(agent.reasoning_effort, None);
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // Restart now flows through the bridge protocol via restart_seq.
+    assert!(
+        agent.restart_seq > 0,
+        "runtime change should bump restart_seq, got {}",
+        agent.restart_seq
+    );
+    let _ = lifecycle;
 }
 
 /// Regression: a config-edit PATCH must not trigger a restart when the
@@ -1702,14 +1609,10 @@ async fn config_edit_does_not_restart_when_no_process_managed_despite_db_active(
         body["restarted"], false,
         "config-edit must not restart when manager has no process, regardless of DB status"
     );
-    assert!(
-        lifecycle.stopped_names().is_empty(),
-        "no managed process means nothing to stop"
-    );
-    assert!(
-        lifecycle.started_names().is_empty(),
-        "no managed process means nothing to restart"
-    );
+    // The platform never calls `lifecycle.start_agent` / `stop_agent`
+    // anymore; the bridge owns that path. We assert through the
+    // response payload instead — `restarted: false` is the contract.
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2092,8 +1995,7 @@ async fn test_send_can_skip_agent_delivery() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert!(lifecycle.started_names().is_empty());
-    assert!(lifecycle.notified_names().is_empty());
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2156,8 +2058,15 @@ async fn test_create_team_endpoint() {
     let channel_members = store.get_channel_members(&ch.id).unwrap();
     assert!(channel_members.iter().any(|m| m.member_id == current_user));
 
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // Team membership changes bump `restart_seq` for affected agents
+    // so the bridge re-launches them with the new system prompt.
+    let bot1_post = store.get_agent("bot1").unwrap().unwrap();
+    assert!(
+        bot1_post.restart_seq > 0,
+        "team membership change should bump bot1 restart_seq, got {}",
+        bot1_post.restart_seq
+    );
+    let _ = lifecycle;
 
     let workspace_id = &team.workspace_id;
     let team_dir_name = format!("{}-{}", team.name, team.id);
@@ -2375,8 +2284,15 @@ async fn test_list_and_update_team_endpoints() {
     assert_eq!(updated_team.display_name, "Applied Science Platform");
     assert_eq!(bot1_member.role, "leader");
     assert_eq!(bot2_member.role, "operator");
-    assert_eq!(lifecycle.started_names().len(), 2);
-    assert_eq!(lifecycle.stopped_names().len(), 2);
+    let bot1_post = store.get_agent("bot1").unwrap().unwrap();
+    let bot2_post = store.get_agent("bot2").unwrap().unwrap();
+    assert!(
+        bot1_post.restart_seq > 0 && bot2_post.restart_seq > 0,
+        "both agents should have bumped restart_seq after team update; bot1={}, bot2={}",
+        bot1_post.restart_seq,
+        bot2_post.restart_seq
+    );
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2515,8 +2431,15 @@ async fn test_add_remove_and_delete_team_endpoints() {
         .join(&workspace_id)
         .join(&team_dir_name)
         .exists());
-    assert_eq!(lifecycle.started_names().len(), 2);
-    assert_eq!(lifecycle.stopped_names().len(), 2);
+    // Membership add/remove and team delete all bump restart_seq for
+    // affected agents — the bridge picks this up and re-launches them.
+    let bot1_post = store.get_agent("bot1").unwrap().unwrap();
+    assert!(
+        bot1_post.restart_seq > 0,
+        "team add/remove/delete should bump bot1 restart_seq, got {}",
+        bot1_post.restart_seq
+    );
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -3217,29 +3140,15 @@ async fn test_non_member_history_returns_message_not_a_member() {
     assert_eq!(body["code"], "MESSAGE_NOT_A_MEMBER");
 }
 
-#[tokio::test]
-async fn test_restart_agent_start_fails_returns_agent_restart_failed() {
-    let store = Arc::new(Store::open(":memory:").unwrap());
-    seed_default_workspace(&store);
-    let req = serde_json::json!({ "mode": "restart" });
-    let bot1 = store.get_agent("bot1").unwrap().unwrap();
-    let app = build_router_with_lifecycle(store, Arc::new(FailStartLifecycle));
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri(format!("/api/agents/{}/restart", bot1.id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    let body = body_json(resp).await;
-    assert_eq!(body["code"], "AGENT_RESTART_FAILED");
-}
+// `test_restart_agent_start_fails_returns_agent_restart_failed` was
+// deleted with the dual-runtime collapse (#149). Its premise — that
+// `POST /api/agents/{id}/restart` returns `AGENT_RESTART_FAILED` when
+// the synchronous platform-side `start_agent` fails — no longer
+// applies. The platform now bumps `restart_seq` and returns 200; the
+// bridge restarts asynchronously and surfaces failures via the
+// realtime `agent.state` stream. A test for the new behavior would
+// register a fake bridge in the registry and assert it received the
+// restart-bumped target frame; deferred to the bridge-test layer.
 
 #[tokio::test]
 async fn create_channel_rejects_invalid_names() {
@@ -3409,17 +3318,23 @@ async fn public_send_allows_empty_content_with_attachments() {
 // asserting that the bridge.target / `agent.directive` frame carries
 // the intro string for fresh creations.
 
+// `test_manual_restart_does_not_fire_intro_directive` was rewritten
+// with the dual-runtime collapse (#149). The platform no longer calls
+// `lifecycle.start_agent` on restart; it bumps `restart_seq` and
+// broadcasts. The bridge sees the bump and re-launches the runtime
+// without an init directive (intro-directive plumbing for new agents
+// is a separate Phase 4 follow-up).
 #[tokio::test]
-async fn test_manual_restart_does_not_fire_intro_directive() {
-    // setup_with_lifecycle() already seeds bot1 in the default workspace.
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    lifecycle.mark_running("bot1");
+async fn test_manual_restart_bumps_restart_seq_without_directive() {
+    let (store, app, _lifecycle) = setup_with_lifecycle();
+    let bot1 = store.get_agent("bot1").unwrap().unwrap();
+    let pre_seq = bot1.restart_seq;
 
     let resp = app
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/agents/bot1/restart")
+                .uri(format!("/api/agents/{}/restart", bot1.id))
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::to_vec(&serde_json::json!({ "mode": "restart" })).unwrap(),
@@ -3430,12 +3345,15 @@ async fn test_manual_restart_does_not_fire_intro_directive() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let started = lifecycle.started_calls();
-    assert_eq!(started.len(), 1);
-    assert_eq!(started[0].0, "bot1");
+    let post = store.get_agent("bot1").unwrap().unwrap();
     assert!(
-        started[0].2.is_none(),
-        "restart must not pass an init directive — only first-time creation does"
+        post.restart_seq > pre_seq,
+        "restart should bump restart_seq: pre={pre_seq}, post={}",
+        post.restart_seq
+    );
+    assert!(
+        post.pending_init_directive.is_none(),
+        "manual restart must not queue an init directive"
     );
 }
 
@@ -3536,15 +3454,20 @@ async fn decision_round_trip_agent_creates_human_resolves_agent_resumed() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK, "resolve must 200");
 
-    // 4. resume_with_prompt fired with the right payload.
-    let calls = lifecycle.resumed_calls();
-    assert_eq!(
-        calls.len(),
-        1,
-        "resume_with_prompt must be called exactly once"
+    // 4. After the dual-runtime collapse (#149), resolving a decision
+    // persists the envelope as `pending_init_directive` and bumps
+    // `restart_seq` instead of calling `lifecycle.resume_with_prompt`
+    // synchronously. The owning bridge picks both up via reconcile and
+    // delivers the prompt on its next start.
+    let bot1 = store.get_agent("bot1").unwrap().unwrap();
+    assert!(
+        bot1.restart_seq > 0,
+        "decision resolve should bump restart_seq, got {}",
+        bot1.restart_seq
     );
-    let (agent, envelope) = &calls[0];
-    assert_eq!(agent, "bot1");
+    let envelope = bot1
+        .pending_init_directive
+        .expect("envelope must be persisted on the agent row");
     assert!(
         envelope.contains("PR #120 retro"),
         "envelope must include original headline; got: {envelope}"
@@ -3553,6 +3476,7 @@ async fn decision_round_trip_agent_creates_human_resolves_agent_resumed() {
     assert!(envelope.contains("Picked option (B): Revert and add tests"));
     assert!(envelope.contains("Revert, add the integration test"));
     assert!(envelope.contains("needs tests first"));
+    let _ = lifecycle;
 
     // 5. The decision row is now resolved, so /open lists nothing.
     let resp = app


### PR DESCRIPTION
## Summary

Phase 4 of [#149](https://github.com/Fullstop000/Chorus/issues/149). Drops the last four direct lifecycle calls from HTTP handlers and shrinks `AgentLifecycle` to observability only. The bridge client owns runtime lifecycle entirely.

- New: \`agents.restart_seq\` (monotonic counter) + \`agents.pending_init_directive\` (one-shot envelope) columns. Idempotent ALTERs.
- New: \`AgentTarget.restart_seq\` wire field. Bridge client tracks last-applied per agent and re-launches the runtime on bump.
- Changed: \`handle_update_agent\`, \`handle_restart_agent\`, \`handle_resolve_decision\`, \`teams.restart_agent_member\` all bump \`restart_seq\` (and persist \`pending_init_directive\` for resume) instead of calling \`lifecycle.start_agent\` / \`stop_agent\` / \`resume_with_prompt\`.
- Trait shrink: \`start_agent\`, \`stop_agent\`, \`notify_agent\`, \`resume_with_prompt\` are gone. Trait keeps \`process_state\` and the activity-log/run methods.
- \`MockLifecycle\` / \`NoopLifecycle\` across all test files lose the matching impls.

## Tradeoff (documented in #149 risks)

\`handle_resolve_decision\` loses the synchronous "delivered to agent" guarantee. The human's pick still reaches the agent on the next bridge reconcile, but the platform now confirms persistence rather than delivery. If a sync confirmation becomes necessary, an \`agent.directive_consumed\` ack frame can be added without changing the handler contract.

## Tests

- 605 cargo tests pass
- LLM-gated MSG-001 / 002 / 004 / 006 / LFC-001 under \`CHORUS_WORKERS=2 --retries=1\` — all 6 green in 41.6s
- Test refactor: tests that asserted via \`MockLifecycle\` spy now assert against the store (\`restart_seq\` increments, \`pending_init_directive\` is persisted). \`test_restart_agent_start_fails_returns_agent_restart_failed\` and \`test_create_agent_passes_intro_directive_referencing_system_channel\` deleted with rationale (the synchronous-error contracts they tested no longer exist).

## Phase 5 / cleanup follow-ups

- Auto-intro directive on agent creation (parked since phase 2+3) needs a similar \`pending_init_directive\` flow at create time.
- The \`paused\` flag could be visible in the API response so UIs can show a "paused" badge instead of guessing from process_state.
- \`agents.machine_id\` could be flipped to \`NOT NULL\` at the schema level now that every code path writes it.

## Test plan

- [x] \`cargo test\` — 605 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Playwright smoke parallel (\`CHORUS_E2E_LLM=0\`)
- [x] LLM-gated MSG suite under WORKERS=2 + retries=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)