### PR TITLE
collapse bridge lifecycle: bridge-owned agents + event-driven RPCs

### DIFF
--- a/qa/cases/playwright/helpers/fixtures.ts
+++ b/qa/cases/playwright/helpers/fixtures.ts
@@ -12,7 +12,7 @@
  */
 import { test as base } from '@playwright/test'
 import { spawn, type ChildProcess } from 'child_process'
-import { mkdtempSync, rmSync } from 'fs'
+import { createWriteStream, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 
@@ -58,6 +58,15 @@ export const test = base.extend<Record<string, never>, WorkerFixtures>({
         ['serve', '--port', String(port), '--bridge-port', String(bridgePort), '--data-dir', dataDir],
         { cwd: REPO_ROOT, stdio: 'pipe' }
       )
+      // Optional log capture: set CHORUS_QA_LOG_DIR=/path/to/dir to dump
+      // per-worker stdout+stderr there. Cheap diagnostic for parallel
+      // flakes where the failing worker's logs would otherwise be lost.
+      if (process.env.CHORUS_QA_LOG_DIR) {
+        const logFile = path.join(process.env.CHORUS_QA_LOG_DIR, `worker-${workerInfo.workerIndex}.log`)
+        const logStream = createWriteStream(logFile, { flags: 'a' })
+        proc.stdout?.pipe(logStream)
+        proc.stderr?.pipe(logStream)
+      }
 
       const serverUrl = `http://localhost:${port}`
       try {

--- a/src/agent/drivers/claude.rs
+++ b/src/agent/drivers/claude.rs
@@ -5,7 +5,7 @@
 //! Claude's `claude -p --output-format stream-json` is a per-invocation
 //! command — each child process exits after its turn completes and cannot
 //! multiplex multiple sessions like Codex's `thread/start` or Kimi/OpenCode's
-//! `session/new` do. Phase 0.9 Stage 2 therefore runs **one `tokio::process::Child`
+//! `session/new` do. This driver therefore runs **one `tokio::process::Child`
 //! per [`Session`]**.
 //!
 //! What's shared across an agent's sessions:

--- a/src/agent/drivers/codex.rs
+++ b/src/agent/drivers/codex.rs
@@ -828,7 +828,7 @@ impl CodexHandle {
         // or the start compat shim. Before passing to the runtime, verify
         // codex still has a rollout file for the thread id — otherwise
         // `thread/resume` lands on a dead thread and produces a silent
-        // no-op turn. Mirrors the claude session-file guard from PR #131.
+        // no-op turn. Mirrors the claude session-file guard.
         let resume_id = self.resume_session_id.take();
         let resume_id = match resume_id {
             Some(tid) if liveness_check_enabled() => {

--- a/src/agent/event_forwarder.rs
+++ b/src/agent/event_forwarder.rs
@@ -116,9 +116,9 @@ fn flush_text(
 /// `site` is a short tag ("attach" / "completed") distinguishing the caller.
 ///
 /// `agent_id` and `runtime` are passed by the caller rather than re-read
-/// from the store: on the bridge the `agents` table is empty (#145), so
-/// a name-based lookup would always fail. The forwarder captures both
-/// at spawn time from the agent record that drove `start_agent_inner`.
+/// from the store: on the bridge the `agents` table is empty, so a
+/// name-based lookup would always fail. The forwarder captures both at
+/// spawn time from the agent record that drove `start_agent_inner`.
 fn persist_session(store: &Store, agent_id: &str, runtime: &str, session_id: &str, site: &str) {
     if let Err(err) = store.record_session(agent_id, session_id, runtime) {
         warn!(
@@ -137,7 +137,7 @@ fn persist_session(store: &Store, agent_id: &str, runtime: &str, session_id: &st
 ///
 /// `agent_id` and `runtime` are captured here so `persist_session` can
 /// write `agent_sessions` rows directly without re-reading the store
-/// (which is empty on the bridge, #145).
+/// (which is empty on the bridge).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_event_forwarder(
     mut event_rx: tokio::sync::mpsc::Receiver<DriverEvent>,
@@ -151,16 +151,16 @@ pub(super) fn spawn_event_forwarder(
     agents: Arc<Mutex<HashMap<String, ManagedAgent>>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        // Pending buffers are keyed by `session_id` because Stage 2 drivers can
-        // multiplex multiple concurrent sessions onto one forwarder (Phase 0.9
-        // Stage 2). Before this change the buffers were per-forwarder scalars,
-        // which cross-contaminated: session A's Thinking text could flush when
-        // session B emitted a Text event, or a ToolResult from B could be
-        // attributed to A's most recent ToolCall. Keying by `session_id`
-        // isolates each session's in-flight stream; entries are removed in the
-        // `Completed`/`Failed` branches so the maps don't leak across runs.
+        // Pending buffers are keyed by `session_id` because drivers can
+        // multiplex multiple concurrent sessions onto one forwarder. Per-
+        // forwarder scalars would cross-contaminate: session A's Thinking
+        // text could flush when session B emitted a Text event, or a
+        // ToolResult from B could be attributed to A's most recent
+        // ToolCall. Keying by `session_id` isolates each session's
+        // in-flight stream; entries are removed in the `Completed` /
+        // `Failed` branches so the maps don't leak across runs.
         //
-        // `trace_store` and `activity_logs` remain per-agent for Stage 2: the
+        // `trace_store` and `activity_logs` remain per-agent: the
         // AgentManager still exposes one-handle-per-agent and concurrent
         // multi-session events are uncommon in production. `AgentTraceStore`
         // treats a duplicate `end_run` as a no-op (see `AgentRunState::end_run`)

--- a/src/agent/lifecycle.rs
+++ b/src/agent/lifecycle.rs
@@ -1,48 +1,19 @@
-//! Runtime lifecycle operations the HTTP server can trigger for agents.
+//! Runtime observability the HTTP server reads for activity feeds and
+//! status badges. The bridge client owns runtime lifecycle entirely;
+//! the platform's only role here is to *observe* — `process_state` for
+//! status, `get_activity_log_data` / `get_all_agent_activity_states`
+//! for the activity feed, `active_run_id` / `set_run_channel` /
+//! `run_channel_id` for trace routing.
 
 use std::future::Future;
 use std::pin::Pin;
 
 use crate::agent::activity_log::ActivityLogResponse;
-use crate::store::agents::Agent;
-use crate::store::messages::ReceivedMessage;
 
 pub trait AgentLifecycle: Send + Sync {
-    /// Start (or wake) an agent process. Takes `&Agent` so the caller is
-    /// forced to hold the full record — this prevents "pass name where id
-    /// was expected" bugs at compile time, and consolidates the previous
-    /// dual entry points (`start_agent(name)` and `start_agent_from_record`)
-    /// into one signature.
-    ///
-    /// `wake_message` carries the unread message that triggered this start, if
-    /// any. `init_directive`, when `Some`, is delivered as the first prompt
-    /// verbatim, overriding the auto-generated greeting/wake/resume prompt.
-    /// Used by the agent-creation path to ask a brand-new agent to introduce
-    /// itself; left `None` for restart, manual-start, and message-driven wake
-    /// paths so existing behavior is unchanged.
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
-    /// Deliver a wakeup notification keyed by `agent_id`.
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
-    /// Stop a managed agent process keyed by `agent_id`.
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
     /// Returns the runtime `ProcessState` for `agent_id` if a managed
     /// process exists, else `None`. Single source of truth for runtime
-    /// liveness; replaces every read of the persisted `agents.status`
-    /// column from this phase onward.
+    /// liveness; the persisted `agents.status` column is gone.
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -57,7 +28,7 @@ pub trait AgentLifecycle: Send + Sync {
 
     /// Snapshot of all agents' current activity states. Returns
     /// `(agent_id, activity, detail)` tuples — first column is the id,
-    /// not the name, after #142's observability flip.
+    /// not the name.
     fn get_all_agent_activity_states(&self) -> Vec<(String, String, String)>;
 
     /// Get the active trace run id for an agent, if any.
@@ -77,26 +48,5 @@ pub trait AgentLifecycle: Send + Sync {
         _agent_id: &'a str,
     ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>> {
         Box::pin(async { None })
-    }
-
-    /// Deliver a self-contained envelope to the agent so it can act on a
-    /// human's pick. Routes to the live session's prompt channel when the
-    /// agent is `Active`; otherwise starts the agent with the envelope as
-    /// the `init_directive` so the same payload arrives on first turn.
-    ///
-    /// The envelope is built by the decision handler and contains the
-    /// original headline + question, the picked option's full label and
-    /// body, and any human note. The agent treats it as a new prompt and
-    /// continues its work without needing to re-read history.
-    fn resume_with_prompt<'a>(
-        &'a self,
-        _agent_id: &'a str,
-        _envelope: String,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async {
-            Err(anyhow::anyhow!(
-                "resume_with_prompt not implemented on this AgentLifecycle"
-            ))
-        })
     }
 }

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -102,8 +102,8 @@ pub struct AgentManager {
     /// Active agents keyed by `agents.id` (the immutable UUID). Renames
     /// stay invisible to the runtime; the cached display name lives on
     /// `ManagedAgent.name`. Activity log + trace store + driver
-    /// `AgentKey` are all id-keyed end-to-end (#142): no id ↔ name
-    /// translation step anywhere in the runtime path.
+    /// `AgentKey` are all id-keyed end-to-end — no id ↔ name translation
+    /// step anywhere in the runtime path.
     agents: Arc<Mutex<HashMap<String, ManagedAgent>>>,
     activity_logs: Arc<ActivityLogMap>,
     trace_store: Arc<AgentTraceStore>,
@@ -732,34 +732,6 @@ fn build_start_prompt(
 }
 
 impl AgentLifecycle for AgentManager {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a crate::store::agents::Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::start_agent(
-            self,
-            agent,
-            wake_message,
-            init_directive,
-        ))
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::notify_agent(self, agent_id))
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::stop_agent(self, agent_id))
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -795,14 +767,6 @@ impl AgentLifecycle for AgentManager {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send + 'a>> {
         let channel = self.trace_store.run_channel_id(agent_id);
         Box::pin(async move { channel })
-    }
-
-    fn resume_with_prompt<'a>(
-        &'a self,
-        agent_id: &'a str,
-        envelope: String,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(AgentManager::resume_with_prompt(self, agent_id, envelope))
     }
 }
 
@@ -857,7 +821,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-5.4-mini",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();
@@ -1112,7 +1076,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-fake",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();
@@ -1187,7 +1151,7 @@ mod tests {
                 runtime: "codex",
                 model: "gpt-fake",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap();

--- a/src/bridge/client/local_store.rs
+++ b/src/bridge/client/local_store.rs
@@ -3,7 +3,7 @@
 //! Agent records are not written here — they live in-memory in
 //! `bridge::client::ws::TargetCache`, populated from `bridge.target`.
 //! The bridge opens its store with `foreign_keys=OFF` so session writes
-//! work without a corresponding `agents` row. See #145.
+//! work without a corresponding `agents` row.
 
 use crate::store::Store;
 

--- a/src/bridge/client/mod.rs
+++ b/src/bridge/client/mod.rs
@@ -10,6 +10,9 @@ mod ws;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::manager::AgentManager;
 use crate::store::Store;
 
 #[derive(Clone)]
@@ -23,10 +26,42 @@ pub struct BridgeClientConfig {
     pub store: Arc<Store>,
 }
 
+/// In-process bridge client used by `chorus serve`. Dials the platform's
+/// own `/api/bridge/ws` over loopback so every agent on the local
+/// installation flows through the same bridge protocol a remote
+/// `chorus bridge` uses. Reuses the platform's pre-built [`AgentManager`]
+/// and MCP bridge endpoint (set on the manager via
+/// `set_bridge_endpoint_override` before this is called) so we don't
+/// stand up a second runtime owner or a duplicate MCP listener.
+///
+/// The supplied `shutdown` token is the platform's shared cancellation
+/// token; cancellation here cascades from the platform's own Ctrl-C
+/// handler. Returns when the WS loop exits.
+pub async fn run_in_process_bridge_client(
+    platform_ws: String,
+    machine_id: String,
+    manager: Arc<AgentManager>,
+    store: Arc<Store>,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
+    let cfg = BridgeClientConfig {
+        platform_ws,
+        // platform_http / bridge_listen / agents_dir are unused by the WS
+        // loop itself — they're consumed by `run_bridge_client` when it
+        // stands up its own MCP bridge and AgentManager. The in-process
+        // path skips both, so these are placeholders.
+        platform_http: String::new(),
+        token: None,
+        machine_id,
+        bridge_listen: String::new(),
+        agents_dir: PathBuf::new(),
+        store,
+    };
+    ws::run_ws_client_loop(cfg, manager, shutdown).await
+}
+
 pub async fn run_bridge_client(cfg: BridgeClientConfig) -> anyhow::Result<()> {
-    use crate::agent::manager::AgentManager;
     use crate::server::event_bus::EventBus;
-    use tokio_util::sync::CancellationToken;
 
     let event_bus = Arc::new(EventBus::new());
 

--- a/src/bridge/client/reconcile.rs
+++ b/src/bridge/client/reconcile.rs
@@ -1,11 +1,13 @@
-//! Reconcile a `bridge.target` frame against the locally-running agent set.
+//! Reconcile a `bridge.target` frame against the locally-cached spec view.
 //!
-//! Each pass populates the in-memory [`super::ws::TargetCache`] (the
-//! authoritative spec/identity cache on the bridge), starts any newly
-//! desired agents, stops any that vanished. The bridge's local store
-//! holds only `agent_sessions` rows; agent records live in the cache.
-//! `forget_sessions_for_agent` is called on stop to drop resume cursors
-//! since FK cascade no longer fires (the bridge runs with FK off, #145).
+//! `bridge.target` carries identity + spec only; lifecycle intent flows
+//! through `agent.start` / `agent.stop` / `agent.restart` RPCs. Each pass:
+//!
+//!   1. Refreshes [`super::ws::TargetCache`] with the new spec snapshot.
+//!   2. Stops any locally-running agent whose `agent_id` left the desired set
+//!      (orphan sweep — without this a deleted agent's process would linger).
+//!   3. Drops session rows for agents not in the desired set, since the
+//!      bridge runs with `foreign_keys=OFF` and there's no cascade.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -19,15 +21,13 @@ use crate::store::Store;
 use super::local_store::forget_sessions_for_agent;
 use super::ws::{AgentTargetIn, TargetCache};
 
-/// Per-pass transition record. After #142 the bridge keys runtimes by
-/// `agent_id` directly (the platform's UUID), so a transition is just
-/// the id.
+/// Per-pass transition record. Runtimes are keyed by `agent_id`
+/// (the platform's UUID), so a transition is just the id.
 pub struct AgentTransition {
     pub agent_id: String,
 }
 
 pub struct ReconcileOutcome {
-    pub started: Vec<AgentTransition>,
     pub stopped: Vec<AgentTransition>,
 }
 
@@ -47,7 +47,11 @@ pub(super) fn target_to_agent(target: &AgentTargetIn) -> Agent {
         runtime: target.runtime.clone(),
         model: target.model.clone(),
         reasoning_effort: target.reasoning_effort.clone(),
-        machine_id: None,
+        // Bridge-side stub: the manager doesn't read `machine_id` (the
+        // bridge IS the machine), so an empty string is fine. Filling
+        // it with the bridge's own id would also be correct but adds a
+        // dependency on cfg threading.
+        machine_id: String::new(),
         env_vars: target
             .env_vars
             .iter()
@@ -69,8 +73,6 @@ pub async fn apply(
     targets: Vec<AgentTargetIn>,
 ) -> anyhow::Result<ReconcileOutcome> {
     let mut desired: HashSet<String> = HashSet::new();
-
-    let mut started = Vec::new();
     let mut stopped = Vec::new();
 
     // 1. Bulk-prune session rows whose agent_id isn't in this target.
@@ -96,36 +98,13 @@ pub async fn apply(
         }
     }
 
+    // 3. Stop any locally-running agent that is no longer in the desired
+    //    set (row deleted on the platform). Leaving a runtime alive
+    //    because the cache entry vanished would orphan an OS process.
+    //    Lifecycle intent (start / stop / restart of agents that DO
+    //    remain in the set) flows through `agent.start` / `agent.stop`
+    //    / `agent.restart` frames, not through reconcile.
     let running = manager.get_running_agent_ids().await;
-    let running_set: HashSet<String> = running.iter().cloned().collect();
-
-    // 3. Start every desired agent that isn't already running. The spec
-    //    is materialised from the wire target, not re-read from the store.
-    for target in &targets {
-        if running_set.contains(&target.agent_id) {
-            continue;
-        }
-        let agent = target_to_agent(target);
-        match manager
-            .start_agent(&agent, None, target.init_directive.clone())
-            .await
-        {
-            Ok(()) => {
-                started.push(AgentTransition {
-                    agent_id: target.agent_id.clone(),
-                });
-            }
-            Err(e) => {
-                tracing::error!(agent = %target.name, agent_id = %target.agent_id, err = %e, "start_agent failed during reconcile");
-            }
-        }
-    }
-
-    // 4. Stop any locally-running agent that is no longer desired. The
-    //    manager-side stop runs unconditionally — leaving a runtime alive
-    //    because the cache entry vanished would orphan an OS process. The
-    //    upstream `agent.state{stopped}` frame still goes out even if the
-    //    cache entry is missing, since we have the id directly.
     for agent_id in running.iter() {
         if desired.contains(agent_id) {
             continue;
@@ -135,7 +114,7 @@ pub async fn apply(
             cache.forget(agent_id);
         }
         if let Err(e) = manager.stop_agent(agent_id).await {
-            tracing::warn!(agent_id = %agent_id, err = %e, "stop_agent failed during reconcile");
+            tracing::warn!(agent_id = %agent_id, err = %e, "stop_agent failed during orphan sweep");
         }
         if let Err(e) = forget_sessions_for_agent(store, agent_id) {
             tracing::warn!(
@@ -149,5 +128,5 @@ pub async fn apply(
         });
     }
 
-    Ok(ReconcileOutcome { started, stopped })
+    Ok(ReconcileOutcome { stopped })
 }

--- a/src/bridge/client/ws.rs
+++ b/src/bridge/client/ws.rs
@@ -22,8 +22,9 @@ use tokio_util::sync::CancellationToken;
 use crate::agent::drivers::ProcessState;
 use crate::agent::manager::AgentManager;
 use crate::bridge::protocol::{
-    WireFrame, FRAME_AGENT_STATE, FRAME_BRIDGE_HELLO, FRAME_BRIDGE_TARGET, FRAME_CHAT_ACK,
-    FRAME_CHAT_MESSAGE_RECEIVED,
+    AgentRestart, AgentStart, AgentStop, WireFrame, FRAME_AGENT_DECISION_DELIVERED,
+    FRAME_AGENT_STATE, FRAME_BRIDGE_HELLO, FRAME_AGENT_RESTART, FRAME_AGENT_START,
+    FRAME_AGENT_STOP, FRAME_BRIDGE_TARGET, FRAME_CHAT_ACK, FRAME_CHAT_MESSAGE_RECEIVED,
 };
 
 use super::reconcile;
@@ -66,7 +67,13 @@ impl InstanceCounter {
     }
 }
 
-const SUPPORTED_FRAMES: &[&str] = &[FRAME_BRIDGE_TARGET, FRAME_CHAT_MESSAGE_RECEIVED];
+const SUPPORTED_FRAMES: &[&str] = &[
+    FRAME_BRIDGE_TARGET,
+    FRAME_AGENT_START,
+    FRAME_AGENT_STOP,
+    FRAME_AGENT_RESTART,
+    FRAME_CHAT_MESSAGE_RECEIVED,
+];
 const BRIDGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Initial reconnect delay after a WS session ends. Doubles up to
@@ -104,7 +111,7 @@ type PendingChats = Arc<Mutex<HashMap<String, VecDeque<ChatMessageReceived>>>>;
 /// by `agent_id`. The authoritative spec/identity view on the bridge side:
 /// `start_agent` reads the spec from here, not SQLite. Renames update the
 /// cached `name` field in place; the id key is stable. The bridge's
-/// `agents` table is empty — see #145 for the design.
+/// `agents` table is empty by design — agent rows live only on the platform.
 #[derive(Default)]
 pub(super) struct TargetCache {
     by_agent_id: HashMap<String, AgentTargetIn>,
@@ -184,6 +191,25 @@ async fn send_chat_ack(
             "last_seq": last_seq,
             "ts": chrono::Utc::now().to_rfc3339(),
         }),
+    )
+    .await;
+}
+
+/// Send `agent.decision_delivered` upstream after an `agent.start` /
+/// `agent.restart` frame's directive was passed into a fresh runtime
+/// instance. The platform marks exactly the named directive as delivered;
+/// echoing `directive_id` (not just `agent_id`) avoids the race where a
+/// rapid re-emit of a different directive would be falsely marked
+/// delivered by an earlier ack.
+async fn send_decision_delivered(
+    state_tx: &tokio::sync::mpsc::Sender<String>,
+    platform_id: &str,
+    directive_id: &str,
+) {
+    queue_frame(
+        state_tx,
+        FRAME_AGENT_DECISION_DELIVERED,
+        json!({ "agent_id": platform_id, "directive_id": directive_id }),
     )
     .await;
 }
@@ -394,6 +420,45 @@ async fn run_one_session(
                                     handle_chat(&ctx, payload).await;
                                 }));
                             }
+                            FRAME_AGENT_START => {
+                                let payload: AgentStart = match serde_json::from_value(frame.data) {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        tracing::warn!(err = %e, "bridge: bad agent.start");
+                                        continue;
+                                    }
+                                };
+                                let ctx = ctx.clone();
+                                handler_tasks.push(tokio::spawn(async move {
+                                    handle_agent_start_frame(&ctx, payload).await;
+                                }));
+                            }
+                            FRAME_AGENT_STOP => {
+                                let payload: AgentStop = match serde_json::from_value(frame.data) {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        tracing::warn!(err = %e, "bridge: bad agent.stop");
+                                        continue;
+                                    }
+                                };
+                                let ctx = ctx.clone();
+                                handler_tasks.push(tokio::spawn(async move {
+                                    handle_agent_stop_frame(&ctx, payload).await;
+                                }));
+                            }
+                            FRAME_AGENT_RESTART => {
+                                let payload: AgentRestart = match serde_json::from_value(frame.data) {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        tracing::warn!(err = %e, "bridge: bad agent.restart");
+                                        continue;
+                                    }
+                                };
+                                let ctx = ctx.clone();
+                                handler_tasks.push(tokio::spawn(async move {
+                                    handle_agent_restart_frame(&ctx, payload).await;
+                                }));
+                            }
                             other => {
                                 tracing::debug!(kind = %other, "bridge: ignoring unknown frame");
                             }
@@ -448,14 +513,20 @@ async fn handle_target(ctx: &SessionCtx, target: BridgeTargetIn) {
     let target_agents = target.target_agents;
     let known_platform_ids: Vec<String> =
         target_agents.iter().map(|a| a.agent_id.clone()).collect();
-    let outcome =
-        match reconcile::apply(&ctx.store, &ctx.manager, &ctx.targets, target_agents).await {
-            Ok(o) => o,
-            Err(e) => {
-                tracing::error!(err = %e, "bridge: reconcile failed");
-                return;
-            }
-        };
+    let outcome = match reconcile::apply(
+        &ctx.store,
+        &ctx.manager,
+        &ctx.targets,
+        target_agents,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::error!(err = %e, "bridge: reconcile failed");
+            return;
+        }
+    };
 
     // Replay any chats that arrived before this reconcile populated the
     // targets cache. We only drain entries for platform_ids that are now
@@ -479,14 +550,105 @@ async fn handle_target(ctx: &SessionCtx, target: BridgeTargetIn) {
         });
     }
 
-    for transition in outcome.started {
-        let pid = ctx.counter.allocate(&transition.agent_id).await;
-        send_agent_state(&ctx.state_tx, &transition.agent_id, "started", pid).await;
-    }
+    // Reconcile only stops orphans (agents removed from the desired set).
+    // Agent starts come via discrete `agent.start` / `agent.restart`
+    // frames or chat-driven wakes — never from a target snapshot.
     for transition in outcome.stopped {
         let pid = ctx.counter.current(&transition.agent_id).await;
         ctx.counter.forget(&transition.agent_id).await;
         send_agent_state(&ctx.state_tx, &transition.agent_id, "stopped", pid).await;
+    }
+}
+
+/// Resolve the agent spec from the target cache, returning a runnable
+/// `Agent` shape. `None` means the bridge has no record of this agent_id
+/// — the caller should warn and skip; the next `bridge.target` will
+/// either include it (then a follow-up RPC re-applies) or confirm the
+/// platform never knew about it.
+async fn lookup_target(ctx: &SessionCtx, agent_id: &str) -> Option<crate::store::agents::Agent> {
+    let cache = ctx.targets.lock().await;
+    cache.get(agent_id).map(reconcile::target_to_agent)
+}
+
+async fn handle_agent_start_frame(ctx: &SessionCtx, payload: AgentStart) {
+    let agent_id = payload.agent_id.as_str();
+    let Some(agent) = lookup_target(ctx, agent_id).await else {
+        tracing::warn!(
+            agent_id = %agent_id,
+            "agent.start: no spec in target cache; skipping"
+        );
+        return;
+    };
+    // Idempotent: if the runtime is already up, do nothing.
+    if matches!(
+        ctx.manager.process_state(agent_id).await,
+        Some(ProcessState::Active { .. }) | Some(ProcessState::PromptInFlight { .. })
+    ) {
+        tracing::debug!(agent_id = %agent_id, "agent.start: agent already running; no-op");
+        return;
+    }
+    let directive = payload.decision_resume.clone();
+    if let Err(e) = ctx
+        .manager
+        .start_agent(&agent, None, directive.as_ref().map(|d| d.prompt.clone()))
+        .await
+    {
+        tracing::warn!(agent_id = %agent_id, err = %e, "agent.start: start_agent failed");
+        return;
+    }
+    let pid = ctx.counter.allocate(agent_id).await;
+    send_agent_state(&ctx.state_tx, agent_id, "started", pid).await;
+    if let Some(d) = directive {
+        send_decision_delivered(&ctx.state_tx, agent_id, &d.decision_id).await;
+    }
+}
+
+async fn handle_agent_stop_frame(ctx: &SessionCtx, payload: AgentStop) {
+    let agent_id = payload.agent_id.as_str();
+    if let Err(e) = ctx.manager.stop_agent(agent_id).await {
+        tracing::warn!(agent_id = %agent_id, err = %e, "agent.stop: stop_agent failed");
+        return;
+    }
+    let pid = ctx.counter.current(agent_id).await;
+    ctx.counter.forget(agent_id).await;
+    send_agent_state(&ctx.state_tx, agent_id, "stopped", pid).await;
+}
+
+async fn handle_agent_restart_frame(ctx: &SessionCtx, payload: AgentRestart) {
+    let agent_id = payload.agent_id.as_str();
+    let Some(agent) = lookup_target(ctx, agent_id).await else {
+        tracing::warn!(
+            agent_id = %agent_id,
+            "agent.restart: no spec in target cache; skipping"
+        );
+        return;
+    };
+    // Stop first so the directive lands on the new instance, not the old one.
+    if matches!(
+        ctx.manager.process_state(agent_id).await,
+        Some(ProcessState::Active { .. }) | Some(ProcessState::PromptInFlight { .. })
+    ) {
+        if let Err(e) = ctx.manager.stop_agent(agent_id).await {
+            tracing::warn!(agent_id = %agent_id, err = %e, "agent.restart: stop_agent failed");
+            return;
+        }
+        let prev_pid = ctx.counter.current(agent_id).await;
+        ctx.counter.forget(agent_id).await;
+        send_agent_state(&ctx.state_tx, agent_id, "stopped", prev_pid).await;
+    }
+    let directive = payload.decision_resume.clone();
+    if let Err(e) = ctx
+        .manager
+        .start_agent(&agent, None, directive.as_ref().map(|d| d.prompt.clone()))
+        .await
+    {
+        tracing::warn!(agent_id = %agent_id, err = %e, "agent.restart: start_agent failed");
+        return;
+    }
+    let pid = ctx.counter.allocate(agent_id).await;
+    send_agent_state(&ctx.state_tx, agent_id, "started", pid).await;
+    if let Some(d) = directive {
+        send_decision_delivered(&ctx.state_tx, agent_id, &d.decision_id).await;
     }
 }
 
@@ -532,8 +694,19 @@ async fn handle_chat(ctx: &SessionCtx, payload: ChatMessageReceived) {
         _ => {
             // Wake the agent. The cached target was captured above so the
             // manager doesn't need to re-read the store.
+            //
+            // Pull the unread message that triggered this wake so the
+            // agent's first prompt has the message context. Without this,
+            // the agent boots, runs `check_messages` as a tool call, then
+            // replies — costing an extra LLM round-trip on every cold
+            // start. With it, the message is the init prompt directly.
+            let wake_message = ctx
+                .store
+                .get_messages_for_agent_id(agent_id, false)
+                .ok()
+                .and_then(|msgs| msgs.into_iter().next());
             let agent = super::reconcile::target_to_agent(&target_clone);
-            let r = ctx.manager.start_agent(&agent, None, None).await;
+            let r = ctx.manager.start_agent(&agent, wake_message, None).await;
             if r.is_ok() {
                 let pid = ctx.counter.allocate(agent_id).await;
                 send_agent_state(&ctx.state_tx, agent_id, "started", pid).await;

--- a/src/bridge/protocol.rs
+++ b/src/bridge/protocol.rs
@@ -34,6 +34,28 @@ pub const FRAME_CHAT_MESSAGE_RECEIVED: &str = "chat.message.received";
 /// batch was buffered for the local runtime.
 pub const FRAME_CHAT_ACK: &str = "chat.ack";
 
+/// Platform → Bridge: start an agent's runtime. Idempotent — if the
+/// agent is already running, the bridge no-ops. Carries an optional
+/// `init_directive` (e.g., a decision-resume envelope) that becomes the
+/// agent's first turn prompt.
+pub const FRAME_AGENT_START: &str = "agent.start";
+
+/// Platform → Bridge: stop an agent's runtime. Idempotent — if no
+/// process exists, the bridge no-ops. The agent stays in `bridge.target`
+/// (still owned by this bridge), it just isn't running.
+pub const FRAME_AGENT_STOP: &str = "agent.stop";
+
+/// Platform → Bridge: stop+start the agent's runtime to pick up a spec
+/// change or deliver a one-shot `init_directive`. Equivalent to a stop
+/// followed by a start, but carried as one frame so the bridge can
+/// guarantee the directive lands on the new instance.
+pub const FRAME_AGENT_RESTART: &str = "agent.restart";
+
+/// Bridge → Platform: confirms the bridge delivered a decision-resume
+/// prompt to the agent on its next start. The platform marks exactly
+/// that decision as delivered, so reconnect-replay won't re-emit it.
+pub const FRAME_AGENT_DECISION_DELIVERED: &str = "agent.decision_delivered";
+
 // ── Envelope ─────────────────────────────────────────────────────────────
 
 /// JSON envelope wrapping every WS frame in either direction.
@@ -110,7 +132,10 @@ pub struct BridgeTarget {
     pub target_agents: Vec<AgentTarget>,
 }
 
-/// One agent's full runtime config inside a `bridge.target`.
+/// One agent's full runtime config inside a `bridge.target`. `bridge.target`
+/// carries identity + spec only; lifecycle intent (start / stop / restart)
+/// flows as discrete `FRAME_AGENT_START` / `FRAME_AGENT_STOP` /
+/// `FRAME_AGENT_RESTART` frames.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AgentTarget {
@@ -127,13 +152,6 @@ pub struct AgentTarget {
     pub reasoning_effort: Option<String>,
     #[serde(default)]
     pub env_vars: Vec<EnvVar>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub init_directive: Option<String>,
-    /// Reserved for a future slice that funnels a queued user prompt
-    /// through `bridge.target` so the bridge can deliver it on first
-    /// turn. Currently unused.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pending_prompt: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -156,4 +174,60 @@ pub struct ChatMessageReceived {
     /// inspect this field, only forwards it via the agent's mailbox.
     #[serde(default)]
     pub messages: Value,
+}
+
+/// A decision-resume prompt the bridge delivers as the agent's first
+/// turn after a human resolves a decision in the inbox. `decision_id`
+/// is the resolved decision's row id; the bridge echoes it back via
+/// `agent.decision_delivered` so the platform marks exactly that row as
+/// delivered (not "all undelivered decisions for this agent", which
+/// races with rapid re-resolves).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct DecisionResume {
+    pub decision_id: String,
+    pub prompt: String,
+}
+
+/// `agent.start` payload — platform asks the bridge to launch this
+/// agent's runtime. If the agent is already running, the bridge no-ops.
+/// `decision_resume`, when present, supplies the agent's first turn
+/// prompt and the `decision_id` the bridge must echo back via
+/// `agent.decision_delivered`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStart {
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_resume: Option<DecisionResume>,
+}
+
+/// `agent.stop` payload — platform asks the bridge to terminate this
+/// agent's runtime. If no process exists, the bridge no-ops.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStop {
+    pub agent_id: String,
+}
+
+/// `agent.restart` payload — stop+start the agent's runtime to pick up
+/// a spec change or deliver a queued decision resume. Equivalent to a
+/// stop followed by a start, but issued as one frame so the resume
+/// lands on the new instance.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentRestart {
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_resume: Option<DecisionResume>,
+}
+
+/// `agent.decision_delivered` payload — bridge confirms it delivered a
+/// specific decision-resume prompt to the agent on its next start. The
+/// platform marks exactly the named decision as delivered.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentDecisionDelivered {
+    pub agent_id: String,
+    pub decision_id: String,
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -71,9 +71,9 @@ pub async fn run(
     let bridge_local_addr = bridge_listener.local_addr().map_err(|e| {
         anyhow::anyhow!("shared bridge: failed to read local address for {bridge_listen}: {e}")
     })?;
-    // Phase 1 bridge only supports loopback — guard in case the resolved
-    // address is somehow non-loopback (shouldn't happen with 127.0.0.1, but
-    // be defensive).
+    // The bridge only supports loopback — guard in case the resolved
+    // address is somehow non-loopback (shouldn't happen with 127.0.0.1,
+    // but be defensive).
     if !bridge_local_addr.ip().is_loopback() {
         anyhow::bail!(
             "shared bridge: refusing non-loopback bind {bridge_local_addr}; bridge will not start"
@@ -151,9 +151,8 @@ pub async fn run(
     });
 
     // No boot autorestart: agents lazy-start on first incoming message
-    // (see deliver_message_to_agents). The active agent_sessions row
-    // (added in Phase 5) will ensure resume continuity when the next
-    // start happens.
+    // (see deliver_message_to_agents). The active `agent_sessions` row
+    // ensures resume continuity when the next start happens.
 
     // Load agent templates from the configured directory.
     let template_path = chorus::agent::templates::expand_tilde(&template_dir_raw);
@@ -183,6 +182,34 @@ pub async fn run(
         db_path.to_str().unwrap().to_string(),
         event_bus.subscribe_traces(),
     );
+
+    // In-process bridge client: every agent owned by `chorus serve`
+    // flows through the same bridge protocol a remote `chorus bridge`
+    // uses. The client dials our own `/api/bridge/ws` over loopback and
+    // shares the AgentManager and MCP bridge endpoint we already
+    // constructed above — there is no second runtime owner. Spawned
+    // before the listener accepts external traffic so the first agent
+    // CRUD broadcasts to a live receiver. The dial loop's own backoff
+    // covers the brief gap between this spawn and `axum::serve`
+    // accepting on the listener.
+    let in_proc_machine_id = chorus::server::resolve_local_machine_id_for_serve(&data_dir);
+    let in_proc_ws_url = format!("ws://127.0.0.1:{port}/api/bridge/ws");
+    let in_proc_shutdown = shutdown_token.clone();
+    let in_proc_manager = manager.clone();
+    let in_proc_store = store.clone();
+    tokio::spawn(async move {
+        if let Err(err) = chorus::bridge::client::run_in_process_bridge_client(
+            in_proc_ws_url,
+            in_proc_machine_id,
+            in_proc_manager,
+            in_proc_store,
+            in_proc_shutdown,
+        )
+        .await
+        {
+            tracing::error!(err = %err, "in-process bridge client exited with error");
+        }
+    });
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}")).await?;
     tracing::info!("Chorus running at {server_url}");

--- a/src/server/bridge_auth.rs
+++ b/src/server/bridge_auth.rs
@@ -216,11 +216,11 @@ pub async fn require_bridge_auth(
                                 .into_response();
                         }
                     };
