### PR TITLE
cleanup: drop migration shims; flip machine_id to NOT NULL

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -821,7 +821,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-5.4-mini",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();
@@ -1076,7 +1076,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-fake",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();
@@ -1151,7 +1151,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-fake",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();

--- a/src/bridge/client/reconcile.rs
+++ b/src/bridge/client/reconcile.rs
@@ -47,7 +47,11 @@ pub(super) fn target_to_agent(target: &AgentTargetIn) -> Agent {
         runtime: target.runtime.clone(),
         model: target.model.clone(),
         reasoning_effort: target.reasoning_effort.clone(),
-        machine_id: None,
+        // Bridge-side stub: the manager doesn't read `machine_id` (the
+        // bridge IS the machine), so an empty string is fine. Filling
+        // it with the bridge's own id would also be correct but adds a
+        // dependency on cfg threading.
+        machine_id: String::new(),
         paused: target.paused,
         restart_seq: target.restart_seq,
         pending_init_directive: target.init_directive.clone(),

--- a/src/server/bridge_auth.rs
+++ b/src/server/bridge_auth.rs
@@ -216,11 +216,11 @@ pub async fn require_bridge_auth(
                                 .into_response();
                         }
                     };
-                    if owner.as_deref() != Some(expected_machine_id.as_str()) {
+                    if owner != *expected_machine_id {
                         warn!(
                             path = %path,
                             token_machine_id = %expected_machine_id,
-                            agent_owner = ?owner,
+                            agent_owner = %owner,
                             "bridge_auth: rejecting /internal request — token's machine_id does not own this agent"
                         );
                         return (StatusCode::FORBIDDEN, "token not authorized for this agent")

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -287,7 +287,7 @@ pub async fn handle_create_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: Some(&machine_id_resolved),
+            machine_id: &machine_id_resolved,
             env_vars: &env_vars,
         },
     )
@@ -319,7 +319,7 @@ pub(crate) struct CreateAgentParams<'a> {
     pub runtime: &'a str,
     pub model: &'a str,
     pub reasoning_effort: Option<&'a str>,
-    pub machine_id: Option<&'a str>,
+    pub machine_id: &'a str,
     pub env_vars: &'a [AgentEnvVar],
 }
 