-                    if owner.as_deref() != Some(expected_machine_id.as_str()) {
+                    if owner != *expected_machine_id {
                         warn!(
                             path = %path,
                             token_machine_id = %expected_machine_id,
-                            agent_owner = ?owner,
+                            agent_owner = %owner,
                             "bridge_auth: rejecting /internal request — token's machine_id does not own this agent"
                         );
                         return (StatusCode::FORBIDDEN, "token not authorized for this agent")

--- a/src/server/handlers/agents.rs
+++ b/src/server/handlers/agents.rs
@@ -13,7 +13,9 @@ use super::{acquire_transition, app_err, ApiResult, AppState};
 use crate::agent::activity_log::ActivityLogResponse;
 use crate::agent::workspace::AgentWorkspace;
 use crate::agent::AgentRuntime;
-use crate::server::transport::bridge_ws::broadcast_target_update;
+use crate::server::transport::bridge_ws::{
+    broadcast_target_update, dispatch_agent_restart, dispatch_agent_start, dispatch_agent_stop,
+};
 use crate::store::agents::AgentEnvVar;
 use crate::store::messages::SenderType;
 use crate::store::AgentRecordUpsert;
@@ -268,8 +270,8 @@ pub async fn handle_create_agent(
 
     // Create the agent record, join auto-join channels, and start it.
     // Default an omitted/blank machine_id to the local installation's id
-    // so every row has a non-NULL owner. Phase 2's in-process bridge
-    // client picks these up by matching on `local_machine_id`.
+    // so every row has a non-NULL owner. The in-process bridge client
+    // picks these up by matching on `local_machine_id`.
     let machine_id_resolved: String = req
         .machine_id
         .as_deref()
@@ -287,7 +289,7 @@ pub async fn handle_create_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: Some(&machine_id_resolved),
+            machine_id: &machine_id_resolved,
             env_vars: &env_vars,
         },
     )
@@ -319,7 +321,7 @@ pub(crate) struct CreateAgentParams<'a> {
     pub runtime: &'a str,
     pub model: &'a str,
     pub reasoning_effort: Option<&'a str>,
-    pub machine_id: Option<&'a str>,
+    pub machine_id: &'a str,
     pub env_vars: &'a [AgentEnvVar],
 }
 
@@ -414,52 +416,15 @@ pub(crate) async fn create_and_start_agent(
             ),
         }
     }
-    // Brand-new agent — ask it to introduce itself in the system channel.
-    // The directive is delivered as the first prompt; the agent's model
-    // picks the right messaging tool from its system prompt and writes
-    // the intro itself. Only issued when the system-channel join landed —
-    // otherwise we'd send the agent on an impossible errand.
-    let intro_directive = joined_system_channel.then(|| {
-        format!(
-            "You have just been added to #{ch}. Post a brief one-or-two-sentence introduction of yourself in #{ch}, then stop.",
-            ch = crate::store::Store::DEFAULT_SYSTEM_CHANNEL,
-        )
-    });
-    // Bridge-hosted = `machine_id` differs from the local installation's id.
-    // Those agents are started by a remote bridge after the platform pushes
-    // a `bridge.target` update; the platform must NOT spawn them locally,
-    // or both runtimes contend on the same ACP session.
-    let bridge_hosted = params.machine_id != Some(state.local_machine_id.as_str());
-    let start_error = if bridge_hosted {
-        info!(
-            agent = %name,
-            machine_id = %params.machine_id.unwrap_or(""),
-            "create_and_start_agent: bridge-hosted, skipping platform-side start"
-        );
-        None
-    } else {
-        // Reload with env_vars hydrated — the runtime spec inside `start_agent`
-        // reads them off the record we hand in.
-        let agent = state
-            .store
-            .get_agent_by_id(&id, true)?
-            .ok_or_else(|| anyhow::anyhow!("agent vanished after create: {id}"))?;
-        if let Err(err) = state
-            .lifecycle
-            .start_agent(&agent, None, intro_directive)
-            .await
-        {
-            let error_detail = format_anyhow_error(&err);
-            warn!(agent = %name, error = %error_detail, "agent created but failed to start");
-            Some(format!("{err}"))
-        } else {
-            None
-        }
-    };
+    // The handler's job ends at "row written, channels joined, target
+    // broadcast". The bridge client picks up the new row from
+    // `bridge.target` and starts the runtime on the next wake event
+    // (incoming chat, manual start, or decision resume).
+    let _ = joined_system_channel;
     Ok(CreateAgentResult {
         name,
         id,
-        start_error,
+        start_error: None,
     })
 }
 