@@ -483,17 +483,16 @@ pub async fn handle_update_agent(
         || existing.env_vars != env_vars;
 
     // Preserve the existing owner when the request omits `machineId`.
-    // Without this, every PATCH would clobber `machine_id` to NULL — a
-    // bridge-hosted agent renamed via the UI (which doesn't echo
-    // `machineId` back) would silently lose its owner.
+    // The UI's "Edit agent" form doesn't always echo `machineId`, and
+    // every row has one already; we never want PATCH to silently move
+    // an agent across machines.
     let machine_id_resolved: String = req
         .machine_id
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
-        .or_else(|| existing.machine_id.clone())
-        .unwrap_or_else(|| state.local_machine_id.clone());
+        .unwrap_or_else(|| existing.machine_id.clone());
     state
         .store
         .update_agent_record(&AgentRecordUpsert {
@@ -504,7 +503,7 @@ pub async fn handle_update_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: Some(&machine_id_resolved),
+            machine_id: &machine_id_resolved,
             env_vars: &env_vars,
         })
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -150,7 +150,7 @@ pub async fn handle_launch_trio(
                 runtime: &template.suggested_runtime,
                 model: &model,
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: &state.local_machine_id,
                 env_vars: &[],
             },
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -117,14 +117,6 @@ pub fn build_router_with_services_and_auth(
         resolve_local_human_identity(store.as_ref(), &data_dir);
     let local_machine_id = resolve_local_machine_id(&data_dir);
 
-    // Backfill rows that pre-date the always-set-machine_id invariant.
-    // After this UPDATE every agent owned by `chorus serve` has a non-NULL
-    // `machine_id` equal to `local_machine_id`. Rows already pinned to a
-    // remote bridge keep their value; only NULLs are touched.
-    if let Err(err) = store.backfill_null_machine_ids(&local_machine_id) {
-        tracing::warn!(err = %err, "backfill_null_machine_ids failed; agent rows may have NULL machine_id");
-    }
-
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS
     // username as both the human row PK and the `#all` member key, which is

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -297,12 +297,10 @@ async fn handle_inbound_frame(
 
 /// Build a serialized `bridge.target` frame from the current set of
 /// agents in the store, scoped to a specific bridge `machine_id`. Only
-/// agents explicitly bound to this bridge are included; agents with
-/// NULL `machine_id` are platform-local and never sent to any bridge.
+/// agents whose `machine_id` matches are included.
 ///
-/// Every agent has exactly one owner (the platform itself, or one named
-/// bridge). Fanning NULL agents to all bridges would cause dual-runtime
-/// contention as soon as a second bridge connects.
+/// Every agent has exactly one owner; fanning agents to bridges that
+/// don't own them would cause dual-runtime contention.
 pub fn build_target_frame_text_for_machine(
     store: &Store,
     machine_id: &str,
@@ -310,7 +308,7 @@ pub fn build_target_frame_text_for_machine(
     let agents: Vec<Agent> = store
         .get_agents()?
         .into_iter()
-        .filter(|a| a.machine_id.as_deref() == Some(machine_id))
+        .filter(|a| a.machine_id == machine_id)
         .collect();
     let target = BridgeTarget {
         target_agents: agents.into_iter().map(agent_to_target).collect(),
@@ -385,15 +383,15 @@ pub fn forward_chat_event_to_bridges(
         return;
     }
     for agent_id in agent_recipients {
-        // Route to the bridge that owns this agent. Every agent has a
-        // non-NULL `machine_id` after Phase 1 of the dual-path collapse
-        // (#149); the bridge that registered with the matching id —
-        // possibly the in-process one inside `chorus serve` — receives
-        // the frame.
-        let agent_record = store.get_agent_by_id(agent_id, false).ok().flatten();
-        let Some(owner_machine_id) = agent_record.and_then(|a| a.machine_id) else {
+        // Route to the bridge that owns this agent. The bridge that
+        // registered with the matching `machine_id` — possibly the
+        // in-process one inside `chorus serve` — receives the frame.
+        // A missing record (deleted between channel-member lookup and
+        // here) silently skips this recipient.
+        let Some(agent) = store.get_agent_by_id(agent_id, false).ok().flatten() else {
             continue;
         };
+        let owner_machine_id = agent.machine_id;
         let frame = match build_chat_message_frame_text(agent_id, event) {
             Ok(t) => t,
             Err(err) => {

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -29,11 +29,12 @@ pub struct Agent {
     pub model: String,
     /// Optional Codex reasoning effort override.
     pub reasoning_effort: Option<String>,
-    /// Owner of this agent's runtime. `Some(machine_id)` binds the
-    /// agent to one named bridge; `None` means platform-local — it runs
-    /// in `chorus serve`'s own `AgentManager` and is never sent to any
-    /// bridge. Every agent has exactly one owner.
-    pub machine_id: Option<String>,
+    /// Owner of this agent's runtime. The bridge with this `machine_id`
+    /// runs the agent's process. For `chorus serve` agents created
+    /// without an explicit owner, this is the installation's
+    /// `local_machine_id`; the in-process bridge client picks them up
+    /// because it registers under the same id.
+    pub machine_id: String,
     /// Soft stop. When `true`, the bridge client treats this agent as
     /// "in the desired set but should not be running". Set by the
     /// stop handler; cleared by the start handler. Survives platform
@@ -92,9 +93,10 @@ pub struct AgentRecordUpsert<'a> {
     pub model: &'a str,
     /// Optional reasoning effort (Codex).
     pub reasoning_effort: Option<&'a str>,
-    /// Owner of this agent's runtime. `Some(machine_id)` binds it to
-    /// one named bridge; `None` = platform-local.
-    pub machine_id: Option<&'a str>,
+    /// Owner of this agent's runtime. Required — every agent row has
+    /// exactly one owner. For platform-local agents, callers pass
+    /// `state.local_machine_id`.
+    pub machine_id: &'a str,
     /// Full env var list to replace existing rows.
     pub env_vars: &'a [AgentEnvVar],
 }
@@ -264,20 +266,6 @@ impl Store {
         Ok(updated)
     }
 
-    /// Set every NULL `machine_id` to `local_machine_id`. Called once at
-    /// startup so rows that pre-date the always-set-machine_id invariant
-    /// get owned by the local installation. Idempotent: rows already
-    /// pinned to a remote bridge keep their value; only NULLs are touched.
-    /// Returns the number of rows updated.
-    pub fn backfill_null_machine_ids(&self, local_machine_id: &str) -> Result<usize> {
-        let conn = self.conn.lock().unwrap();
-        let updated = conn.execute(
-            "UPDATE agents SET machine_id = ?1 WHERE machine_id IS NULL",
-            params![local_machine_id],
-        )?;
-        Ok(updated)
-    }
-
     pub fn delete_agent_record(&self, name: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let agent_id: Option<String> = conn
@@ -425,7 +413,7 @@ impl Store {
             runtime: row.get(6)?,
             model: row.get(7)?,
             reasoning_effort: row.get(8)?,
-            machine_id: row.get(9)?,
+            machine_id: row.get::<_, String>(9)?,
             paused: paused != 0,
             restart_seq: row.get(11)?,
             pending_init_directive: row.get(12)?,

--- a/src/store/decisions.rs
+++ b/src/store/decisions.rs
@@ -211,8 +211,8 @@ mod tests {
         .unwrap();
         let agent_id = "agent-1".to_string();
         conn.execute(
-            "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-             VALUES (?1, ?2, 'bot', 'Bot', 'claude', 'sonnet')",
+            "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+             VALUES (?1, ?2, 'bot', 'Bot', 'claude', 'sonnet', 'test-machine')",
             params![agent_id, workspace_id],
         )
         .unwrap();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -49,8 +49,12 @@ impl Store {
     pub fn open(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        // Validate BEFORE init_schema so the validator inspects the
+        // user's actual on-disk shape — not a freshly-minted shape that
+        // `CREATE TABLE IF NOT EXISTS` would write into a half-empty
+        // legacy DB and then trivially pass.
+        Self::validate_schema_shape(&conn, path)?;
         Self::init_schema(&conn)?;
-        Self::validate_schema_shape(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -64,8 +68,8 @@ impl Store {
     pub fn open_for_bridge(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
+        Self::validate_schema_shape(&conn, path)?;
         Self::init_schema(&conn)?;
-        Self::validate_schema_shape(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -105,8 +109,25 @@ impl Store {
     /// NOT EXISTS` is a no-op on existing tables, so opening an old DB
     /// would otherwise succeed here and surface a cryptic SQLite error
     /// later when the first INSERT trips `NOT NULL`. Fail loudly with a
-    /// "fresh data dir" hint instead.
-    fn validate_schema_shape(conn: &Connection) -> Result<()> {
+    /// "delete this file" hint instead.
+    ///
+    /// Runs BEFORE `init_schema` so the check inspects the user's
+    /// on-disk shape, not a freshly-minted-by-CREATE-IF-NOT-EXISTS one.
+    /// A completely fresh DB (no tables yet) passes through to
+    /// `init_schema`; only DBs that already have an `agents` table get
+    /// the shape check.
+    fn validate_schema_shape(conn: &Connection, path: &str) -> Result<()> {
+        // No tables yet → fresh install. Skip and let init_schema
+        // create the canonical shape.
+        let table_count: i64 = conn.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table'",
+            [],
+            |row| row.get(0),
+        )?;
+        if table_count == 0 {
+            return Ok(());
+        }
+
         // Only check `agents.machine_id`: it's the marker column for
         // every recent schema phase (added in #150, made NOT NULL in
         // this cleanup). Older shapes are caught by either the column
@@ -124,15 +145,15 @@ impl Store {
         }
         match machine_id_notnull {
             None => anyhow::bail!(
-                "local database is missing `agents.machine_id` — this DB \
-                 pre-dates #150. Run with a fresh data directory (or wipe \
-                 the existing one) and restart."
+                "incompatible database schema at {path}: \
+                 `agents.machine_id` is missing. Delete this file and \
+                 restart to recreate it from scratch."
             ),
             Some(0) => anyhow::bail!(
-                "local database has nullable `agents.machine_id` — this DB \
-                 pre-dates the cleanup that flipped the column to NOT NULL. \
-                 Run with a fresh data directory (or wipe the existing one) \
-                 and restart."
+                "incompatible database schema at {path}: \
+                 `agents.machine_id` is nullable but the current schema \
+                 declares it NOT NULL. Delete this file and restart to \
+                 recreate it from scratch."
             ),
             Some(_) => Ok(()),
         }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -49,7 +49,6 @@ impl Store {
     pub fn open(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-        Self::validate_supported_identity_schema(&conn)?;
         Self::init_schema(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -64,7 +63,6 @@ impl Store {
     pub fn open_for_bridge(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
-        Self::validate_supported_identity_schema(&conn)?;
         Self::init_schema(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -94,154 +92,9 @@ impl Store {
     }
 
     fn init_schema(conn: &Connection) -> Result<()> {
-        // The schema below uses `CREATE TABLE IF NOT EXISTS` so this is a
-        // no-op on existing DBs; column-shape migrations run after.
         let schema = include_str!("schema.sql");
         conn.execute_batch(schema)?;
-        // Idempotent `machine_id` migration: SQLite has no
-        // `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Attempt the ALTER
-        // and ignore *only* the "duplicate column name" error; surface
-        // anything else (locked DB, syntax errors, real schema drift)
-        // so first-run failures aren't silent.
-        match conn.execute("ALTER TABLE agents ADD COLUMN machine_id TEXT", []) {
-            Ok(_) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(e.into()),
-        }
-        // Same idempotent ALTER for the `paused` flag introduced when the
-        // platform stopped owning runtime state. NOT NULL DEFAULT 0 so
-        // existing rows backfill to "running" automatically.
-        match conn.execute(
-            "ALTER TABLE agents ADD COLUMN paused INTEGER NOT NULL DEFAULT 0",
-            [],
-        ) {
-            Ok(_) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(e.into()),
-        }
-        // `restart_seq` and `pending_init_directive` arrived with the
-        // bridge-driven restart/resume protocol (#149 phase 4). Same
-        // idempotent ALTER pattern.
-        match conn.execute(
-            "ALTER TABLE agents ADD COLUMN restart_seq INTEGER NOT NULL DEFAULT 0",
-            [],
-        ) {
-            Ok(_) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(e.into()),
-        }
-        match conn.execute(
-            "ALTER TABLE agents ADD COLUMN pending_init_directive TEXT",
-            [],
-        ) {
-            Ok(_) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(e.into()),
-        }
-        // Migrate agent_env_vars from agent_name FK to agent_id FK.
-        // SQLite has no ALTER TABLE DROP COLUMN, so we recreate the table.
-        if Self::schema_column_exists(conn, "agent_env_vars", "agent_name")? {
-            conn.execute_batch(
-                "BEGIN;
-                 CREATE TABLE agent_env_vars_new (
-                     agent_id TEXT NOT NULL,
-                     key TEXT NOT NULL,
-                     value TEXT NOT NULL,
-                     position INTEGER NOT NULL,
-                     PRIMARY KEY (agent_id, key),
-                     FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_env_vars_new (agent_id, key, value, position)
-                     SELECT a.id, e.key, e.value, e.position
-                     FROM agent_env_vars e
-                     JOIN agents a ON a.name = e.agent_name;
-                 DROP TABLE agent_env_vars;
-                 ALTER TABLE agent_env_vars_new RENAME TO agent_env_vars;
-                 COMMIT;",
-            )?;
-        }
         Ok(())
-    }
-
-    fn validate_supported_identity_schema(conn: &Connection) -> Result<()> {
-        for (table, column) in [
-            ("humans", "display_name"),
-            ("workspaces", "created_by_human"),
-            ("workspace_members", "human_name"),
-            ("channel_members", "member_name"),
-            ("inbox_read_state", "member_name"),
-            ("messages", "sender_name"),
-            ("tasks", "created_by"),
-            ("tasks", "claimed_by"),
-            ("team_members", "member_name"),
-        ] {
-            if Self::schema_column_exists(conn, table, column)? {
-                anyhow::bail!(Self::old_identity_schema_message(table, column));
-            }
-        }
-
-        for (table, columns) in [
-            ("humans", &["id", "name"][..]),
-            ("workspaces", &["created_by_human_id"][..]),
-            ("workspace_members", &["human_id"][..]),
-            ("channel_members", &["member_id", "member_type"][..]),
-            ("inbox_read_state", &["member_id", "member_type"][..]),
-            ("messages", &["sender_id", "sender_type"][..]),
-            (
-                "tasks",
-                &[
-                    "created_by_id",
-                    "created_by_type",
-                    "claimed_by_id",
-                    "claimed_by_type",
-                ][..],
-            ),
-            ("team_members", &["member_id", "member_type"][..]),
-        ] {
-            if !Self::schema_table_exists(conn, table)? {
-                continue;
-            }
-            for column in columns {
-                if !Self::schema_column_exists(conn, table, column)? {
-                    anyhow::bail!(Self::old_identity_schema_message(table, column));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn old_identity_schema_message(table: &str, column: &str) -> String {
-        format!(
-            "local database uses an old identity schema ({table}.{column}); run with a fresh data directory or reset local data"
-        )
-    }
-
-    fn schema_table_exists(conn: &Connection, table: &str) -> Result<bool> {
-        Ok(conn
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
-                params![table],
-                |_| Ok(()),
-            )
-            .optional()?
-            .is_some())
-    }
-
-    fn schema_column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
-        if !Self::schema_table_exists(conn, table)? {
-            return Ok(false);
-        }
-        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
-        let exists = stmt
-            .query_map([], |row| row.get::<_, String>(1))?
-            .filter_map(Result::ok)
-            .any(|name| name == column);
-        Ok(exists)
     }
 
     /// Look up the channel_id for a given run_id (from the first message in that run).

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -50,6 +50,7 @@ impl Store {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
         Self::init_schema(&conn)?;
+        Self::validate_schema_shape(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -64,6 +65,7 @@ impl Store {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
         Self::init_schema(&conn)?;
+        Self::validate_schema_shape(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -95,6 +97,45 @@ impl Store {
         let schema = include_str!("schema.sql");
         conn.execute_batch(schema)?;
         Ok(())
+    }
+
+    /// Catch DBs that pre-date the always-set-machine_id invariant. The
+    /// runtime ALTER shims that used to fix these in place were dropped
+    /// once every code path stopped writing NULL — but `CREATE TABLE IF
+    /// NOT EXISTS` is a no-op on existing tables, so opening an old DB
+    /// would otherwise succeed here and surface a cryptic SQLite error
+    /// later when the first INSERT trips `NOT NULL`. Fail loudly with a
+    /// "fresh data dir" hint instead.
+    fn validate_schema_shape(conn: &Connection) -> Result<()> {
+        // Only check `agents.machine_id`: it's the marker column for
+        // every recent schema phase (added in #150, made NOT NULL in
+        // this cleanup). Older shapes are caught by either the column
+        // being absent or by `notnull = 0`.
+        let mut stmt = conn.prepare("PRAGMA table_info(agents)")?;
+        let mut machine_id_notnull: Option<i64> = None;
+        for row in stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(1)?, row.get::<_, i64>(3)?))
+        })? {
+            let (name, notnull) = row?;
+            if name == "machine_id" {
+                machine_id_notnull = Some(notnull);
+                break;
+            }
+        }
+        match machine_id_notnull {
+            None => anyhow::bail!(
+                "local database is missing `agents.machine_id` — this DB \
+                 pre-dates #150. Run with a fresh data directory (or wipe \
+                 the existing one) and restart."
+            ),
+            Some(0) => anyhow::bail!(
+                "local database has nullable `agents.machine_id` — this DB \
+                 pre-dates the cleanup that flipped the column to NOT NULL. \
+                 Run with a fresh data directory (or wipe the existing one) \
+                 and restart."
+            ),
+            Some(_) => Ok(()),
+        }
     }
 
     /// Look up the channel_id for a given run_id (from the first message in that run).

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS agents (
     runtime TEXT NOT NULL, -- The runtime driver used (e.g., 'claude', 'codex')
     model TEXT NOT NULL, -- The specific LLM model used
     reasoning_effort TEXT, -- The reasoning effort configuration
-    machine_id TEXT, -- Owner. Some(machine_id) = bound to that bridge; NULL = platform-local. Every agent has one owner.
+    machine_id TEXT NOT NULL, -- Owner. The bridge that runs this agent's runtime; for `chorus serve` agents created without an explicit machine_id, this is the installation's `local_machine_id` from `config.toml`.
     paused INTEGER NOT NULL DEFAULT 0, -- Soft-stop: 1 = bridge client should keep this agent stopped even though it's still in the desired set; 0 = run normally. Set by handle_agent_stop, cleared by handle_agent_start.
     restart_seq INTEGER NOT NULL DEFAULT 0, -- Monotonic counter bumped by handlers that need the bridge to stop+start the runtime (spec change, manual restart, decision resume). Bridge client tracks last-applied per agent and triggers a restart on bump.
     pending_init_directive TEXT, -- One-shot envelope delivered as the first prompt on the next restart_seq bump. Used by handle_resolve_decision so a human's pick reaches the agent without a synchronous lifecycle call from the platform.

--- a/src/store/sessions.rs
+++ b/src/store/sessions.rs
@@ -125,8 +125,8 @@ mod tests {
             .lock()
             .unwrap()
             .execute(
-                "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-             VALUES ('a1', ?1, 'a', 'A', 'fake', 'fake')",
+                "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+             VALUES ('a1', ?1, 'a', 'A', 'fake', 'fake', 'test-machine')",
                 params![workspace.id],
             )
             .unwrap();

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -685,7 +685,7 @@ mod sub_channel_tests {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap()

--- a/tests/agent_session_persistence_tests.rs
+++ b/tests/agent_session_persistence_tests.rs
@@ -30,7 +30,7 @@ fn seed_agent_with_session(store: &Store, name: &str, session_id: &str) -> Strin
             runtime: "codex",
             model: "gpt-fake",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/agent_status_derivation_tests.rs
+++ b/tests/agent_status_derivation_tests.rs
@@ -97,7 +97,7 @@ async fn list_agents_returns_asleep_for_unmanaged_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -143,7 +143,7 @@ async fn list_agents_returns_ready_for_running_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -195,7 +195,7 @@ async fn get_agent_returns_asleep_for_unmanaged_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -28,8 +28,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();

--- a/tests/bridge_ws_tests.rs
+++ b/tests/bridge_ws_tests.rs
@@ -82,7 +82,7 @@ async fn bridge_ws_hello_returns_target_with_agent_records() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("test-machine-001"),
+            machine_id: "test-machine-001",
             env_vars: &[],
         })
         .unwrap();
@@ -95,7 +95,7 @@ async fn bridge_ws_hello_returns_target_with_agent_records() {
             runtime: "codex",
             model: "gpt-5",
             reasoning_effort: Some("medium"),
-            machine_id: Some("test-machine-001"),
+            machine_id: "test-machine-001",
             env_vars: &[],
         })
         .unwrap();
@@ -672,7 +672,7 @@ async fn bridge_ws_pushes_chat_message_received_when_agent_member_gets_message()
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("chat-machine"),
+            machine_id: "chat-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -743,7 +743,7 @@ async fn bridge_ws_two_machines_chat_isolation() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-a"),
+            machine_id: "machine-a",
             env_vars: &[],
         })
         .unwrap();
@@ -756,7 +756,7 @@ async fn bridge_ws_two_machines_chat_isolation() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-b"),
+            machine_id: "machine-b",
             env_vars: &[],
         })
         .unwrap();
@@ -929,7 +929,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -943,7 +943,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-a"),
+            machine_id: "machine-a",
             env_vars: &[],
         })
         .unwrap();
@@ -957,7 +957,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-b"),
+            machine_id: "machine-b",
             env_vars: &[],
         })
         .unwrap();
@@ -1026,7 +1026,7 @@ async fn internal_agent_endpoints_pass_through_when_auth_disabled() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1060,7 +1060,7 @@ async fn internal_agent_endpoints_require_bearer_when_auth_enabled() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-x"),
+            machine_id: "machine-x",
             env_vars: &[],
         })
         .unwrap();
@@ -1129,7 +1129,7 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-y"),
+            machine_id: "machine-y",
             env_vars: &[],
         })
         .unwrap();
@@ -1183,7 +1183,7 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -62,8 +62,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -231,7 +231,7 @@ fn seed_agent(
         runtime,
         model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(store, "general", agent_key, "agent");

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -451,7 +451,7 @@ async fn opencode_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "opencode",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -589,7 +589,7 @@ async fn claude_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "claude",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -726,7 +726,7 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "codex",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -864,7 +864,7 @@ async fn gemini_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "gemini",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -988,7 +988,7 @@ async fn kimi_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "kimi",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -82,8 +82,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();
@@ -356,7 +356,7 @@ async fn test_internal_agent_name_send_uses_canonical_agent_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -770,7 +770,7 @@ async fn test_public_dm_route_accepts_agent_id_and_stores_canonical_member_id() 
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -952,7 +952,7 @@ async fn test_channel_members_api_lists_members_and_supports_invite() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1061,7 +1061,7 @@ async fn test_all_channel_member_count_matches_agents_plus_humans() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1106,7 +1106,7 @@ async fn test_history_rejects_non_member_agent() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1528,7 +1528,7 @@ async fn test_update_agent_to_kimi_clears_reasoning_effort() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("high"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2157,7 +2157,7 @@ async fn test_list_and_update_team_endpoints() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2452,7 +2452,7 @@ async fn test_at_mention_forwards_to_team_channel() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2698,7 +2698,7 @@ async fn test_active_workspace_filters_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -2714,7 +2714,7 @@ async fn test_active_workspace_filters_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -3118,7 +3118,7 @@ async fn test_non_member_history_returns_message_not_a_member() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -99,13 +99,45 @@ fn make_store() -> (Store, tempfile::TempDir) {
     (store, dir)
 }
 
-// `test_open_old_identity_schema_fails_loudly` was deleted with the
-// migration cleanup. The validator it covered
-// (`validate_supported_identity_schema`) is gone — we no longer carry
-// compatibility shims for pre-id-flip DBs. If a legacy DB is opened,
-// SQLite itself surfaces the schema error on the first query against
-// a missing column. "Wipe your data dir" is the documented upgrade
-// path, same as for the dropped ALTER migrations.
+/// `Store::open` on a pre-id-flip DB (no `agents.machine_id`) must
+/// abort with the "fresh data dir" hint, not silently succeed and then
+/// fail mid-query later. `validate_schema_shape` is the single
+/// remaining check the migration-cleanup PR kept around.
+#[test]
+fn test_open_old_db_without_machine_id_fails_loudly() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("legacy.db");
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        // Old shape: agents table with no machine_id column. A fresh
+        // CREATE TABLE IF NOT EXISTS won't add the column to an
+        // existing table, so this is exactly the upgrade landmine the
+        // validator catches.
+        conn.execute_batch(
+            "CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                workspace_id TEXT NOT NULL,
+                name TEXT UNIQUE NOT NULL,
+                display_name TEXT NOT NULL,
+                runtime TEXT NOT NULL,
+                model TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );",
+        )
+        .unwrap();
+    }
+
+    let err = match Store::open(db_path.to_str().unwrap()) {
+        Ok(_) => panic!("opening pre-id-flip DB should fail"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("missing `agents.machine_id`")
+            && message.contains("fresh data directory"),
+        "expected fresh-data-dir hint, got: {message}"
+    );
+}
 
 #[test]
 fn test_create_local_workspace_sets_owner_and_active_context() {

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -127,16 +127,35 @@ fn test_open_old_db_without_machine_id_fails_loudly() {
         .unwrap();
     }
 
-    let err = match Store::open(db_path.to_str().unwrap()) {
+    let path_str = db_path.to_str().unwrap().to_string();
+    let err = match Store::open(&path_str) {
         Ok(_) => panic!("opening pre-id-flip DB should fail"),
         Err(err) => err,
     };
     let message = err.to_string();
     assert!(
-        message.contains("missing `agents.machine_id`")
-            && message.contains("fresh data directory"),
-        "expected fresh-data-dir hint, got: {message}"
+        message.contains("`agents.machine_id` is missing")
+            && message.contains("Delete this file")
+            && message.contains(&path_str),
+        "expected delete-this-file hint pointing at {path_str}, got: {message}"
     );
+}
+
+/// A completely empty DB file (no tables) must NOT trip the validator
+/// — that's the fresh-install path. `init_schema` creates the
+/// canonical shape. Without the empty-DB bypass, every fresh install
+/// would fail with "missing agents.machine_id" because `agents` doesn't
+/// exist yet.
+#[test]
+fn test_open_fresh_empty_db_passes_validator() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("fresh.db");
+    {
+        // Just touch the file via Connection::open; create no tables.
+        let _conn = Connection::open(&db_path).unwrap();
+    }
+
+    Store::open(db_path.to_str().unwrap()).expect("fresh empty DB must open clean");
 }
 
 #[test]

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -99,34 +99,13 @@ fn make_store() -> (Store, tempfile::TempDir) {
     (store, dir)
 }
 
-#[test]
-fn test_open_old_identity_schema_fails_loudly() {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("legacy.db");
-    {
-        let conn = Connection::open(&db_path).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE humans (
-                name TEXT PRIMARY KEY,
-                display_name TEXT,
-                created_at TEXT NOT NULL DEFAULT (datetime('now'))
-             );",
-        )
-        .unwrap();
-    }
-
-    let err = match Store::open(db_path.to_str().unwrap()) {
-        Ok(_) => panic!("opening old identity schema should fail"),
-        Err(err) => err,
-    };
-    let message = err.to_string();
-    assert!(
-        message.contains("old identity schema")
-            && message.contains("humans.display_name")
-            && message.contains("fresh data directory"),
-        "unexpected error: {message}"
-    );
-}
+// `test_open_old_identity_schema_fails_loudly` was deleted with the
+// migration cleanup. The validator it covered
+// (`validate_supported_identity_schema`) is gone — we no longer carry
+// compatibility shims for pre-id-flip DBs. If a legacy DB is opened,
+// SQLite itself surfaces the schema error on the first query against
+// a missing column. "Wipe your data dir" is the documented upgrade
+// path, same as for the dropped ALTER migrations.
 
 #[test]
 fn test_create_local_workspace_sets_owner_and_active_context() {
@@ -187,8 +166,8 @@ fn test_scoped_resource_schema_requires_workspace_id() {
 
     let agent_err = conn
         .execute(
-            "INSERT INTO agents (id, name, display_name, runtime, model)
-             VALUES ('missing-workspace-agent', 'orphan-agent', 'Orphan Agent', 'claude', 'sonnet')",
+            "INSERT INTO agents (id, name, display_name, runtime, model, machine_id)
+             VALUES ('missing-workspace-agent', 'orphan-agent', 'Orphan Agent', 'claude', 'sonnet', 'test-machine')",
             [],
         )
         .unwrap_err();
@@ -324,7 +303,7 @@ fn test_workspace_scoped_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -340,7 +319,7 @@ fn test_workspace_scoped_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -439,7 +418,7 @@ fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -454,7 +433,7 @@ fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -501,7 +480,7 @@ fn test_delete_workspace_wipes_scoped_data_and_keeps_other_workspaces() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[AgentEnvVar {
                     key: "TOKEN".to_string(),
                     value: "secret".to_string(),
@@ -705,7 +684,7 @@ fn test_shell_style_workspace_mutations_persist() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -744,7 +723,7 @@ fn test_shell_style_workspace_mutations_persist() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -815,7 +794,7 @@ fn test_send_and_receive_messages() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -854,7 +833,7 @@ fn test_agent_does_not_receive_its_own_sent_message() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -982,7 +961,7 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1094,7 +1073,7 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1344,7 +1323,7 @@ fn test_agent_env_vars_persist_in_agent_record() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &env_vars,
         })
         .unwrap();
@@ -1365,7 +1344,7 @@ fn test_agent_reasoning_effort_persists_in_agent_record() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("low"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1382,7 +1361,7 @@ fn test_agent_reasoning_effort_persists_in_agent_record() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("high"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1406,7 +1385,7 @@ fn test_mark_agent_messages_deleted_marks_history_rows() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1474,7 +1453,7 @@ fn test_unread_excludes_own_messages_for_sender() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1547,7 +1526,7 @@ fn test_tasks_crud() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1583,7 +1562,7 @@ fn test_task_claim_and_status() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1596,7 +1575,7 @@ fn test_task_claim_and_status() {
             runtime: "codex",
             model: "o3",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1638,7 +1617,7 @@ fn test_resolve_target() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1668,7 +1647,7 @@ fn test_list_channels_excludes_dm() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1697,7 +1676,7 @@ fn test_dm_channels() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1844,7 +1823,7 @@ fn test_ensure_builtin_channels_backfills_all_existing_humans_and_agents() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1857,7 +1836,7 @@ fn test_ensure_builtin_channels_backfills_all_existing_humans_and_agents() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1889,7 +1868,7 @@ fn test_ensure_builtin_channels_only_exposes_all_system_channel() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1933,7 +1912,7 @@ fn test_new_agents_auto_join_all_when_it_exists() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1977,7 +1956,7 @@ fn test_ensure_builtin_channels_repairs_active_workspace_all() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -2013,7 +1992,7 @@ fn test_delete_channel_removes_messages_tasks_and_memberships() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2263,7 +2242,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2332,7 +2311,7 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();


### PR DESCRIPTION
## Summary

After [#149](https://github.com/Fullstop000/Chorus/issues/149) wrapped, the runtime ALTER migrations and the \`Option<String>\` wrapper around \`machine_id\` were carrying compatibility weight that no longer pays for itself. This PR drops them.

- Schema flip: \`agents.machine_id\` is now \`NOT NULL\`. The application has been setting this on every insert since #150.
- Drops the four \`ALTER TABLE agents ADD COLUMN …\` shims for \`machine_id\` / \`paused\` / \`restart_seq\` / \`pending_init_directive\`, and the \`agent_env_vars\` FK rebuild from before the id-flip.
- Drops \`Store::backfill_null_machine_ids\` and its \`chorus serve\` startup call.
- Drops \`validate_supported_identity_schema\` (and \`old_identity_schema_message\`, \`schema_table_exists\`, plus the matching test) — pre-id-flip DBs are not supported.
- \`Agent.machine_id\`: \`Option<String>\` → \`String\`. \`AgentRecordUpsert.machine_id\`: \`Option<&str>\` → \`&str\`. Cascading simplifications in \`bridge_auth.rs\`, \`bridge_ws.rs\`, and \`handle_update_agent\`.
- Tests updated: \`machine_id: None\` → \`"test-machine"\` across 9 test files; direct \`INSERT INTO agents\` SQL in 4 files extended to set \`machine_id\`.

## Upgrade path

Existing dev DBs with rows from before #150 need a fresh data dir. Per the project's "no-compat" stance for OSS research, this is the documented upgrade path.

## Test plan

- [x] \`cargo test\` — 605 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Playwright smoke (\`CHORUS_E2E_LLM=0\`, 4 workers): pre-existing parallel flakes only
- [x] LLM-gated MSG suite (MSG-001 / MSG-002 / MSG-004 / MSG-006 / LFC-001) under \`CHORUS_WORKERS=2 --retries=1\` — all 6 green in 45.9s

🤖 Generated with [Claude Code](https://claude.com/claude-code)