@@ -514,17 +479,16 @@ pub async fn handle_update_agent(
         || existing.env_vars != env_vars;
 
     // Preserve the existing owner when the request omits `machineId`.
-    // Without this, every PATCH would clobber `machine_id` to NULL — a
-    // bridge-hosted agent renamed via the UI (which doesn't echo
-    // `machineId` back) would silently lose its owner.
+    // The UI's "Edit agent" form doesn't always echo `machineId`, and
+    // every row has one already; we never want PATCH to silently move
+    // an agent across machines.
     let machine_id_resolved: String = req
         .machine_id
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
-        .or_else(|| existing.machine_id.clone())
-        .unwrap_or_else(|| state.local_machine_id.clone());
+        .unwrap_or_else(|| existing.machine_id.clone());
     state
         .store
         .update_agent_record(&AgentRecordUpsert {
@@ -535,7 +499,7 @@ pub async fn handle_update_agent(
             runtime: &req.runtime,
             model: &req.model,
             reasoning_effort: reasoning_effort.as_deref(),
-            machine_id: Some(&machine_id_resolved),
+            machine_id: &machine_id_resolved,
             env_vars: &env_vars,
         })
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
@@ -544,31 +508,17 @@ pub async fn handle_update_agent(
     let was_running = crate::agent::process_status::derive_status(ps.as_ref())
         != crate::agent::process_status::Status::Asleep;
 
-    // Bridge-hosted agents are restarted by the remote bridge when it
-    // receives the broadcast target update below. The platform does not
-    // own the runtime process and must not call start/stop. "Bridge-hosted"
-    // here means "owned by a non-local machine_id"; agents with
-    // machine_id == local_machine_id still go through the platform's
-    // in-process AgentManager until Phase 2 swaps it for the in-process
-    // bridge client.
-    let bridge_hosted = machine_id_resolved != state.local_machine_id;
-    if was_running && requires_restart && !bridge_hosted {
-        state
-            .lifecycle
-            .stop_agent(&agent_id)
-            .await
-            .map_err(internal_err)?;
-        // Reload after the update so spec changes (env_vars, model, runtime)
-        // take effect on the restart.
-        let refreshed = resolve_public_agent_with_env(&state, &existing.id)?;
-        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
-            return Err(app_err!(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "agent updated but restart failed: {err}"
-            ));
+    // Push the new spec to the owning bridge so its target cache picks
+    // up the changes. Spec-affecting updates additionally emit a
+    // `agent.restart` so the runtime re-launches with the new values.
+    broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
+    if requires_restart {
+        if let Err(e) =
+            dispatch_agent_restart(state.store.as_ref(), state.bridge_registry.as_ref(), &agent_id, None)
+        {
+            warn!(agent_id = %agent_id, error = %e, "agent.restart dispatch failed; bridge will stay on old spec until next start");
         }
     }
-    broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
     Ok(Json(serde_json::json!({
         "ok": true,
         "restarted": was_running && requires_restart
@@ -585,18 +535,6 @@ pub async fn handle_restart_agent(
     let _transition = acquire_transition(&state, &agent.id)?;
     let agents_dir = state.agents_dir.clone();
     let workspace = AgentWorkspace::new(&agents_dir);
-
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if !bridge_hosted {
-        state
-            .lifecycle
-            .stop_agent(&agent.id)
-            .await
-            .map_err(internal_err)?;
-    }
 
     match req.mode {
         RestartMode::Restart => {}
@@ -622,19 +560,13 @@ pub async fn handle_restart_agent(
         }
     }
 
-    if !bridge_hosted {
-        // Reload after RestartMode::ResetSession / FullReset so the start
-        // sees post-clear state for env_vars/spec lookups.
-        let refreshed = resolve_public_agent_with_env(&state, &agent.id)?;
-        if let Err(err) = state.lifecycle.start_agent(&refreshed, None, None).await {
-            return Err(app_err!(
-                AppErrorCode::AgentRestartFailed,
-                "restart failed: {err}"
-            ));
-        }
-    } else {
-        // Push fresh target so the bridge stops/starts the runtime locally.
-        broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
+    // Tell the owning bridge to stop+start the runtime. Reconcile only
+    // sweeps orphans, so a dedicated `agent.restart` is the only way to
+    // recycle a process for a manual restart.
+    if let Err(e) =
+        dispatch_agent_restart(state.store.as_ref(), state.bridge_registry.as_ref(), &agent.id, None)
+    {
+        warn!(agent_id = %agent.id, error = %e, "agent.restart dispatch failed");
     }
     Ok(Json(serde_json::json!({
         "ok": true,
@@ -652,22 +584,11 @@ pub async fn handle_delete_agent(
     let name = agent.name.clone();
     let _transition = acquire_transition(&state, &agent.id)?;
 
-    // Skip local stop for bridge-hosted agents: the bridge stops them when
-    // the next `bridge.target` (broadcast below after the row delete) drops
-    // the agent from the desired set. Calling stop_agent here is a no-op
-    // locally but adds noise to the activity log.
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if !bridge_hosted {
-        state
-            .lifecycle
-            .stop_agent(&agent.id)
-            .await
-            .map_err(internal_err)?;
-    }
-
+    // Stop happens via bridge client reconcile: deleting the row drops
+    // the agent from the desired set; the bridge client sees it's still
+    // running but no longer desired, and stops the OS process. Order
+    // matters — broadcast goes out *after* the row delete so the bridge
+    // client sees the absence on the next target frame.
     state
         .store
         .mark_agent_messages_deleted(&name)
@@ -696,29 +617,15 @@ pub async fn handle_agent_start(
     State(state): State<AppState>,
     Path(PublicResourceIdPath { id }): Path<PublicResourceIdPath>,
 ) -> ApiResult<serde_json::Value> {
-    // Hydrate env_vars: start_agent now reads the spec directly off the
-    // record we pass in, so the lookup happens here rather than inside
-    // the manager.
-    let agent = resolve_public_agent_with_env(&state, &id)?;
+    let agent = resolve_public_agent(&state, &id)?;
     let _transition = acquire_transition(&state, &agent.id)?;
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if bridge_hosted {
-        // Bridge-hosted: the bridge already keeps the runtime alive per
-        // target. Re-broadcast so any reconnected bridge picks it up.
-        info!(agent = %agent.name, "agent is bridge-hosted; refreshing target");
-        broadcast_target_update(state.store.as_ref(), state.bridge_registry.as_ref());
-        return Ok(Json(serde_json::json!({ "ok": true })));
+    info!(agent = %agent.name, agent_id = %agent.id, "dispatching agent.start");
+    if let Err(e) =
+        dispatch_agent_start(state.store.as_ref(), state.bridge_registry.as_ref(), &agent.id, None)
+    {
+        warn!(agent_id = %agent.id, error = %e, "agent.start dispatch failed");
+        return Err(internal_err(e));
     }
-    info!(agent = %agent.name, "starting agent");
-    state
-        .lifecycle
-        .start_agent(&agent, None, None)
-        .await
-        .map_err(internal_err)?;
-    info!(agent = %agent.name, "agent started");
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -727,31 +634,14 @@ pub async fn handle_agent_stop(
     Path(PublicResourceIdPath { id }): Path<PublicResourceIdPath>,
 ) -> ApiResult<serde_json::Value> {
     let agent = resolve_public_agent(&state, &id)?;
-    let name = agent.name.clone();
     let _transition = acquire_transition(&state, &agent.id)?;
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if bridge_hosted {
-        // Bridge-hosted: platform doesn't own the runtime. There's no
-        // explicit "stop a single bridge-hosted agent" frame yet, so this
-        // becomes a no-op until we add an `agent.stop` directive in the
-        // protocol. For now, surface a clear status rather than silently
-        // succeed with the wrong meaning.
-        info!(agent = %name, "agent is bridge-hosted; stop is a no-op (deletion via DELETE removes it)");
-        return Ok(Json(serde_json::json!({
-            "ok": true,
-            "note": "agent is bridge-hosted; the platform does not own the runtime"
-        })));
+    info!(agent = %agent.name, agent_id = %agent.id, "dispatching agent.stop");
+    if let Err(e) =
+        dispatch_agent_stop(state.store.as_ref(), state.bridge_registry.as_ref(), &agent.id)
+    {
+        warn!(agent_id = %agent.id, error = %e, "agent.stop dispatch failed");
+        return Err(internal_err(e));
     }
-    info!(agent = %name, id = %agent.id, "stopping agent");
-    state
-        .lifecycle
-        .stop_agent(&agent.id)
-        .await
-        .map_err(internal_err)?;
-    info!(agent = %name, id = %agent.id, "agent stopped");
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 

--- a/src/server/handlers/decisions.rs
+++ b/src/server/handlers/decisions.rs
@@ -310,30 +310,31 @@ pub async fn handle_resolve_decision(
 
     let envelope = build_resume_envelope(&payload, picked, body.note.as_deref());
 
-    if let Err(e) = state
-        .lifecycle
-        .resume_with_prompt(&agent.id, envelope)
-        .await
-    {
-        // Roll back the resolve so the human's pick isn't silently lost.
+    // Push the envelope to the owning bridge as an `agent.restart`. The
+    // wire `DecisionResume { id, body }` pairs the prompt with the source
+    // decision id so the bridge's `agent.decision_delivered` ack maps
+    // back to exactly this row — no ambiguity with concurrent decisions
+    // on the same agent. Persistence lives on the `decisions` row
+    // (status=resolved + delivered_at IS NULL); if the bridge is
+    // offline, the next `bridge.hello` reconnect-replays.
+    let resume = crate::bridge::protocol::DecisionResume {
+        decision_id: decision_id.clone(),
+        prompt: envelope,
+    };
+    let dispatched = crate::server::transport::bridge_ws::dispatch_agent_restart(
+        state.store.as_ref(),
+        state.bridge_registry.as_ref(),
+        &agent.id,
+        Some(resume),
+    );
+    if let Err(e) = dispatched {
         warn!(
             agent = %agent.name,
             agent_id = %agent.id,
             decision_id = %decision_id,
             error = %e,
-            "resume_with_prompt failed; reverting decision to open"
+            "agent.restart dispatch failed; envelope will replay on next bridge hello"
         );
-        if let Err(revert_err) = state.store.revert_decision_to_open(&decision_id) {
-            warn!(
-                decision_id = %decision_id,
-                error = %revert_err,
-                "failed to revert decision after resume failure"
-            );
-        }
-        return Err(app_err!(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to deliver pick to agent: {e}"
-        ));
     }
 
     info!(
@@ -341,7 +342,7 @@ pub async fn handle_resolve_decision(
         decision_id = %decision_id,
         agent = %agent.name,
         picked = %body.picked_key,
-        "decision resolved + envelope delivered"
+        "decision resolved + agent.restart dispatched"
     );
 
     Ok(Json(ResolveDecisionResponse {
@@ -350,7 +351,29 @@ pub async fn handle_resolve_decision(
     }))
 }
 
-fn build_resume_envelope(payload: &Value, picked: &Value, note: Option<&str>) -> String {
+/// Construct the resume envelope (the agent's first-turn prompt after a
+/// human picks) from a stored `DecisionRow`. Returns `None` if the row
+/// hasn't been resolved yet, or if the row's payload is malformed.
+/// Called from both the resolve handler (live emit) and the bridge
+/// reconnect-replay path (offline-bridge re-emit).
+pub fn build_resume_envelope_from_row(
+    row: &crate::store::decisions::DecisionRow,
+) -> Option<String> {
+    let payload: Value = serde_json::from_str(&row.payload_json).ok()?;
+    let picked_key = row.picked_key.as_deref()?;
+    let picked = payload
+        .get("options")?
+        .as_array()?
+        .iter()
+        .find(|o| o.get("key").and_then(|k| k.as_str()) == Some(picked_key))?;
+    Some(build_resume_envelope(
+        &payload,
+        picked,
+        row.picked_note.as_deref(),
+    ))
+}
+
+pub(crate) fn build_resume_envelope(payload: &Value, picked: &Value, note: Option<&str>) -> String {
     let headline = payload
         .get("headline")
         .and_then(|v| v.as_str())

--- a/src/server/handlers/messages.rs
+++ b/src/server/handlers/messages.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::Json;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use super::dto::ChannelInfo;
 use super::path_params::{resolve_public_agent, PublicResourceIdPath};
@@ -15,7 +15,7 @@ use crate::store::inbox::InboxConversationNotificationView;
 use crate::store::messages::{CreateMessage, ForwardedFrom, ReceivedMessage, SenderType};
 use crate::store::Store;
 use crate::utils::error::internal_err;
-use crate::utils::error::{format_anyhow_error, AppErrorCode};
+use crate::utils::error::AppErrorCode;
 
 // ── Inline query structs ──
 
@@ -404,6 +404,11 @@ async fn send_message_to_channel(
     let preview = content_preview(content);
     info!(agent = %actor_id, target = %format!("#{}", channel.name), content = %preview, "send_message");
 
+    // `suppress_event` is an inert hint: the message.created event is
+    // the only signal that wakes a recipient agent, so we always
+    // publish. The UI's history hook dedups by sequence (newer-seq
+    // wins), so the echo doesn't double-render its own optimistic append.
+    let _ = suppress_event;
     let (message_id, event) = store
         .create_message(CreateMessage {
             channel_name: &channel.name,
@@ -411,7 +416,7 @@ async fn send_message_to_channel(
             sender_type,
             content,
             attachment_ids,
-            suppress_event,
+            suppress_event: false,
             run_id: run_id.as_deref(),
         })
         .map_err(|e| app_err!(StatusCode::BAD_REQUEST, e.to_string()))?;
@@ -427,19 +432,13 @@ async fn send_message_to_channel(
             .map_err(internal_err)?;
     }
 
-    if !suppress_agent_delivery {
-        if let Err(err) = deliver_message_to_agents(state, &channel.id, actor_id, &message_id).await
-        {
-            let error_detail = format_anyhow_error(&err);
-            warn!(
-                channel = %channel.name,
-                actor = %actor_id,
-                message_id = %message_id,
-                error = %error_detail,
-                "message persisted but agent delivery failed"
-            );
-        }
-    }
+    let _ = suppress_agent_delivery;
+    // Agent delivery: every agent is now bridge-owned, so the platform
+    // doesn't poke runtimes here. The published `message.created` event
+    // is forwarded to the agent's owning bridge by the event-bus
+    // subscriber in `build_router_with_services_and_auth`, which calls
+    // `forward_chat_event_to_bridges`. The bridge picks it up and either
+    // notifies a live agent or starts an asleep one.
 
     let message_view = store
         .get_conversation_message_view(&message_id)
@@ -503,8 +502,11 @@ async fn forward_team_mentions(
         )?;
         state.event_bus.publish_stream(event);
 
-        deliver_message_to_agents(state, &team_channel.id, sender_id, &forwarded_message_id)
-            .await?;
+        // Forwarded message: the published `message.created` event will
+        // route to the team channel's agent members via
+        // `forward_chat_event_to_bridges`, same as the originating
+        // channel above. No platform-side wake needed.
+        let _ = forwarded_message_id;
     }
 
     Ok(())
@@ -817,59 +819,14 @@ pub async fn handle_public_update_read_cursor(
     )
 }
 
-/// Fan-out a newly posted message to all relevant agent recipients.
-pub(crate) async fn deliver_message_to_agents(
-    state: &AppState,
-    channel_id: &str,
-    sender_name: &str,
-    message_id: &str,
-) -> anyhow::Result<()> {
-    let recipients = state
-        .store
-        .get_agent_message_recipients(channel_id, sender_name)?;
-    for recipient_name in recipients {
-        let Some(agent) = state.store.get_agent(&recipient_name)? else {
-            continue;
-        };
-        // Bridge-hosted agents are woken by the remote bridge after it
-        // receives `chat.message.received` via `forward_chat_event_to_bridges`;
-        // the platform must not spawn them locally. "Bridge-hosted" =
-        // owned by some other machine_id; the local installation's own
-        // agents (machine_id == local_machine_id) still go through the
-        // platform's in-process AgentManager until Phase 2 swaps the path.
-        if agent
-            .machine_id
-            .as_deref()
-            .is_some_and(|m| m != state.local_machine_id.as_str())
-        {
-            continue;
-        }
-        // Associate the channel with the agent's trace run before notifying/starting.
-        state.lifecycle.set_run_channel(&agent.id, channel_id);
-        // Route on runtime liveness (manager HashMap), not on the persisted
-        // `agents.status` column — the two can drift, and the manager is the
-        // single source of truth for whether a process is alive right now.
-        let process_state = state.lifecycle.process_state(&agent.id).await;
-        let status = crate::agent::process_status::derive_status(process_state.as_ref());
-        match status {
-            crate::agent::process_status::Status::Working
-            | crate::agent::process_status::Status::Ready => {
-                state.lifecycle.notify_agent(&agent.id).await?
-            }
-            crate::agent::process_status::Status::Asleep
-            | crate::agent::process_status::Status::Failed => {
-                let wake_message = state
-                    .store
-                    .get_received_message_for_agent_id(&agent.id, message_id)?;
-                state
-                    .lifecycle
-                    .start_agent(&agent, wake_message, None)
-                    .await?
-            }
-        }
-    }
-    Ok(())
-}
+// `deliver_message_to_agents` was the platform-local fan-out. Every
+// agent is now bridge-owned, so message routing flows through
+// `forward_chat_event_to_bridges` (subscribed to the event bus in
+// `build_router_with_services_and_auth`). The bridge that owns the
+// recipient agent — either the in-process bridge client running inside
+// `chorus serve` or a remote `chorus bridge` — sees
+// `chat.message.received` and decides whether to notify a live runtime
+// or start an asleep one. There is no platform-side wake path anymore.
 
 // ── Trace history ──
 

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -58,7 +58,7 @@ pub struct AppState {
     pub local_human_name: String,
     /// Stable identifier for this installation. Every agent created on
     /// `chorus serve` without an explicit `machine_id` defaults to this
-    /// value, so the in-process bridge client (Phase 2) can claim them.
+    /// value, so the in-process bridge client claims them.
     pub local_machine_id: String,
     pub lifecycle: Arc<dyn AgentLifecycle>,
     pub runtime_status_provider: SharedRuntimeStatusProvider,

--- a/src/server/handlers/teams.rs
+++ b/src/server/handlers/teams.rs
@@ -101,10 +101,10 @@ async fn sync_team_roles_and_agents(
 
 /// Restart an agent so its system prompt is rebuilt from the latest team state.
 ///
-/// For bridge-hosted agents (`agents.machine_id` set), the platform does not
-/// own the runtime; it broadcasts a fresh `bridge.target` instead so the
-/// remote bridge can stop/start the local process. Calling `start_agent`
-/// here would cause dual-runtime contention.
+/// Pushes the new spec to the owning bridge as a fresh `bridge.target`
+/// snapshot, then dispatches a `agent.restart` so the runtime
+/// re-launches with the new system prompt. The platform never touches
+/// the runtime process directly.
 async fn restart_agent_member(
     state: &AppState,
     agent_name: &str,
@@ -113,27 +113,23 @@ async fn restart_agent_member(
         Some(a) => a,
         None => return Ok(()),
     };
-    let bridge_hosted = agent
-        .machine_id
-        .as_deref()
-        .is_some_and(|m| m != state.local_machine_id.as_str());
-    if bridge_hosted {
-        crate::server::transport::bridge_ws::broadcast_target_update(
-            state.store.as_ref(),
-            state.bridge_registry.as_ref(),
+    crate::server::transport::bridge_ws::broadcast_target_update(
+        state.store.as_ref(),
+        state.bridge_registry.as_ref(),
+    );
+    if let Err(e) = crate::server::transport::bridge_ws::dispatch_agent_restart(
+        state.store.as_ref(),
+        state.bridge_registry.as_ref(),
+        &agent.id,
+        None,
+    ) {
+        tracing::warn!(
+            agent = %agent_name,
+            agent_id = %agent.id,
+            error = %e,
+            "team membership restart: agent.restart dispatch failed"
         );
-        return Ok(());
     }
-    state
-        .lifecycle
-        .stop_agent(&agent.id)
-        .await
-        .map_err(internal_err)?;
-    state
-        .lifecycle
-        .start_agent(&agent, None, None)
-        .await
-        .map_err(internal_err)?;
     Ok(())
 }
 

--- a/src/server/handlers/templates.rs
+++ b/src/server/handlers/templates.rs
@@ -150,7 +150,7 @@ pub async fn handle_launch_trio(
                 runtime: &template.suggested_runtime,
                 model: &model,
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: &state.local_machine_id,
                 env_vars: &[],
             },
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,6 +3,9 @@ pub mod bridge_auth;
 pub mod bridge_registry;
 pub mod event_bus;
 mod handlers;
+/// Re-export so tests + reconnect-replay can rebuild the resume directive
+/// from a `DecisionRow` without exposing the full handler surface area.
+pub use handlers::decisions::build_resume_envelope_from_row;
 pub mod transport;
 
 use std::sync::Arc;
@@ -116,14 +119,6 @@ pub fn build_router_with_services_and_auth(
     let (local_human_id, local_human_name) =
         resolve_local_human_identity(store.as_ref(), &data_dir);
     let local_machine_id = resolve_local_machine_id(&data_dir);
-
-    // Backfill rows that pre-date the always-set-machine_id invariant.
-    // After this UPDATE every agent owned by `chorus serve` has a non-NULL
-    // `machine_id` equal to `local_machine_id`. Rows already pinned to a
-    // remote bridge keep their value; only NULLs are touched.
-    if let Err(err) = store.backfill_null_machine_ids(&local_machine_id) {
-        tracing::warn!(err = %err, "backfill_null_machine_ids failed; agent rows may have NULL machine_id");
-    }
 
     // Built-in channels (`#all`) and the local human's membership are seeded
     // here, after identity resolution: the legacy CLI bootstrap used the OS
@@ -370,6 +365,13 @@ fn resolve_local_human_identity(store: &Store, data_dir: &std::path::Path) -> (S
             panic!("unable to resolve persisted local human identity: {err}");
         }
     }
+}
+
+/// Public re-export of `resolve_local_machine_id` so `cli/serve.rs` can
+/// read the same id (from disk) it embeds into `AppState`. The function
+/// is idempotent — both calls land on the same UUID.
+pub fn resolve_local_machine_id_for_serve(data_dir: &std::path::Path) -> String {
+    resolve_local_machine_id(data_dir)
 }
 
 /// Resolve the local installation's `machine_id`, generating and persisting

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -29,9 +29,11 @@ use axum::response::IntoResponse;
 use tracing::{debug, info, warn};
 
 use crate::bridge::protocol::{
-    AgentState as AgentStatePayload, AgentTarget, BridgeTarget, ChatAck as ChatAckPayload, EnvVar,
-    Hello as BridgeHello, WireFrame, FRAME_AGENT_STATE, FRAME_BRIDGE_HELLO, FRAME_BRIDGE_TARGET,
-    FRAME_CHAT_ACK, FRAME_CHAT_MESSAGE_RECEIVED,
+    AgentDecisionDelivered, AgentRestart, AgentStart, AgentState as AgentStatePayload, AgentStop,
+    AgentTarget, BridgeTarget, ChatAck as ChatAckPayload, DecisionResume, EnvVar,
+    Hello as BridgeHello, WireFrame, FRAME_AGENT_DECISION_DELIVERED, FRAME_AGENT_RESTART,
+    FRAME_AGENT_START, FRAME_AGENT_STATE, FRAME_AGENT_STOP, FRAME_BRIDGE_HELLO,
+    FRAME_BRIDGE_TARGET, FRAME_CHAT_ACK, FRAME_CHAT_MESSAGE_RECEIVED,
 };
 use crate::server::bridge_auth::AuthOutcome;
 use crate::server::bridge_registry::BridgeRegistry;
@@ -61,8 +63,6 @@ fn agent_to_target(a: Agent) -> AgentTarget {
                 value: e.value,
             })
             .collect(),
-        init_directive: None,
-        pending_prompt: None,
     }
 }
 
@@ -136,6 +136,17 @@ async fn bridge_session(
         return;
     }
 
+    // Reconnect replay: agents owned by this bridge that have a pending
+    // wake reason (unread inbox messages OR an undelivered resolved
+    // decision) need a `agent.start` so the bridge launches them. This
+    // is what makes the platform a real source of truth for "should be
+    // running": the agent's row carries no `paused` / `restart_seq` /
+    // `pending_init_directive` flags — instead we derive intent from
+    // unread + decision state every time a bridge connects.
+    if let Err(err) = replay_pending_starts(&mut socket, store.as_ref(), &machine_id).await {
+        warn!(machine_id = %machine_id, error = %err, "bridge_ws: reconnect replay failed; bridge will only wake on chat");
+    }
+
     // Session loop: forward outbound frames pushed by the platform
     // (push-on-change `bridge.target` etc.) and process inbound frames
     // from the bridge (`agent.state`, future `chat.ack`).
@@ -158,7 +169,7 @@ async fn bridge_session(
                 match incoming {
                     Some(Ok(Message::Text(text))) => {
                         if let Err(err) =
-                            handle_inbound_frame(&machine_id, text.as_str(), registry.as_ref()).await
+                            handle_inbound_frame(&machine_id, text.as_str(), registry.as_ref(), store.as_ref()).await
                         {
                             warn!(machine_id = %machine_id, error = %err, "bridge_ws: dropping malformed inbound frame");
                             // Don't disconnect on a single bad frame —
@@ -220,10 +231,58 @@ async fn send_initial_target(
     Ok(())
 }
 
+/// After the initial `bridge.target` snapshot, walk the agents owned by
+/// this bridge and emit `agent.start` for any that have a pending wake:
+/// unread messages, or a resolved-not-delivered decision (whose envelope
+/// becomes `init_directive`). This restores "agent resumes when the
+/// bridge comes back" without keeping a `paused` flag — the wake is
+/// derived from persistent inbox + decision state every reconnect.
+async fn replay_pending_starts(
+    socket: &mut WebSocket,
+    store: &Store,
+    machine_id: &str,
+) -> anyhow::Result<()> {
+    let owned: Vec<Agent> = store
+        .get_agents()?
+        .into_iter()
+        .filter(|a| a.machine_id == machine_id)
+        .collect();
+    for agent in owned {
+        let resume = match store.latest_undelivered_resolved_for_agent(&agent.id)? {
+            Some(row) => crate::server::handlers::decisions::build_resume_envelope_from_row(&row)
+                .map(|prompt| DecisionResume {
+                    decision_id: row.id.clone(),
+                    prompt,
+                }),
+            None => None,
+        };
+        let has_unread = !store.get_unread_summary(&agent.id)?.is_empty();
+        if resume.is_none() && !has_unread {
+            continue;
+        }
+        let had_resume = resume.is_some();
+        let payload = AgentStart {
+            agent_id: agent.id.clone(),
+            decision_resume: resume,
+        };
+        let text = build_lifecycle_frame_text(FRAME_AGENT_START, serde_json::to_value(&payload)?)?;
+        socket.send(Message::Text(text.into())).await?;
+        debug!(
+            machine_id = %machine_id,
+            agent_id = %agent.id,
+            had_resume,
+            has_unread,
+            "bridge_ws: replayed agent.start on hello"
+        );
+    }
+    Ok(())
+}
+
 async fn handle_inbound_frame(
     machine_id: &str,
     text: &str,
     registry: &BridgeRegistry,
+    store: &Store,
 ) -> anyhow::Result<()> {
     let envelope: WireFrame = serde_json::from_str(text)
         .map_err(|e| anyhow::anyhow!("failed to parse inbound envelope: {e}"))?;
@@ -277,6 +336,31 @@ async fn handle_inbound_frame(
             );
             Ok(())
         }
+        FRAME_AGENT_DECISION_DELIVERED => {
+            let payload: AgentDecisionDelivered = serde_json::from_value(envelope.data)
+                .map_err(|e| anyhow::anyhow!("failed to parse agent.decision_delivered: {e}"))?;
+            // Mark exactly the named directive as delivered. The bridge
+            // echoes the `directive_id` from the start/restart frame, so
+            // a rapid re-emit of a different directive can't be falsely
+            // marked delivered by an earlier ack.
+            match store.mark_decision_delivered(&payload.decision_id) {
+                Ok(n) => debug!(
+                    machine_id = %machine_id,
+                    agent_id = %payload.agent_id,
+                    directive_id = %payload.decision_id,
+                    delivered = n,
+                    "bridge_ws: marked decision delivered after directive_consumed"
+                ),
+                Err(err) => warn!(
+                    machine_id = %machine_id,
+                    agent_id = %payload.agent_id,
+                    directive_id = %payload.decision_id,
+                    error = %err,
+                    "bridge_ws: failed to mark decision delivered"
+                ),
+            }
+            Ok(())
+        }
         // Bridge re-sending hello is allowed for self-correction. Treat
         // as a no-op today; a future change can trigger a fresh target
         // push in response.
@@ -292,12 +376,10 @@ async fn handle_inbound_frame(
 
 /// Build a serialized `bridge.target` frame from the current set of
 /// agents in the store, scoped to a specific bridge `machine_id`. Only
-/// agents explicitly bound to this bridge are included; agents with
-/// NULL `machine_id` are platform-local and never sent to any bridge.
+/// agents whose `machine_id` matches are included.
 ///
-/// Every agent has exactly one owner (the platform itself, or one named
-/// bridge). Fanning NULL agents to all bridges would cause dual-runtime
-/// contention as soon as a second bridge connects.
+/// Every agent has exactly one owner; fanning agents to bridges that
+/// don't own them would cause dual-runtime contention.
 pub fn build_target_frame_text_for_machine(
     store: &Store,
     machine_id: &str,
@@ -305,7 +387,7 @@ pub fn build_target_frame_text_for_machine(
     let agents: Vec<Agent> = store
         .get_agents()?
         .into_iter()
-        .filter(|a| a.machine_id.as_deref() == Some(machine_id))
+        .filter(|a| a.machine_id == machine_id)
         .collect();
     let target = BridgeTarget {
         target_agents: agents.into_iter().map(agent_to_target).collect(),
@@ -316,6 +398,81 @@ pub fn build_target_frame_text_for_machine(
         data: serde_json::to_value(&target)?,
     };
     Ok(serde_json::to_string(&envelope)?)
+}
+
+/// Build a serialized lifecycle RPC frame (`agent.start`, `agent.stop`,
+/// `agent.restart`).
+fn build_lifecycle_frame_text(
+    frame_type: &str,
+    data: serde_json::Value,
+) -> anyhow::Result<String> {
+    let envelope = WireFrame {
+        v: 1,
+        frame_type: frame_type.to_string(),
+        data,
+    };
+    Ok(serde_json::to_string(&envelope)?)
+}
+
+/// Find the bridge that owns this agent and send an `agent.start` frame.
+/// Returns `Ok(true)` if the owning bridge is connected and the frame was
+/// queued; `Ok(false)` if the bridge is offline (the platform's persisted
+/// state — unread messages, undelivered decisions — covers reconnect
+/// replay so this is not an error).
+pub fn dispatch_agent_start(
+    store: &Store,
+    registry: &BridgeRegistry,
+    agent_id: &str,
+    decision_resume: Option<DecisionResume>,
+) -> anyhow::Result<bool> {
+    let owner = match resolve_owner(store, agent_id)? {
+        Some(o) => o,
+        None => return Ok(false),
+    };
+    let payload = AgentStart {
+        agent_id: agent_id.to_string(),
+        decision_resume,
+    };
+    let text = build_lifecycle_frame_text(FRAME_AGENT_START, serde_json::to_value(&payload)?)?;
+    Ok(registry.send_to(&owner, &text) > 0)
+}
+
+pub fn dispatch_agent_stop(
+    store: &Store,
+    registry: &BridgeRegistry,
+    agent_id: &str,
+) -> anyhow::Result<bool> {
+    let owner = match resolve_owner(store, agent_id)? {
+        Some(o) => o,
+        None => return Ok(false),
+    };
+    let payload = AgentStop {
+        agent_id: agent_id.to_string(),
+    };
+    let text = build_lifecycle_frame_text(FRAME_AGENT_STOP, serde_json::to_value(&payload)?)?;
+    Ok(registry.send_to(&owner, &text) > 0)
+}
+
+pub fn dispatch_agent_restart(
+    store: &Store,
+    registry: &BridgeRegistry,
+    agent_id: &str,
+    decision_resume: Option<DecisionResume>,
+) -> anyhow::Result<bool> {
+    let owner = match resolve_owner(store, agent_id)? {
+        Some(o) => o,
+        None => return Ok(false),
+    };
+    let payload = AgentRestart {
+        agent_id: agent_id.to_string(),
+        decision_resume,
+    };
+    let text = build_lifecycle_frame_text(FRAME_AGENT_RESTART, serde_json::to_value(&payload)?)?;
+    Ok(registry.send_to(&owner, &text) > 0)
+}
+
+fn resolve_owner(store: &Store, agent_id: &str) -> anyhow::Result<Option<String>> {
+    Ok(store.get_agent_by_id(agent_id, false)?.map(|a| a.machine_id))
 }
 
 /// Push a fresh `bridge.target` to every connected bridge, scoped to
@@ -345,13 +502,12 @@ pub fn broadcast_target_update(store: &Store, registry: &BridgeRegistry) {
 }
 
 /// Forward a chat-message stream event to the bridge that owns each
-/// recipient agent. Called wherever a `message.created` `StreamEvent`
-/// is published. Routes by the agent's `machine_id`; platform-local
-/// agents (NULL `machine_id`) are skipped — they're delivered by the
-/// platform's own `AgentManager` in `deliver_message_to_agents`.
-///
-/// The bridge is responsible for matching the inner `agent_id` to its
-/// own running runtime and updating that mailbox.
+/// recipient agent. Called from the event-bus subscriber spawned in
+/// `build_router_with_services_and_auth`, fired on every `message.created`
+/// event. Routes by the agent's `machine_id`; for `chorus serve` that
+/// includes the in-process bridge client (registered under
+/// `local_machine_id`). This is the only agent-delivery path — there
+/// is no platform-local fallback.
 pub fn forward_chat_event_to_bridges(
     store: &Store,
     registry: &BridgeRegistry,
@@ -380,14 +536,15 @@ pub fn forward_chat_event_to_bridges(
         return;
     }
     for agent_id in agent_recipients {
-        // Route only to the bridge that owns this agent. Platform-local
-        // agents (machine_id NULL) are delivered by the platform's own
-        // AgentManager via deliver_message_to_agents — they have no
-        // bridge to push to.
-        let agent_record = store.get_agent_by_id(agent_id, false).ok().flatten();
-        let Some(owner_machine_id) = agent_record.and_then(|a| a.machine_id) else {
+        // Route to the bridge that owns this agent. The bridge that
+        // registered with the matching `machine_id` — possibly the
+        // in-process one inside `chorus serve` — receives the frame.
+        // A missing record (deleted between channel-member lookup and
+        // here) silently skips this recipient.
+        let Some(agent) = store.get_agent_by_id(agent_id, false).ok().flatten() else {
             continue;
         };
+        let owner_machine_id = agent.machine_id;
         let frame = match build_chat_message_frame_text(agent_id, event) {
             Ok(t) => t,
             Err(err) => {

--- a/src/store/agents.rs
+++ b/src/store/agents.rs
@@ -29,11 +29,12 @@ pub struct Agent {
     pub model: String,
     /// Optional Codex reasoning effort override.
     pub reasoning_effort: Option<String>,
-    /// Owner of this agent's runtime. `Some(machine_id)` binds the
-    /// agent to one named bridge; `None` means platform-local — it runs
-    /// in `chorus serve`'s own `AgentManager` and is never sent to any
-    /// bridge. Every agent has exactly one owner.
-    pub machine_id: Option<String>,
+    /// Owner of this agent's runtime. The bridge with this `machine_id`
+    /// runs the agent's process. For `chorus serve` agents created
+    /// without an explicit owner, this is the installation's
+    /// `local_machine_id`; the in-process bridge client picks them up
+    /// because it registers under the same id.
+    pub machine_id: String,
     /// Injected environment variables (ordered by `position`).
     pub env_vars: Vec<AgentEnvVar>,
     /// Row creation time.
@@ -67,9 +68,10 @@ pub struct AgentRecordUpsert<'a> {
     pub model: &'a str,
     /// Optional reasoning effort (Codex).
     pub reasoning_effort: Option<&'a str>,
-    /// Owner of this agent's runtime. `Some(machine_id)` binds it to
-    /// one named bridge; `None` = platform-local.
-    pub machine_id: Option<&'a str>,
+    /// Owner of this agent's runtime. Required — every agent row has
+    /// exactly one owner. For platform-local agents, callers pass
+    /// `state.local_machine_id`.
+    pub machine_id: &'a str,
     /// Full env var list to replace existing rows.
     pub env_vars: &'a [AgentEnvVar],
 }
@@ -189,20 +191,6 @@ impl Store {
         conn.execute("DELETE FROM agents WHERE id = ?1", params![id])?;
         Self::create_agent_record_inner_with_id(&conn, &workspace_id, id, record)?;
         Ok(())
-    }
-
-    /// Set every NULL `machine_id` to `local_machine_id`. Called once at
-    /// startup so rows that pre-date the always-set-machine_id invariant
-    /// get owned by the local installation. Idempotent: rows already
-    /// pinned to a remote bridge keep their value; only NULLs are touched.
-    /// Returns the number of rows updated.
-    pub fn backfill_null_machine_ids(&self, local_machine_id: &str) -> Result<usize> {
-        let conn = self.conn.lock().unwrap();
-        let updated = conn.execute(
-            "UPDATE agents SET machine_id = ?1 WHERE machine_id IS NULL",
-            params![local_machine_id],
-        )?;
-        Ok(updated)
     }
 
     pub fn delete_agent_record(&self, name: &str) -> Result<()> {
@@ -351,7 +339,7 @@ impl Store {
             runtime: row.get(6)?,
             model: row.get(7)?,
             reasoning_effort: row.get(8)?,
-            machine_id: row.get(9)?,
+            machine_id: row.get::<_, String>(9)?,
             env_vars: Vec::new(),
             created_at: parse_datetime(&created_at),
         })

--- a/src/store/decisions.rs
+++ b/src/store/decisions.rs
@@ -48,6 +48,11 @@ pub struct DecisionRow {
     pub picked_key: Option<String>,
     pub picked_note: Option<String>,
     pub resolved_at: Option<String>,
+    /// Null until the agent acks consumption of the resume envelope built
+    /// from this decision (`agent.directive_consumed` over the bridge
+    /// protocol). Reconnect-replay re-emits the envelope as
+    /// `agent.start.init_directive` while this is null.
+    pub delivered_at: Option<String>,
 }
 
 impl Store {
@@ -82,7 +87,7 @@ impl Store {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, workspace_id, channel_id, agent_id, session_id,
-                    created_at, status, payload_json, picked_key, picked_note, resolved_at
+                    created_at, status, payload_json, picked_key, picked_note, resolved_at, delivered_at
              FROM decisions WHERE id = ?1",
         )?;
         let row = stmt.query_row(params![id], row_to_decision).optional()?;
@@ -100,7 +105,7 @@ impl Store {
         let rows: Vec<DecisionRow> = if let Some(s) = status {
             let mut stmt = conn.prepare(
                 "SELECT id, workspace_id, channel_id, agent_id, session_id,
-                        created_at, status, payload_json, picked_key, picked_note, resolved_at
+                        created_at, status, payload_json, picked_key, picked_note, resolved_at, delivered_at
                  FROM decisions WHERE workspace_id = ?1 AND status = ?2
                  ORDER BY created_at DESC",
             )?;
@@ -111,7 +116,7 @@ impl Store {
         } else {
             let mut stmt = conn.prepare(
                 "SELECT id, workspace_id, channel_id, agent_id, session_id,
-                        created_at, status, payload_json, picked_key, picked_note, resolved_at
+                        created_at, status, payload_json, picked_key, picked_note, resolved_at, delivered_at
                  FROM decisions WHERE workspace_id = ?1
                  ORDER BY created_at DESC",
             )?;
@@ -155,11 +160,54 @@ impl Store {
              SET status = 'open',
                  picked_key = NULL,
                  picked_note = NULL,
-                 resolved_at = NULL
+                 resolved_at = NULL,
+                 delivered_at = NULL
              WHERE id = ?1 AND status = 'resolved'",
             params![id],
         )?;
         Ok(())
+    }
+
+    /// The most recent `resolved`-but-not-yet-`delivered_at` decision for
+    /// an agent. Used by reconnect-replay on `bridge.hello`: if the bridge
+    /// was offline when the user resolved a decision, the platform
+    /// rebuilds the envelope from this row and re-emits it as
+    /// `agent.start.init_directive`. Returns `None` once every resolved
+    /// decision for the agent has been delivered.
+    pub fn latest_undelivered_resolved_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<DecisionRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, workspace_id, channel_id, agent_id, session_id,
+                    created_at, status, payload_json, picked_key, picked_note, resolved_at, delivered_at
+             FROM decisions
+             WHERE agent_id = ?1 AND status = 'resolved' AND delivered_at IS NULL
+             ORDER BY resolved_at DESC
+             LIMIT 1",
+        )?;
+        let row = stmt
+            .query_row(params![agent_id], row_to_decision)
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Mark exactly one decision as delivered, by its row id. Called
+    /// when the bridge sends `agent.directive_consumed` echoing the
+    /// `directive_id` it received on the matching `agent.start` /
+    /// `agent.restart`. Idempotent — re-acking an already-delivered row
+    /// touches 0 rows, no error. Returns the number of rows touched
+    /// (0 or 1).
+    pub fn mark_decision_delivered(&self, decision_id: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn.execute(
+            "UPDATE decisions
+             SET delivered_at = datetime('now')
+             WHERE id = ?1 AND status = 'resolved' AND delivered_at IS NULL",
+            params![decision_id],
+        )?;
+        Ok(n)
     }
 }
 
@@ -184,6 +232,7 @@ fn row_to_decision(row: &rusqlite::Row) -> rusqlite::Result<DecisionRow> {
         picked_key: row.get(8)?,
         picked_note: row.get(9)?,
         resolved_at: row.get(10)?,
+        delivered_at: row.get(11)?,
     })
 }
 
@@ -211,8 +260,8 @@ mod tests {
         .unwrap();
         let agent_id = "agent-1".to_string();
         conn.execute(
-            "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-             VALUES (?1, ?2, 'bot', 'Bot', 'claude', 'sonnet')",
+            "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+             VALUES (?1, ?2, 'bot', 'Bot', 'claude', 'sonnet', 'test-machine')",
             params![agent_id, workspace_id],
         )
         .unwrap();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -49,7 +49,11 @@ impl Store {
     pub fn open(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-        Self::validate_supported_identity_schema(&conn)?;
+        // Validate BEFORE init_schema so the validator inspects the
+        // user's actual on-disk shape — not a freshly-minted shape that
+        // `CREATE TABLE IF NOT EXISTS` would write into a half-empty
+        // legacy DB and then trivially pass.
+        Self::validate_schema_shape(&conn, path)?;
         Self::init_schema(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -60,11 +64,11 @@ impl Store {
     /// bridge can write `agent_sessions` rows without a corresponding
     /// `agents` row. The bridge's local DB is a runtime-state cache, not
     /// a normalized model — agent records live in-memory in the
-    /// reconcile loop's `TargetCache`. See #145 for the design.
+    /// reconcile loop's `TargetCache`.
     pub fn open_for_bridge(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
-        Self::validate_supported_identity_schema(&conn)?;
+        Self::validate_schema_shape(&conn, path)?;
         Self::init_schema(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -94,99 +98,65 @@ impl Store {
     }
 
     fn init_schema(conn: &Connection) -> Result<()> {
-        // The schema below uses `CREATE TABLE IF NOT EXISTS` so this is a
-        // no-op on existing DBs; column-shape migrations run after.
         let schema = include_str!("schema.sql");
         conn.execute_batch(schema)?;
-        // Idempotent `machine_id` migration: SQLite has no
-        // `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Attempt the ALTER
-        // and ignore *only* the "duplicate column name" error; surface
-        // anything else (locked DB, syntax errors, real schema drift)
-        // so first-run failures aren't silent.
-        match conn.execute("ALTER TABLE agents ADD COLUMN machine_id TEXT", []) {
-            Ok(_) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(e.into()),
-        }
         Ok(())
     }
 
-    fn validate_supported_identity_schema(conn: &Connection) -> Result<()> {
-        for (table, column) in [
-            ("humans", "display_name"),
-            ("workspaces", "created_by_human"),
-            ("workspace_members", "human_name"),
-            ("channel_members", "member_name"),
-            ("inbox_read_state", "member_name"),
-            ("messages", "sender_name"),
-            ("tasks", "created_by"),
-            ("tasks", "claimed_by"),
-            ("team_members", "member_name"),
-        ] {
-            if Self::schema_column_exists(conn, table, column)? {
-                anyhow::bail!(Self::old_identity_schema_message(table, column));
-            }
+    /// Catch DBs that pre-date the always-set-machine_id invariant. The
+    /// runtime ALTER shims that used to fix these in place were dropped
+    /// once every code path stopped writing NULL — but `CREATE TABLE IF
+    /// NOT EXISTS` is a no-op on existing tables, so opening an old DB
+    /// would otherwise succeed here and surface a cryptic SQLite error
+    /// later when the first INSERT trips `NOT NULL`. Fail loudly with a
+    /// "delete this file" hint instead.
+    ///
+    /// Runs BEFORE `init_schema` so the check inspects the user's
+    /// on-disk shape, not a freshly-minted-by-CREATE-IF-NOT-EXISTS one.
+    /// A completely fresh DB (no tables yet) passes through to
+    /// `init_schema`; only DBs that already have an `agents` table get
+    /// the shape check.
+    fn validate_schema_shape(conn: &Connection, path: &str) -> Result<()> {
+        // No tables yet → fresh install. Skip and let init_schema
+        // create the canonical shape.
+        let table_count: i64 = conn.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table'",
+            [],
+            |row| row.get(0),
+        )?;
+        if table_count == 0 {
+            return Ok(());
         }
 
-        for (table, columns) in [
-            ("humans", &["id", "name"][..]),
-            ("workspaces", &["created_by_human_id"][..]),
-            ("workspace_members", &["human_id"][..]),
-            ("channel_members", &["member_id", "member_type"][..]),
-            ("inbox_read_state", &["member_id", "member_type"][..]),
-            ("messages", &["sender_id", "sender_type"][..]),
-            (
-                "tasks",
-                &[
-                    "created_by_id",
-                    "created_by_type",
-                    "claimed_by_id",
-                    "claimed_by_type",
-                ][..],
+        // Only check `agents.machine_id`: it's the marker column for
+        // every recent schema phase (added in #150, made NOT NULL in
+        // this cleanup). Older shapes are caught by either the column
+        // being absent or by `notnull = 0`.
+        let mut stmt = conn.prepare("PRAGMA table_info(agents)")?;
+        let mut machine_id_notnull: Option<i64> = None;
+        for row in stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(1)?, row.get::<_, i64>(3)?))
+        })? {
+            let (name, notnull) = row?;
+            if name == "machine_id" {
+                machine_id_notnull = Some(notnull);
+                break;
+            }
+        }
+        match machine_id_notnull {
+            None => anyhow::bail!(
+                "incompatible database schema at {path}: \
+                 `agents.machine_id` is missing. Delete this file and \
+                 restart to recreate it from scratch."
             ),
-            ("team_members", &["member_id", "member_type"][..]),
-        ] {
-            if !Self::schema_table_exists(conn, table)? {
-                continue;
-            }
-            for column in columns {
-                if !Self::schema_column_exists(conn, table, column)? {
-                    anyhow::bail!(Self::old_identity_schema_message(table, column));
-                }
-            }
+            Some(0) => anyhow::bail!(
+                "incompatible database schema at {path}: \
+                 `agents.machine_id` is nullable but the current schema \
+                 declares it NOT NULL. Delete this file and restart to \
+                 recreate it from scratch."
+            ),
+            Some(_) => Ok(()),
         }
-
-        Ok(())
-    }
-
-    fn old_identity_schema_message(table: &str, column: &str) -> String {
-        format!(
-            "local database uses an old identity schema ({table}.{column}); run with a fresh data directory or reset local data"
-        )
-    }
-
-    fn schema_table_exists(conn: &Connection, table: &str) -> Result<bool> {
-        Ok(conn
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
-                params![table],
-                |_| Ok(()),
-            )
-            .optional()?
-            .is_some())
-    }
-
-    fn schema_column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
-        if !Self::schema_table_exists(conn, table)? {
-            return Ok(false);
-        }
-        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
-        let exists = stmt
-            .query_map([], |row| row.get::<_, String>(1))?
-            .filter_map(Result::ok)
-            .any(|name| name == column);
-        Ok(exists)
     }
 
     /// Look up the channel_id for a given run_id (from the first message in that run).

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -105,7 +105,7 @@ CREATE TABLE IF NOT EXISTS agents (
     runtime TEXT NOT NULL, -- The runtime driver used (e.g., 'claude', 'codex')
     model TEXT NOT NULL, -- The specific LLM model used
     reasoning_effort TEXT, -- The reasoning effort configuration
-    machine_id TEXT, -- Owner. Some(machine_id) = bound to that bridge; NULL = platform-local. Every agent has one owner.
+    machine_id TEXT NOT NULL, -- Owner. The bridge that runs this agent's runtime; for `chorus serve` agents created without an explicit machine_id, this is the installation's `local_machine_id` from `config.toml`.
     created_at TEXT NOT NULL DEFAULT (datetime('now')) -- When the agent was created
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_workspace_name
@@ -278,7 +278,13 @@ CREATE TABLE IF NOT EXISTS decisions (
     payload_json TEXT NOT NULL,
     picked_key TEXT,
     picked_note TEXT,
-    resolved_at TEXT
+    resolved_at TEXT,
+    -- When the resume envelope built from this decision was confirmed
+    -- consumed by the agent (via `agent.directive_consumed`). Until set,
+    -- the platform re-emits the envelope as `init_directive` on every
+    -- bridge hello, so a `resolved` pick eventually reaches the agent
+    -- even if the bridge was offline at resolve time.
+    delivered_at TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_decisions_workspace_status
     ON decisions(workspace_id, status, created_at DESC);

--- a/src/store/sessions.rs
+++ b/src/store/sessions.rs
@@ -71,8 +71,8 @@ impl Store {
 
     /// Drop every `agent_sessions` row for the given agent. Called from
     /// the bridge's reconcile when an agent leaves the desired set —
-    /// the bridge runs with FK enforcement off so cascade no longer
-    /// fires automatically (#145).
+    /// the bridge runs with FK enforcement off so cascade does not fire
+    /// automatically.
     pub fn delete_sessions_for_agent(&self, agent_id: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -125,8 +125,8 @@ mod tests {
             .lock()
             .unwrap()
             .execute(
-                "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-             VALUES ('a1', ?1, 'a', 'A', 'fake', 'fake')",
+                "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+             VALUES ('a1', ?1, 'a', 'A', 'fake', 'fake', 'test-machine')",
                 params![workspace.id],
             )
             .unwrap();
@@ -215,7 +215,7 @@ mod tests {
     /// The bridge opens its store with `foreign_keys=OFF` so it can
     /// write resume cursors without a corresponding `agents` row. Pin
     /// that contract so a future regression flipping the PRAGMA back
-    /// gets caught here. See #145.
+    /// gets caught here.
     #[test]
     fn bridge_store_writes_session_without_agent_row() {
         let dir = TempDir::new().unwrap();

--- a/src/store/tasks/mod.rs
+++ b/src/store/tasks/mod.rs
@@ -685,7 +685,7 @@ mod sub_channel_tests {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             })
             .unwrap()

--- a/tests/agent_session_persistence_tests.rs
+++ b/tests/agent_session_persistence_tests.rs
@@ -1,5 +1,5 @@
-//! Phase 4 Task 4.1 regression: stopping or sleeping an agent must NOT clear
-//! the persisted `session_id`. Session lifetime is independent of process
+//! Regression: stopping or sleeping an agent must NOT clear the
+//! persisted `session_id`. Session lifetime is independent of process
 //! lifetime — the next `start_agent` must be able to resume the prior
 //! conversation. Clearing the session only happens via the explicit
 //! `reset_session` / `full_reset` restart modes on the agents handler.
@@ -25,12 +25,12 @@ fn seed_agent_with_session(store: &Store, name: &str, session_id: &str) -> Strin
         .create_agent_record(&AgentRecordUpsert {
             name,
             display_name: "Session Persistence Bot",
-            description: Some("Phase 4 session-persistence regression"),
+            description: Some("session-persistence regression"),
             system_prompt: None,
             runtime: "codex",
             model: "gpt-fake",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/agent_status_derivation_tests.rs
+++ b/tests/agent_status_derivation_tests.rs
@@ -10,7 +10,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use chorus::agent::AgentLifecycle;
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{ReceivedMessage, SenderType};
+use chorus::store::messages::SenderType;
 use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
 use harness::build_router_with_lifecycle;
@@ -31,36 +31,6 @@ struct MockLifecycle {
 }
 
 impl AgentLifecycle for MockLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let id = agent.id.clone();
-        Box::pin(async move {
-            self.running.lock().unwrap().insert(id);
-            Ok(())
-        })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async move {
-            self.running.lock().unwrap().remove(agent_id);
-            Ok(())
-        })
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -127,7 +97,7 @@ async fn list_agents_returns_asleep_for_unmanaged_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -173,7 +143,7 @@ async fn list_agents_returns_ready_for_running_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -182,7 +152,7 @@ async fn list_agents_returns_ready_for_running_agent() {
     // Manually insert into the running set (simulates start_agent having been
     // called, and the process reaching the Active/idle state). The handler
     // looks up `process_state` by `agent.id`, so the mock's running set must
-    // be keyed by id to mirror production semantics post-#142.
+    // be keyed by id to mirror production semantics.
     lifecycle.running.lock().unwrap().insert(agent_id);
 
     let resp = app
@@ -225,7 +195,7 @@ async fn get_agent_returns_asleep_for_unmanaged_agent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::ReceivedMessage;
+// removed: ReceivedMessage no longer needed after AgentLifecycle trait shrink
 use chorus::store::Store;
 use harness::join_channel_silent;
 
@@ -28,8 +28,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();
@@ -72,29 +72,6 @@ async fn start_bridge_with_server(
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/bridge_ws_tests.rs
+++ b/tests/bridge_ws_tests.rs
@@ -82,7 +82,7 @@ async fn bridge_ws_hello_returns_target_with_agent_records() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("test-machine-001"),
+            machine_id: "test-machine-001",
             env_vars: &[],
         })
         .unwrap();
@@ -95,7 +95,7 @@ async fn bridge_ws_hello_returns_target_with_agent_records() {
             runtime: "codex",
             model: "gpt-5",
             reasoning_effort: Some("medium"),
-            machine_id: Some("test-machine-001"),
+            machine_id: "test-machine-001",
             env_vars: &[],
         })
         .unwrap();
@@ -672,7 +672,7 @@ async fn bridge_ws_pushes_chat_message_received_when_agent_member_gets_message()
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("chat-machine"),
+            machine_id: "chat-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -743,7 +743,7 @@ async fn bridge_ws_two_machines_chat_isolation() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-a"),
+            machine_id: "machine-a",
             env_vars: &[],
         })
         .unwrap();
@@ -756,7 +756,7 @@ async fn bridge_ws_two_machines_chat_isolation() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-b"),
+            machine_id: "machine-b",
             env_vars: &[],
         })
         .unwrap();
@@ -929,7 +929,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -943,7 +943,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-a"),
+            machine_id: "machine-a",
             env_vars: &[],
         })
         .unwrap();
@@ -957,7 +957,7 @@ async fn bridge_ws_target_scoped_by_agent_machine_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-b"),
+            machine_id: "machine-b",
             env_vars: &[],
         })
         .unwrap();
@@ -1026,7 +1026,7 @@ async fn internal_agent_endpoints_pass_through_when_auth_disabled() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1060,7 +1060,7 @@ async fn internal_agent_endpoints_require_bearer_when_auth_enabled() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-x"),
+            machine_id: "machine-x",
             env_vars: &[],
         })
         .unwrap();
@@ -1129,7 +1129,7 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: Some("machine-y"),
+            machine_id: "machine-y",
             env_vars: &[],
         })
         .unwrap();
@@ -1183,7 +1183,7 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1198,4 +1198,378 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
         403,
         "bridge token must not be allowed to act on platform-local agents"
     );
+}
+
+// ── event-driven lifecycle: agent.start / agent.stop / agent.restart ──
+
+/// Drain frames until one matching `predicate` arrives, or panic on timeout.
+async fn read_until<F>(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    predicate: F,
+    label: &str,
+) -> Value
+where
+    F: Fn(&Value) -> bool,
+{
+    for _ in 0..16 {
+        let frame = match timeout(Duration::from_millis(800), read_json_frame(socket)).await {
+            Ok(f) => f,
+            Err(_) => break,
+        };
+        if predicate(&frame) {
+            return frame;
+        }
+    }
+    panic!("never observed expected frame ({label})");
+}
+
+#[tokio::test]
+async fn http_agent_start_dispatches_bridge_start_frame() {
+    let (ws_url, http_url, store) = start_test_server().await;
+
+    // Seed an agent owned by this bridge's machine_id.
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "lifecycle-bot",
+            display_name: "Lifecycle Bot",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "ev-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "ev-machine").await;
+    let initial = read_json_frame(&mut socket).await;
+    assert_eq!(initial["type"], "bridge.target");
+
+    // POST /api/agents/{id}/start → platform must push a `agent.start`.
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http_url}/api/agents/{agent_id}/start"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let frame = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.start",
+        "agent.start after /start",
+    )
+    .await;
+    assert_eq!(frame["data"]["agent_id"], agent_id);
+    assert!(
+        frame["data"]["decision_resume"].is_null(),
+        "manual start must not carry a directive"
+    );
+}
+
+#[tokio::test]
+async fn http_agent_stop_dispatches_bridge_stop_frame() {
+    let (ws_url, http_url, store) = start_test_server().await;
+
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "stoppable-bot",
+            display_name: "Stoppable Bot",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "ev-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "ev-machine").await;
+    let _ = read_json_frame(&mut socket).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http_url}/api/agents/{agent_id}/stop"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let frame = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.stop",
+        "agent.stop after /stop",
+    )
+    .await;
+    assert_eq!(frame["data"]["agent_id"], agent_id);
+}
+
+#[tokio::test]
+async fn http_agent_restart_dispatches_bridge_restart_frame() {
+    let (ws_url, http_url, store) = start_test_server().await;
+
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "restartable-bot",
+            display_name: "Restartable Bot",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "ev-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "ev-machine").await;
+    let _ = read_json_frame(&mut socket).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http_url}/api/agents/{agent_id}/restart"))
+        .json(&json!({"mode": "restart"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let frame = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.restart",
+        "agent.restart after /restart",
+    )
+    .await;
+    assert_eq!(frame["data"]["agent_id"], agent_id);
+    assert!(
+        frame["data"]["decision_resume"].is_null(),
+        "manual restart must not carry a directive"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_replay_emits_bridge_start_for_agent_with_unread() {
+    // Agent has unread messages when the bridge connects → platform
+    // must follow `bridge.target` with a `agent.start` for that agent.
+    let (ws_url, store, event_bus, alice_id) = start_test_server_with_event_bus_handle().await;
+
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "wakeable-bot",
+            display_name: "Wakeable",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "wake-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+    harness::join_channel_silent(&store, "general", &agent_id, "agent");
+
+    // Land an unread message before the bridge connects.
+    let (_msg_id, _ev) = store
+        .create_message(chorus::store::messages::CreateMessage {
+            channel_name: "general",
+            sender_id: &alice_id,
+            sender_type: chorus::store::messages::SenderType::Human,
+            content: "wake up please",
+            attachment_ids: &[],
+            suppress_event: false,
+            run_id: None,
+        })
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "wake-machine").await;
+    let _ = read_json_frame(&mut socket).await;
+    let frame = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.start" && f["data"]["agent_id"] == json!(agent_id),
+        "reconnect-replay agent.start",
+    )
+    .await;
+    assert_eq!(frame["data"]["agent_id"], agent_id);
+    let _ = event_bus;
+}
+
+#[tokio::test]
+async fn decision_resolve_dispatches_bridge_restart_with_directive() {
+    let (ws_url, http_url, store) = start_test_server().await;
+
+    // Seed agent + active session row so the decision handler can locate it.
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "decider-bot",
+            display_name: "Decider",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "dec-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    // Create the decision directly so we don't need a live agent run.
+    let payload = json!({
+        "headline": "Ship this PR?",
+        "question": "Merge or revert?",
+        "options": [
+            {"key": "A", "label": "Merge", "body": "Merge it now."},
+            {"key": "B", "label": "Revert", "body": "Revert and add tests."},
+        ],
+    });
+    let channel_id = store
+        .create_channel("decisions-room", None, ChannelType::Channel, None)
+        .unwrap();
+    let decision_id = "dec-1".to_string();
+    store
+        .create_decision(
+            &decision_id,
+            &workspace_id,
+            &channel_id,
+            &agent_id,
+            "session-1",
+            &payload.to_string(),
+        )
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "dec-machine").await;
+    let _ = read_json_frame(&mut socket).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http_url}/api/decisions/{decision_id}/resolve"))
+        .json(&json!({"picked_key": "B", "note": "needs tests"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let frame = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.restart",
+        "agent.restart from decision resolve",
+    )
+    .await;
+    assert_eq!(frame["data"]["agent_id"], agent_id);
+    assert_eq!(
+        frame["data"]["decision_resume"]["decision_id"], decision_id,
+        "decision_id must be on the wire so the ack maps back to this row"
+    );
+    let prompt = frame["data"]["decision_resume"]["prompt"]
+        .as_str()
+        .expect("prompt must be present on a decision-driven restart");
+    assert!(prompt.contains("Ship this PR?"));
+    assert!(prompt.contains("Picked option (B): Revert"));
+    assert!(prompt.contains("needs tests"));
+}
+
+#[tokio::test]
+async fn agent_directive_consumed_marks_decision_delivered() {
+    let (ws_url, http_url, store) = start_test_server().await;
+
+    let agent_id = store
+        .create_agent_record(&AgentRecordUpsert {
+            name: "ack-bot",
+            display_name: "Ack Bot",
+            description: None,
+            system_prompt: None,
+            runtime: "claude",
+            model: "sonnet",
+            reasoning_effort: None,
+            machine_id: "ack-machine",
+            env_vars: &[],
+        })
+        .unwrap();
+    let workspace_id = store.get_active_workspace().unwrap().unwrap().id;
+    let channel_id = store
+        .create_channel("ack-room", None, ChannelType::Channel, None)
+        .unwrap();
+    let decision_id = "dec-ack".to_string();
+    let payload = json!({
+        "headline": "h",
+        "question": "q",
+        "options": [
+            {"key": "A", "label": "L", "body": "B"},
+        ],
+    });
+    store
+        .create_decision(
+            &decision_id,
+            &workspace_id,
+            &channel_id,
+            &agent_id,
+            "session-1",
+            &payload.to_string(),
+        )
+        .unwrap();
+
+    let (mut socket, _) = connect_async(format!("{ws_url}/api/bridge/ws"))
+        .await
+        .unwrap();
+    send_hello(&mut socket, "ack-machine").await;
+    let _ = read_json_frame(&mut socket).await;
+
+    // Resolve so the row is `resolved` + `delivered_at IS NULL`.
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{http_url}/api/decisions/{decision_id}/resolve"))
+        .json(&json!({"picked_key": "A"}))
+        .send()
+        .await
+        .unwrap();
+    let _ = read_until(
+        &mut socket,
+        |f| f["type"] == "agent.restart",
+        "agent.restart pre-ack",
+    )
+    .await;
+    let pre = store.get_decision(&decision_id).unwrap().unwrap();
+    assert!(pre.delivered_at.is_none());
+
+    // Bridge sends `agent.decision_delivered` upstream → row gets marked.
+    // The ack carries the `decision_id` from the original frame so the
+    // platform marks exactly that row (not "all undelivered for agent",
+    // which races with rapid re-resolves).
+    let ack = json!({
+        "v": 1,
+        "type": "agent.decision_delivered",
+        "data": {"agent_id": agent_id, "decision_id": decision_id},
+    });
+    socket
+        .send(Message::Text(ack.to_string().into()))
+        .await
+        .unwrap();
+
+    // Wait for the platform to process (the inbound handler is async).
+    for _ in 0..20 {
+        let row = store.get_decision(&decision_id).unwrap().unwrap();
+        if row.delivered_at.is_some() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("delivered_at was never set after agent.decision_delivered");
 }

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -62,8 +62,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -12,37 +12,12 @@ use chorus::agent::AgentLifecycle;
 use chorus::server::bridge_auth::BridgeAuth;
 use chorus::server::event_bus::EventBus;
 use chorus::server::{build_router_with_services, build_router_with_services_and_auth};
-use chorus::store::agents::Agent;
-use chorus::store::messages::ReceivedMessage;
 use chorus::store::Store;
 use rusqlite::params;
 
 pub struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -89,7 +89,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::ReceivedMessage;
+// removed: ReceivedMessage no longer needed after AgentLifecycle trait shrink
 use chorus::store::{AgentRecordUpsert, Store};
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
@@ -105,29 +105,6 @@ use tokio::time::timeout;
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,
@@ -254,7 +231,7 @@ fn seed_agent(
         runtime,
         model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(store, "general", agent_key, "agent");

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -1,6 +1,6 @@
 //! Live runtime integration tests for the shared MCP bridge.
 //!
-//! These tests exercise the full Phase 1+2 stack end-to-end against a **real**
+//! These tests exercise the full stack end-to-end against a **real**
 //! runtime binary (not a mock or in-process MCP client). They prove that:
 //!
 //!   1. A driver, given `AgentSpec.bridge_endpoint = Some(url)`, pairs with
@@ -82,7 +82,7 @@ use chorus::agent::AgentLifecycle;
 use chorus::bridge::serve::build_bridge_router;
 
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
+use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::{AgentRecordUpsert, Store};
 
 // ---------------------------------------------------------------------------
@@ -95,29 +95,6 @@ use chorus::store::{AgentRecordUpsert, Store};
 struct NoopLifecycle;
 
 impl AgentLifecycle for NoopLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn get_activity_log_data(
         &self,
         _agent_name: &str,
@@ -474,7 +451,7 @@ async fn opencode_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "opencode",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -612,7 +589,7 @@ async fn claude_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "claude",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -749,7 +726,7 @@ async fn codex_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "codex",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -887,7 +864,7 @@ async fn gemini_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "gemini",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");
@@ -1011,7 +988,7 @@ async fn kimi_agent_replies_through_shared_bridge() -> anyhow::Result<()> {
         runtime: "kimi",
         model: &model,
         reasoning_effort: None,
-        machine_id: None,
+        machine_id: "test-machine",
         env_vars: &[],
     })?;
     join_channel_silent(&store, "general", &agent_id, "agent");

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -12,7 +12,7 @@ use chorus::server::dto::ChannelInfo;
 use chorus::server::dto::ServerInfo;
 use chorus::server::{AgentDetailResponse, HistoryResponse};
 use chorus::store::channels::ChannelType;
-use chorus::store::messages::{CreateMessage, ReceivedMessage, SenderType};
+use chorus::store::messages::{CreateMessage, SenderType};
 use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
 use harness::{build_router, build_router_with_lifecycle, join_channel_silent};
@@ -82,8 +82,8 @@ fn seed_agent_with_id(
         .id;
     let conn = store.conn_for_test();
     conn.execute(
-        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model)
-         VALUES (?1, ?2, ?1, ?3, ?4, ?5)",
+        "INSERT INTO agents (id, workspace_id, name, display_name, runtime, model, machine_id)
+         VALUES (?1, ?2, ?1, ?3, ?4, ?5, 'test-machine')",
         rusqlite::params![id, workspace_id, display_name, runtime, model],
     )
     .unwrap();
@@ -105,33 +105,23 @@ fn setup_with_data_dir() -> (Arc<Store>, axum::Router, tempfile::TempDir) {
 
 /// One observed `start_agent` invocation: `(agent_name, wake_message, init_directive)`.
 /// Tests assert against the recorded sequence to pin call-site behavior.
-type StartedCall = (String, Option<ReceivedMessage>, Option<String>);
-
 #[derive(Default)]
 struct MockLifecycle {
-    started: Mutex<Vec<StartedCall>>,
-    stopped: Mutex<Vec<String>>,
-    notified: Mutex<Vec<String>>,
     activity_logs: ActivityLogMap,
-    /// Tracks which agents are currently "running" so that process_state,
-    /// start_agent, and stop_agent share one source of truth. Keyed by
-    /// agent name internally so existing tests can use `mark_running(name)`
-    /// without knowing the agent's id; trait calls that arrive by id are
-    /// translated through `store` below before lookup.
+    /// Tracks which agents are currently "running" so that
+    /// `process_state` returns Active for them. Tests use
+    /// `mark_running(name)` to simulate a live runtime without
+    /// spinning up a real `AgentManager`. Keyed by agent name; trait
+    /// calls that arrive by id are translated through `store` below
+    /// before lookup.
     running: Mutex<HashSet<String>>,
-    /// Records every (agent_name, envelope) pair delivered via
-    /// `resume_with_prompt`. Decision-inbox round-trip tests assert the
-    /// envelope reached the agent.
-    resumed_with: Mutex<Vec<(String, String)>>,
     /// Per-agent channel id returned by `run_channel_id`. Tests preset
     /// this to simulate the trace_store's "current channel for current
     /// run" record without spinning a real AgentManager.
     run_channels: Mutex<std::collections::HashMap<String, String>>,
-    /// Optional store reference used to translate `agent_id` (the new
-    /// keying after #142) back into `agent_name` so internal recording
-    /// stays name-keyed for assertion compatibility. Wire this via
-    /// `set_store` in setup helpers; trait methods fall through to
-    /// raw-string semantics when absent.
+    /// Optional store reference used to translate `agent_id` back into
+    /// `agent_name` so internal recording stays name-keyed for assertion
+    /// compatibility. Wire this via `set_store` in setup helpers.
     store: Mutex<Option<Arc<Store>>>,
 }
 
@@ -160,9 +150,9 @@ impl RuntimeStatusProvider for MockRuntimeStatusProvider {
 }
 
 impl MockLifecycle {
-    /// Wire a store so trait methods receiving `agent_id` (post-#142) can
-    /// resolve to `agent_name` for internal recording. Tests that don't
-    /// call this still work for paths that pass names (e.g. `start_agent`).
+    /// Wire a store so trait methods receiving `agent_id` can resolve
+    /// to `agent_name` for internal recording. Tests that don't call
+    /// this still work for paths that pass names (e.g. `start_agent`).
     fn set_store(&self, store: Arc<Store>) {
         *self.store.lock().unwrap() = Some(store);
     }
@@ -178,27 +168,6 @@ impl MockLifecycle {
             }
         }
         key.to_string()
-    }
-
-    fn started_names(&self) -> Vec<String> {
-        self.started
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(name, _, _)| name.clone())
-            .collect()
-    }
-
-    fn notified_names(&self) -> Vec<String> {
-        self.notified.lock().unwrap().clone()
-    }
-
-    fn started_calls(&self) -> Vec<StartedCall> {
-        self.started.lock().unwrap().clone()
-    }
-
-    fn stopped_names(&self) -> Vec<String> {
-        self.stopped.lock().unwrap().clone()
     }
 
     /// Simulate an already-running managed process. Subsequent
@@ -217,53 +186,9 @@ impl MockLifecycle {
             .unwrap()
             .insert(agent_name.to_string(), channel_id.to_string());
     }
-
-    fn resumed_calls(&self) -> Vec<(String, String)> {
-        self.resumed_with.lock().unwrap().clone()
-    }
 }
 
 impl AgentLifecycle for MockLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        agent: &'a chorus::store::agents::Agent,
-        wake_message: Option<ReceivedMessage>,
-        init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = agent.name.clone();
-        Box::pin(async move {
-            self.started
-                .lock()
-                .unwrap()
-                .push((name.clone(), wake_message, init_directive));
-            self.running.lock().unwrap().insert(name);
-            Ok(())
-        })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.notified.lock().unwrap().push(name);
-            Ok(())
-        })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        agent_id: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.stopped.lock().unwrap().push(name.clone());
-            self.running.lock().unwrap().remove(&name);
-            Ok(())
-        })
-    }
-
     fn process_state<'a>(
         &'a self,
         agent_id: &'a str,
@@ -301,44 +226,9 @@ impl AgentLifecycle for MockLifecycle {
         let id = self.run_channels.lock().unwrap().get(agent_name).cloned();
         Box::pin(async move { id })
     }
-
-    fn resume_with_prompt<'a>(
-        &'a self,
-        agent_id: &'a str,
-        envelope: String,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let name = self.resolve_to_name(agent_id);
-        Box::pin(async move {
-            self.resumed_with.lock().unwrap().push((name, envelope));
-            Ok(())
-        })
-    }
 }
 
 impl AgentLifecycle for FailStartLifecycle {
-    fn start_agent<'a>(
-        &'a self,
-        _agent: &'a chorus::store::agents::Agent,
-        _wake_message: Option<ReceivedMessage>,
-        _init_directive: Option<String>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Err(anyhow::anyhow!("runtime unavailable")) })
-    }
-
-    fn notify_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
-    fn stop_agent<'a>(
-        &'a self,
-        _agent_name: &'a str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
-    }
-
     fn process_state<'a>(
         &'a self,
         _agent_name: &'a str,
@@ -465,7 +355,7 @@ async fn test_internal_agent_name_send_uses_canonical_agent_id() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -558,63 +448,18 @@ async fn test_receive_timeout_is_interpreted_in_milliseconds() {
     );
 }
 
-#[tokio::test]
-async fn test_send_starts_sleeping_agent_with_wake_message() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-
-    let send_req = serde_json::json!({ "target": "#general", "content": "wake up from sleep" });
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let started = lifecycle.started_calls();
-    assert_eq!(started.len(), 1);
-    assert_eq!(started[0].0, "bot1");
-    let wake_message = started[0]
-        .1
-        .as_ref()
-        .expect("sleeping agent restart should include wake message");
-    assert_eq!(wake_message.content, "wake up from sleep");
-    assert_eq!(wake_message.sender_name, "alice");
-    assert_eq!(wake_message.channel_name, "general");
-    assert_eq!(wake_message.channel_type, "channel");
-    assert!(lifecycle.notified_names().is_empty());
-}
-
-#[tokio::test]
-async fn test_send_notifies_active_agent_without_restart() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    lifecycle.mark_running("bot1");
-
-    let send_req = serde_json::json!({ "target": "#general", "content": "stay online" });
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    assert!(lifecycle.started_names().is_empty());
-    assert_eq!(lifecycle.notified_names(), vec!["bot1".to_string()]);
-}
+// `test_send_starts_sleeping_agent_with_wake_message`,
+// `test_send_notifies_active_agent_without_restart`, the DM equivalents,
+// the cross-channel send variants, and `delivery_starts_agent_when_no_process_managed_*`
+// were unit tests that observed `MockLifecycle.started_names()` /
+// `notified_names()` to verify the platform-driven wake path. The
+// platform no longer calls `lifecycle.start_agent` / `lifecycle.notify_agent`;
+// the bridge client receiving `chat.message.received` does. Coverage moves to:
+//   - the Playwright LLM-gated MSG suite (MSG-001 / MSG-002 / MSG-004 /
+//     MSG-006), which exercises real round-trips via the in-process
+//     bridge client; and
+//   - bridge-layer tests that verify `forward_chat_event_to_bridges`
+//     emits the right frames (existing in `bridge_ws` integration coverage).
 
 #[tokio::test]
 async fn test_server_info() {
@@ -921,7 +766,7 @@ async fn test_public_dm_route_accepts_agent_id_and_stores_canonical_member_id() 
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1103,7 +948,7 @@ async fn test_channel_members_api_lists_members_and_supports_invite() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1212,7 +1057,7 @@ async fn test_all_channel_member_count_matches_agents_plus_humans() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1257,7 +1102,7 @@ async fn test_history_rejects_non_member_agent() {
             runtime: "codex",
             model: "gpt-5.4",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1531,73 +1376,12 @@ async fn test_list_runtime_models() {
     assert_eq!(payload, serde_json::json!(["openai/gpt-5.4"]));
 }
 
-#[tokio::test]
-async fn test_create_agent_via_api_keeps_inactive_record_when_start_fails() {
-    let store = Arc::new(Store::open(":memory:").unwrap());
-    seed_default_workspace(&store);
-    let app = build_router_with_lifecycle(store.clone(), Arc::new(FailStartLifecycle));
-
-    let req = serde_json::json!({
-        "name": "stuck-bot",
-        "runtime": "claude",
-        "model": "sonnet"
-    });
-    let resp = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/agents")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    // Start failure is now an explicit error, not a 200 with a warning.
-    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-
-    let payload = body_json(resp).await;
-    assert_eq!(payload["code"].as_str(), Some("AGENT_START_FAILED"));
-
-    // The agent record must still be persisted (inactive) so operators can inspect it.
-    let agents = store.get_agents().unwrap();
-    let agent = agents
-        .iter()
-        .find(|a| a.name.starts_with("stuck-bot-"))
-        .expect("agent should remain in the store after failed start");
-    assert!(store.is_member("all", &agent.id).unwrap());
-
-    // After a failed start the manager has no live process, so the derived
-    // status surfaced through the API must be `asleep`. Regression guard:
-    // before status was derived from ProcessState the persisted column
-    // carried this claim; that column is gone, so verify through the API.
-    let list_resp = app
-        .oneshot(
-            Request::builder()
-                .uri("/api/agents")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(list_resp.status(), StatusCode::OK);
-    let listed: Vec<serde_json::Value> = serde_json::from_slice(
-        &axum::body::to_bytes(list_resp.into_body(), 1_000_000)
-            .await
-            .unwrap(),
-    )
-    .unwrap();
-    let entry = listed
-        .iter()
-        .find(|a| a["name"] == agent.name.as_str())
-        .expect("failed-start agent must still appear in /api/agents");
-    assert_eq!(
-        entry["status"], "asleep",
-        "failed-start agent must derive to `asleep`, got `{}`",
-        entry["status"]
-    );
-}
+// `test_create_agent_via_api_keeps_inactive_record_when_start_fails`
+// no longer applies: the platform doesn't start the agent at create
+// time. The bridge client does, and start failures surface
+// asynchronously via the realtime stream's `agent.state` events. The
+// "row is persisted even if start fails" guarantee is trivial — the
+// row is persisted regardless because no synchronous start happens.
 
 #[tokio::test]
 async fn test_create_kimi_agent_via_api() {
@@ -1638,11 +1422,19 @@ async fn test_create_kimi_agent_via_api() {
     );
     let agent = store.get_agent(&name).unwrap().expect("agent should exist");
     assert_eq!(payload["id"], agent.id);
-    assert_eq!(payload["status"], "ready");
+    // The platform doesn't start the agent on create — the bridge
+    // client does, asynchronously. So a freshly-created agent surfaces
+    // as `asleep` until the bridge's `agent.state{started}` frame
+    // arrives via the realtime stream.
+    assert_eq!(payload["status"], "asleep");
     assert_eq!(agent.runtime, "kimi");
     assert_eq!(agent.model, "kimi-code/kimi-for-coding");
     assert_eq!(agent.reasoning_effort, None);
-    assert_eq!(lifecycle.started_names(), vec![name]);
+    // The platform no longer calls `lifecycle.start_agent` at create
+    // time — coverage of that invariant moved to the trait shape itself
+    // (the trait is now observability-only; there's no `start_agent`
+    // method to call).
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -1702,8 +1494,11 @@ async fn test_get_and_update_agent_via_api() {
     assert_eq!(agent.reasoning_effort.as_deref(), Some("low"));
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // Spec changes dispatch a `agent.restart` via the registry. With
+    // no bridge connected in this test, dispatch returns Ok(false) and
+    // the API still 200s. The bridge-protocol coverage for restart
+    // delivery lives in bridge_serve_tests.
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -1721,7 +1516,7 @@ async fn test_update_agent_to_kimi_clears_reasoning_effort() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("high"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1756,8 +1551,9 @@ async fn test_update_agent_to_kimi_clears_reasoning_effort() {
     assert_eq!(agent.reasoning_effort, None);
     assert_eq!(agent.env_vars.len(), 1);
     assert_eq!(agent.env_vars[0].key, "DEBUG");
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // Runtime change dispatches a `agent.restart`; bridge-protocol
+    // coverage for delivery lives in bridge_serve_tests.
+    let _ = lifecycle;
 }
 
 /// Regression: a config-edit PATCH must not trigger a restart when the
@@ -1795,14 +1591,10 @@ async fn config_edit_does_not_restart_when_no_process_managed_despite_db_active(
         body["restarted"], false,
         "config-edit must not restart when manager has no process, regardless of DB status"
     );
-    assert!(
-        lifecycle.stopped_names().is_empty(),
-        "no managed process means nothing to stop"
-    );
-    assert!(
-        lifecycle.started_names().is_empty(),
-        "no managed process means nothing to restart"
-    );
+    // The platform never calls `lifecycle.start_agent` / `stop_agent`
+    // anymore; the bridge owns that path. We assert through the
+    // response payload instead — `restarted: false` is the contract.
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -1906,42 +1698,10 @@ async fn test_delete_agent_marks_history_and_preserves_workspace() {
     assert_eq!(json["messages"][0]["senderDeleted"], true);
 }
 
-#[tokio::test]
-async fn test_send_starts_inactive_agent_recipients() {
-    let (store, app, lifecycle) = setup_with_lifecycle();
-    let bot2_id = store
-        .create_agent_record(&AgentRecordUpsert {
-            name: "bot2",
-            display_name: "Bot 2",
-            description: None,
-            system_prompt: None,
-            runtime: "codex",
-            model: "gpt-5.4",
-            reasoning_effort: None,
-            machine_id: None,
-            env_vars: &[],
-        })
-        .unwrap();
-    join_channel_silent(&store, "general", &bot2_id, "agent");
-
-    let send_req = serde_json::json!({ "target": "#general", "content": "wake bot2" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let mut started = lifecycle.started_names();
-    started.sort();
-    assert_eq!(started, vec!["bot1".to_string(), "bot2".to_string()]);
-    assert!(lifecycle.notified_names().is_empty());
-}
+// `test_send_starts_inactive_agent_recipients` was deleted alongside the
+// other handler-driven wake assertions; the bridge protocol is the new
+// owner of that path. See the deletion note above
+// `test_send_starts_sleeping_agent_with_wake_message`.
 
 #[tokio::test]
 async fn test_send_persists_message_even_if_agent_delivery_fails() {
@@ -1973,115 +1733,16 @@ async fn test_send_persists_message_even_if_agent_delivery_fails() {
         .any(|message| message.content == "persist despite delivery failure"));
 }
 
-#[tokio::test]
-async fn test_dm_send_starts_inactive_agent() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
+// `test_dm_send_starts_inactive_agent` deleted with the other
+// handler-driven wake assertions; see the note above
+// `test_send_starts_sleeping_agent_with_wake_message`.
 
-    let send_req = serde_json::json!({ "target": "dm:@bot1", "content": "hey bot1 via dm" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(
-        lifecycle.started_names(),
-        vec!["bot1".to_string()],
-        "DM to inactive agent must trigger start_agent"
-    );
-    assert!(lifecycle.notified_names().is_empty());
-}
-
-#[tokio::test]
-async fn test_dm_send_notifies_active_agent() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    // Runtime liveness is the manager HashMap, not the DB column:
-    // mark the agent as having a live managed process.
-    lifecycle.mark_running("bot1");
-
-    let send_req = serde_json::json!({ "target": "dm:@bot1", "content": "hey active bot1 via dm" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert!(lifecycle.started_names().is_empty());
-    assert_eq!(
-        lifecycle.notified_names(),
-        vec!["bot1".to_string()],
-        "DM to active agent must trigger notify_agent"
-    );
-}
-
-/// Regression: persisted `AgentStatus::Active` does not mean the
-/// runtime has a managed process. Delivery must route on the
-/// manager HashMap (`process_state`), not the DB column, so an
-/// agent whose row says Active but whose process is absent still
-/// gets woken via `start_agent`.
-#[tokio::test]
-async fn delivery_starts_agent_when_no_process_managed_even_if_db_says_active() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    // Deliberately DO NOT call lifecycle.mark_running("bot1").
-
-    let send_req = serde_json::json!({ "target": "dm:@bot1", "content": "wake up despite drift" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(
-        lifecycle.started_names(),
-        vec!["bot1".to_string()],
-        "delivery must route on process_state, not the persisted AgentStatus column",
-    );
-    assert!(
-        lifecycle.notified_names().is_empty(),
-        "no live process means notify_agent must not be called",
-    );
-}
-
-#[tokio::test]
-async fn test_send_notifies_active_agents() {
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    lifecycle.mark_running("bot1");
-
-    let send_req = serde_json::json!({ "target": "#general", "content": "ping active bot" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/internal/agent/alice/send")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&send_req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert!(lifecycle.started_names().is_empty());
-    assert_eq!(lifecycle.notified_names(), vec!["bot1".to_string()]);
-}
+// `test_dm_send_notifies_active_agent`,
+// `delivery_starts_agent_when_no_process_managed_even_if_db_says_active`,
+// and `test_send_notifies_active_agents` are gone — they verified
+// handler-driven wake behavior that no longer exists at this layer.
+// The Playwright LLM-gated MSG suite covers the bridge-driven path
+// end-to-end.
 
 #[tokio::test]
 async fn test_history() {
@@ -2316,8 +1977,7 @@ async fn test_send_can_skip_agent_delivery() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert!(lifecycle.started_names().is_empty());
-    assert!(lifecycle.notified_names().is_empty());
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2380,8 +2040,11 @@ async fn test_create_team_endpoint() {
     let channel_members = store.get_channel_members(&ch.id).unwrap();
     assert!(channel_members.iter().any(|m| m.member_id == current_user));
 
-    assert_eq!(lifecycle.stopped_names(), vec!["bot1".to_string()]);
-    assert_eq!(lifecycle.started_names(), vec!["bot1".to_string()]);
+    // Team membership changes dispatch a `agent.restart` for affected
+    // agents so the bridge re-launches them with the new system prompt.
+    // Bridge-protocol coverage for delivery lives in bridge_serve_tests.
+    let _ = store.get_agent("bot1").unwrap().unwrap();
+    let _ = lifecycle;
 
     let workspace_id = &team.workspace_id;
     let team_dir_name = format!("{}-{}", team.name, team.id);
@@ -2474,7 +2137,7 @@ async fn test_list_and_update_team_endpoints() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2599,8 +2262,11 @@ async fn test_list_and_update_team_endpoints() {
     assert_eq!(updated_team.display_name, "Applied Science Platform");
     assert_eq!(bot1_member.role, "leader");
     assert_eq!(bot2_member.role, "operator");
-    assert_eq!(lifecycle.started_names().len(), 2);
-    assert_eq!(lifecycle.stopped_names().len(), 2);
+    // Team update dispatches `agent.restart` for affected agents;
+    // bridge-protocol coverage for delivery lives in bridge_serve_tests.
+    let _ = store.get_agent("bot1").unwrap().unwrap();
+    let _ = store.get_agent("bot2").unwrap().unwrap();
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2739,8 +2405,11 @@ async fn test_add_remove_and_delete_team_endpoints() {
         .join(&workspace_id)
         .join(&team_dir_name)
         .exists());
-    assert_eq!(lifecycle.started_names().len(), 2);
-    assert_eq!(lifecycle.stopped_names().len(), 2);
+    // Membership add/remove and team delete all dispatch a
+    // `agent.restart` for affected agents; bridge-protocol coverage
+    // for delivery lives in bridge_serve_tests.
+    let _ = store.get_agent("bot1").unwrap().unwrap();
+    let _ = lifecycle;
 }
 
 #[tokio::test]
@@ -2755,7 +2424,7 @@ async fn test_at_mention_forwards_to_team_channel() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2804,21 +2473,12 @@ async fn test_at_mention_forwards_to_team_channel() {
     assert_eq!(provenance.channel_name, "general");
     assert_eq!(provenance.sender_name, "alice");
 
-    let notified = lifecycle.notified_names();
-    assert_eq!(
-        notified
-            .iter()
-            .filter(|name| name.as_str() == "bot1")
-            .count(),
-        2
-    );
-    assert_eq!(
-        notified
-            .iter()
-            .filter(|name| name.as_str() == "bot2")
-            .count(),
-        1
-    );
+    // Notification fan-out lives on the bridge; the platform no longer
+    // calls `lifecycle.notify_agent` directly. The team-mention
+    // forwarding (which is what this test is really pinning) still
+    // lives on the platform — verified above by the channel +
+    // provenance assertions.
+    let _ = lifecycle;
 }
 
 // ── Template API tests ──
@@ -3010,7 +2670,7 @@ async fn test_active_workspace_filters_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -3026,7 +2686,7 @@ async fn test_active_workspace_filters_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -3430,7 +3090,7 @@ async fn test_non_member_history_returns_message_not_a_member() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -3450,29 +3110,11 @@ async fn test_non_member_history_returns_message_not_a_member() {
     assert_eq!(body["code"], "MESSAGE_NOT_A_MEMBER");
 }
 
-#[tokio::test]
-async fn test_restart_agent_start_fails_returns_agent_restart_failed() {
-    let store = Arc::new(Store::open(":memory:").unwrap());
-    seed_default_workspace(&store);
-    let req = serde_json::json!({ "mode": "restart" });
-    let bot1 = store.get_agent("bot1").unwrap().unwrap();
-    let app = build_router_with_lifecycle(store, Arc::new(FailStartLifecycle));
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri(format!("/api/agents/{}/restart", bot1.id))
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    let body = body_json(resp).await;
-    assert_eq!(body["code"], "AGENT_RESTART_FAILED");
-}
+// `test_restart_agent_start_fails_returns_agent_restart_failed` no
+// longer applies. The platform dispatches an `agent.restart` RPC and
+// returns 200 synchronously; restart failures surface asynchronously
+// via the realtime `agent.state` stream. Coverage of the dispatch path
+// lives in `bridge_ws_tests`.
 
 #[tokio::test]
 async fn create_channel_rejects_invalid_names() {
@@ -3632,59 +3274,28 @@ async fn public_send_allows_empty_content_with_attachments() {
 // other start paths (manual restart, message wake) do not.
 // ─────────────────────────────────────────────────────────────────────
 
+// `test_create_agent_passes_intro_directive_referencing_system_channel`
+// is gone. The intro-directive path depended on `create_and_start_agent`
+// calling `lifecycle.start_agent(_, _, Some(directive))` directly. The
+// platform doesn't start the agent at create time at all anymore.
+// Restoring auto-intro would require a one-shot directive carried via
+// the bridge protocol on first start.
+
+// The platform no longer calls `lifecycle.start_agent` on restart. The
+// handler dispatches an `agent.restart` over the registry. With no
+// bridge connected in this test, dispatch returns Ok(false) and the
+// API still 200s. Bridge-protocol coverage for delivery lives in
+// bridge_ws_tests.
 #[tokio::test]
-async fn test_create_agent_passes_intro_directive_referencing_system_channel() {
-    let (store, app, lifecycle) = setup_with_lifecycle();
-    store.ensure_builtin_channels("alice").unwrap();
-
-    let req = serde_json::json!({ "name": "newbot", "runtime": "claude", "model": "sonnet" });
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/agents")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&req).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let started = lifecycle.started_calls();
-    assert_eq!(started.len(), 1, "create-agent should fire one start");
-    let directive = started[0]
-        .2
-        .as_ref()
-        .expect("create-agent must pass an init directive");
-    let expected_channel = Store::DEFAULT_SYSTEM_CHANNEL;
-    assert!(
-        directive.contains(expected_channel),
-        "directive should reference #{expected_channel}: {directive:?}"
-    );
-    assert!(
-        directive.contains("introduc"),
-        "directive should mention introducing: {directive:?}"
-    );
-    // Tool name is intentionally NOT asserted: runtimes can prefix tools
-    // (e.g. mcp__chat__send_message), and the agent's standing system
-    // prompt already names the tool. Hardcoding it here would be brittle.
-    // wake_message stays None for a fresh creation — the directive is
-    // the only first-prompt source.
-    assert!(started[0].1.is_none());
-}
-
-#[tokio::test]
-async fn test_manual_restart_does_not_fire_intro_directive() {
-    // setup_with_lifecycle() already seeds bot1 in the default workspace.
-    let (_store, app, lifecycle) = setup_with_lifecycle();
-    lifecycle.mark_running("bot1");
+async fn test_manual_restart_dispatches_bridge_restart() {
+    let (store, app, _lifecycle) = setup_with_lifecycle();
+    let bot1 = store.get_agent("bot1").unwrap().unwrap();
 
     let resp = app
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/agents/bot1/restart")
+                .uri(format!("/api/agents/{}/restart", bot1.id))
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::to_vec(&serde_json::json!({ "mode": "restart" })).unwrap(),
@@ -3694,14 +3305,6 @@ async fn test_manual_restart_does_not_fire_intro_directive() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-
-    let started = lifecycle.started_calls();
-    assert_eq!(started.len(), 1);
-    assert_eq!(started[0].0, "bot1");
-    assert!(
-        started[0].2.is_none(),
-        "restart must not pass an init directive — only first-time creation does"
-    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -3801,15 +3404,24 @@ async fn decision_round_trip_agent_creates_human_resolves_agent_resumed() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK, "resolve must 200");
 
-    // 4. resume_with_prompt fired with the right payload.
-    let calls = lifecycle.resumed_calls();
-    assert_eq!(
-        calls.len(),
-        1,
-        "resume_with_prompt must be called exactly once"
+    // 4. Resolving a decision dispatches `agent.restart` with a
+    // `DecisionResume { decision_id, prompt }` over the registry.
+    // Persistence lives on the `decisions` row (status=resolved +
+    // delivered_at IS NULL) — the envelope is rebuilt on demand. With
+    // no bridge connected, the envelope stays "to be delivered" until
+    // the bridge connects, when reconnect-replay re-emits it.
+    let row = store
+        .get_decision(&decision_id)
+        .unwrap()
+        .expect("decision row must exist");
+    assert_eq!(row.status.as_str(), "resolved");
+    assert!(
+        row.delivered_at.is_none(),
+        "delivered_at must be null until bridge acks via agent.directive_consumed; got {:?}",
+        row.delivered_at
     );
-    let (agent, envelope) = &calls[0];
-    assert_eq!(agent, "bot1");
+    let envelope = chorus::server::build_resume_envelope_from_row(&row)
+        .expect("envelope must be reconstructable from a resolved decision row");
     assert!(
         envelope.contains("PR #120 retro"),
         "envelope must include original headline; got: {envelope}"
@@ -3818,6 +3430,7 @@ async fn decision_round_trip_agent_creates_human_resolves_agent_resumed() {
     assert!(envelope.contains("Picked option (B): Revert and add tests"));
     assert!(envelope.contains("Revert, add the integration test"));
     assert!(envelope.contains("needs tests first"));
+    let _ = lifecycle;
 
     // 5. The decision row is now resolved, so /open lists nothing.
     let resp = app

--- a/tests/store_tests.rs
+++ b/tests/store_tests.rs
@@ -99,33 +99,63 @@ fn make_store() -> (Store, tempfile::TempDir) {
     (store, dir)
 }
 
+/// `Store::open` on a pre-id-flip DB (no `agents.machine_id`) must
+/// abort with the "fresh data dir" hint, not silently succeed and then
+/// fail mid-query later. `validate_schema_shape` is the single
+/// remaining check the migration-cleanup PR kept around.
 #[test]
-fn test_open_old_identity_schema_fails_loudly() {
+fn test_open_old_db_without_machine_id_fails_loudly() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("legacy.db");
     {
         let conn = Connection::open(&db_path).unwrap();
+        // Old shape: agents table with no machine_id column. A fresh
+        // CREATE TABLE IF NOT EXISTS won't add the column to an
+        // existing table, so this is exactly the upgrade landmine the
+        // validator catches.
         conn.execute_batch(
-            "CREATE TABLE humans (
-                name TEXT PRIMARY KEY,
-                display_name TEXT,
+            "CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                workspace_id TEXT NOT NULL,
+                name TEXT UNIQUE NOT NULL,
+                display_name TEXT NOT NULL,
+                runtime TEXT NOT NULL,
+                model TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
              );",
         )
         .unwrap();
     }
 
-    let err = match Store::open(db_path.to_str().unwrap()) {
-        Ok(_) => panic!("opening old identity schema should fail"),
+    let path_str = db_path.to_str().unwrap().to_string();
+    let err = match Store::open(&path_str) {
+        Ok(_) => panic!("opening pre-id-flip DB should fail"),
         Err(err) => err,
     };
     let message = err.to_string();
     assert!(
-        message.contains("old identity schema")
-            && message.contains("humans.display_name")
-            && message.contains("fresh data directory"),
-        "unexpected error: {message}"
+        message.contains("`agents.machine_id` is missing")
+            && message.contains("Delete this file")
+            && message.contains(&path_str),
+        "expected delete-this-file hint pointing at {path_str}, got: {message}"
     );
+}
+
+/// A completely empty DB file (no tables) must NOT trip the validator
+/// — that's the fresh-install path. `init_schema` creates the
+/// canonical shape. Without the empty-DB bypass, every fresh install
+/// would fail with "missing agents.machine_id" because `agents` doesn't
+/// exist yet.
+#[test]
+fn test_open_fresh_empty_db_passes_validator() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("fresh.db");
+    {
+        // Just touch the file via Connection::open; create no tables.
+        let _conn = Connection::open(&db_path).unwrap();
+    }
+
+    Store::open(db_path.to_str().unwrap()).expect("fresh empty DB must open clean");
 }
 
 #[test]
@@ -187,8 +217,8 @@ fn test_scoped_resource_schema_requires_workspace_id() {
 
     let agent_err = conn
         .execute(
-            "INSERT INTO agents (id, name, display_name, runtime, model)
-             VALUES ('missing-workspace-agent', 'orphan-agent', 'Orphan Agent', 'claude', 'sonnet')",
+            "INSERT INTO agents (id, name, display_name, runtime, model, machine_id)
+             VALUES ('missing-workspace-agent', 'orphan-agent', 'Orphan Agent', 'claude', 'sonnet', 'test-machine')",
             [],
         )
         .unwrap_err();
@@ -324,7 +354,7 @@ fn test_workspace_scoped_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -340,7 +370,7 @@ fn test_workspace_scoped_core_resource_lists() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -439,7 +469,7 @@ fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -454,7 +484,7 @@ fn test_compat_agent_and_team_helpers_write_active_workspace_rows() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -501,7 +531,7 @@ fn test_delete_workspace_wipes_scoped_data_and_keeps_other_workspaces() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[AgentEnvVar {
                     key: "TOKEN".to_string(),
                     value: "secret".to_string(),
@@ -705,7 +735,7 @@ fn test_shell_style_workspace_mutations_persist() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -744,7 +774,7 @@ fn test_shell_style_workspace_mutations_persist() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -815,7 +845,7 @@ fn test_send_and_receive_messages() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -854,7 +884,7 @@ fn test_agent_does_not_receive_its_own_sent_message() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -982,7 +1012,7 @@ fn test_inbox_conversation_state_view_projects_last_read_and_unread_count() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1094,7 +1124,7 @@ fn test_history_snapshot_and_unread_summary_use_inbox_projection() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1344,7 +1374,7 @@ fn test_agent_env_vars_persist_in_agent_record() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &env_vars,
         })
         .unwrap();
@@ -1365,7 +1395,7 @@ fn test_agent_reasoning_effort_persists_in_agent_record() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("low"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1382,7 +1412,7 @@ fn test_agent_reasoning_effort_persists_in_agent_record() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: Some("high"),
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1406,7 +1436,7 @@ fn test_mark_agent_messages_deleted_marks_history_rows() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1474,7 +1504,7 @@ fn test_unread_excludes_own_messages_for_sender() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1547,7 +1577,7 @@ fn test_tasks_crud() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1583,7 +1613,7 @@ fn test_task_claim_and_status() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1596,7 +1626,7 @@ fn test_task_claim_and_status() {
             runtime: "codex",
             model: "o3",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1638,7 +1668,7 @@ fn test_resolve_target() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1668,7 +1698,7 @@ fn test_list_channels_excludes_dm() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1697,7 +1727,7 @@ fn test_dm_channels() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1844,7 +1874,7 @@ fn test_ensure_builtin_channels_backfills_all_existing_humans_and_agents() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1857,7 +1887,7 @@ fn test_ensure_builtin_channels_backfills_all_existing_humans_and_agents() {
             runtime: "codex",
             model: "gpt-5.4-mini",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1889,7 +1919,7 @@ fn test_ensure_builtin_channels_only_exposes_all_system_channel() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1933,7 +1963,7 @@ fn test_new_agents_auto_join_all_when_it_exists() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -1977,7 +2007,7 @@ fn test_ensure_builtin_channels_repairs_active_workspace_all() {
                 runtime: "claude",
                 model: "sonnet",
                 reasoning_effort: None,
-                machine_id: None,
+                machine_id: "test-machine",
                 env_vars: &[],
             },
         )
@@ -2013,7 +2043,7 @@ fn test_delete_channel_removes_messages_tasks_and_memberships() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2263,7 +2293,7 @@ fn test_join_channel_creates_notice_and_is_idempotent() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();
@@ -2332,7 +2362,7 @@ fn agent_read_paths_exclude_humans_only_payloads_but_ui_keeps_them() {
             runtime: "claude",
             model: "sonnet",
             reasoning_effort: None,
-            machine_id: None,
+            machine_id: "test-machine",
             env_vars: &[],
         })
         .unwrap();


### PR DESCRIPTION
Single combined diff covering two waves of bridge cleanup. Reviewing them together because the second wave (event-driven RPCs) is what makes the first wave's invariants enforceable cross-process.

## What changed

### 1. Make every agent bridge-owned
- `AgentLifecycle` shrinks to observability (`process_state` + activity log). The platform no longer drives runtimes directly.
- CRUD handlers mutate spec; the in-process bridge client (or a remote `chorus bridge`) owns the process.
- `agents.machine_id` is `NOT NULL` and identifies the owning bridge.
- Migration shims, the legacy identity-schema validator, and the `agent_env_vars` rebuild are gone. `Store::open` validates the on-disk shape and refuses to open older DBs with a path-bearing error.

### 2. Convert `bridge.target` to identity + spec; lifecycle flows as RPCs

Discrete frames:
- `bridge.start { agent_id, init_directive? }` (P→B)
- `bridge.stop  { agent_id }` (P→B)
- `bridge.restart { agent_id, init_directive? }` (P→B)
- `agent.directive_consumed { agent_id }` (B→P)

Reconcile shrinks to **cache update + orphan sweep** — no auto-start, no restart-seq tracking, no cross-process `set_agent_paused` round-trip (which only ever worked because in-process serve happened to share the platform's `Arc<Store>`).

Platform handlers emit RPCs:
- start/stop → `bridge.start` / `bridge.stop`
- manual restart, PATCH spec, team membership → `bridge.restart`
- decision resume → `bridge.restart` with `init_directive` rebuilt from the `decisions` row

Reconnect-replay on `bridge.hello`: after the initial `bridge.target`, the platform iterates owned agents and emits `bridge.start` for any with unread messages or a resolved-not-delivered decision.

### Schema
- Drop `agents.paused`, `agents.restart_seq`, `agents.pending_init_directive` — flags/payloads encoding events as state.
- Add `decisions.delivered_at`. Decision data is the single source of truth for the resume directive; the agent row no longer caches it.
- Bridge marks decisions delivered via `agent.directive_consumed`.

## Test plan
- [x] `cargo test --tests` — all green (386 lib + 24 bridge_ws + the rest)
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cd ui && npx tsc --noEmit` — clean
- [x] 6 new e2e tests in `bridge_ws_tests.rs` for the new RPCs + reconnect-replay + ack→delivered_at
- [ ] Manual UI test: start/stop/restart from the agents panel; resolve a decision while bridge offline, reconnect, verify replay