### PR TITLE
Bridge auth unification (stacks on #157)

### DIFF
--- a/src/bridge/backend.rs
+++ b/src/bridge/backend.rs
@@ -126,16 +126,37 @@ pub trait Backend: Send + Sync {
 #[derive(Clone)]
 pub struct ChorusBackend {
     server_url: String,
+    /// Bearer token sent on every platform HTTP call. `None` skips the
+    /// `Authorization` header entirely — used during the env-driven
+    /// passthrough legacy path and in tests. After the api_tokens
+    /// unification, in-process bridges always set this from
+    /// `bridge-credentials.toml`.
+    bearer_token: Option<String>,
     client: reqwest::Client,
 }
 
 impl ChorusBackend {
     pub fn new(server_url: String) -> Self {
+        Self::with_token(server_url, None)
+    }
+
+    pub fn with_token(server_url: String, bearer_token: Option<String>) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()
             .expect("failed to build reqwest client");
-        Self { server_url, client }
+        Self {
+            server_url,
+            bearer_token,
+            client,
+        }
+    }
+
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.bearer_token {
+            Some(t) => req.bearer_auth(t),
+            None => req,
+        }
     }
 
     /// Build the per-agent base URL for internal agent endpoints.
@@ -150,13 +171,16 @@ impl ChorusBackend {
         )
     }
 
-    /// Send a request and handle common transport/server errors.
+    /// Send a request and handle common transport/server errors. Attaches
+    /// the bridge's bearer token (if configured) before sending, so
+    /// every call site automatically participates in the auth scheme.
     async fn send_request(
         &self,
         req: reqwest::RequestBuilder,
         url: &str,
     ) -> Result<reqwest::Response, BridgeError> {
-        let res = req
+        let res = self
+            .apply_auth(req)
             .send()
             .await
             .map_err(|e| BridgeError::PlatformUnreachable {

--- a/src/bridge/client/mod.rs
+++ b/src/bridge/client/mod.rs
@@ -40,6 +40,7 @@ pub struct BridgeClientConfig {
 pub async fn run_in_process_bridge_client(
     platform_ws: String,
     machine_id: String,
+    bearer_token: Option<String>,
     manager: Arc<AgentManager>,
     store: Arc<Store>,
     shutdown: CancellationToken,
@@ -51,7 +52,7 @@ pub async fn run_in_process_bridge_client(
         // stands up its own MCP bridge and AgentManager. The in-process
         // path skips both, so these are placeholders.
         platform_http: String::new(),
-        token: None,
+        token: bearer_token,
         machine_id,
         bridge_listen: String::new(),
         agents_dir: PathBuf::new(),

--- a/src/bridge/client/mod.rs
+++ b/src/bridge/client/mod.rs
@@ -66,7 +66,7 @@ pub async fn run_bridge_client(cfg: BridgeClientConfig) -> anyhow::Result<()> {
     let event_bus = Arc::new(EventBus::new());
 
     // 1. Bind embedded MCP bridge for local agents to reach the platform's HTTP API.
-    let (bridge_app, bridge_ct) = crate::bridge::serve::build_bridge_router(&cfg.platform_http);
+    let (bridge_app, bridge_ct) = crate::bridge::serve::build_bridge_router(&cfg.platform_http, cfg.token.clone());
     let bridge_listener = tokio::net::TcpListener::bind(&cfg.bridge_listen)
         .await
         .map_err(|e| anyhow::anyhow!("bridge listen {}: {e}", cfg.bridge_listen))?;

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -84,8 +84,12 @@ pub struct ChatBridge {
 
 impl ChatBridge {
     pub fn new(server_url: String) -> Self {
+        Self::with_token(server_url, None)
+    }
+
+    pub fn with_token(server_url: String, bearer_token: Option<String>) -> Self {
         Self {
-            backend: ChorusBackend::new(server_url),
+            backend: ChorusBackend::with_token(server_url, bearer_token),
             tool_router: Self::tool_router(),
         }
     }

--- a/src/bridge/serve.rs
+++ b/src/bridge/serve.rs
@@ -25,7 +25,11 @@ struct BridgeServer {
 }
 
 impl BridgeServer {
-    fn new(server_url: String, cancellation_token: CancellationToken) -> Self {
+    fn new(
+        server_url: String,
+        bearer_token: Option<String>,
+        cancellation_token: CancellationToken,
+    ) -> Self {
         let url = server_url.clone();
         let config = StreamableHttpServerConfig {
             cancellation_token: cancellation_token.child_token(),
@@ -40,8 +44,9 @@ impl BridgeServer {
             },
         };
 
+        let token = bearer_token.clone();
         let service = StreamableHttpService::new(
-            move || Ok(ChatBridge::new(url.clone())),
+            move || Ok(ChatBridge::with_token(url.clone(), token.clone())),
             Arc::new(session_manager),
             config,
         );
@@ -112,10 +117,22 @@ async fn handle_mcp(
 
 /// Build the bridge Axum router without binding or writing discovery info.
 ///
+/// `bearer_token` is the bridge's credential against the platform; every
+/// agent-driven HTTP call out of `ChorusBackend` carries it.
+/// `None` is accepted for transitional / test paths where the platform's
+/// `bridge_auth` is in passthrough mode.
+///
 /// Useful for tests that want to plug the router into their own listener.
-pub fn build_bridge_router(server_url: &str) -> (Router, CancellationToken) {
+pub fn build_bridge_router(
+    server_url: &str,
+    bearer_token: Option<String>,
+) -> (Router, CancellationToken) {
     let ct = CancellationToken::new();
-    let server = Arc::new(BridgeServer::new(server_url.to_string(), ct.clone()));
+    let server = Arc::new(BridgeServer::new(
+        server_url.to_string(),
+        bearer_token,
+        ct.clone(),
+    ));
 
     let app = Router::new()
         .route("/mcp", any(handle_mcp))
@@ -129,7 +146,7 @@ pub fn build_bridge_router(server_url: &str) -> (Router, CancellationToken) {
 ///
 /// Agents connect via `http://<listen_addr>/mcp` with the `X-Agent-Id` header.
 pub async fn run_bridge_server(listen_addr: &str, server_url: &str) -> anyhow::Result<()> {
-    let (app, ct) = build_bridge_router(server_url);
+    let (app, ct) = build_bridge_router(server_url, None);
 
     // Resolve listen_addr before binding so we can reject non-loopback addresses
     // without ever opening a listening socket on them.

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -73,7 +73,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
             } else {
                 model
             };
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let mut payload = serde_json::json!({
                 "display_name": name,
                 "runtime": runtime,
@@ -103,7 +104,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
         }
         AgentCommands::Stop { name, server_url } => {
             tracing::info!("Stopping agent @{name}...");
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             let agent_id = resolve_agent_id(&agents, &name)?;
             let res = client
@@ -127,7 +129,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
             // username into `/internal/agent/{agent_id}/server`, which only
             // worked when the OS user happened to share a name with an
             // agent and conflated identity types.
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             if agents.is_empty() {
                 tracing::info!("No agents.");
@@ -142,7 +145,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
             Ok(())
         }
         AgentCommands::Get { name, server_url } => {
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             let agent_id = resolve_agent_id(&agents, &name)?;
             let res = client
@@ -184,7 +188,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
         }
         AgentCommands::Start { name, server_url } => {
             tracing::info!("Starting agent @{name}...");
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             let agent_id = resolve_agent_id(&agents, &name)?;
             let res = client
@@ -208,7 +213,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
             server_url,
         } => {
             tracing::info!("Restarting agent @{name} (mode: {mode})...");
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             let agent_id = resolve_agent_id(&agents, &name)?;
             let res = client
@@ -262,7 +268,8 @@ pub async fn run(cmd: AgentCommands) -> anyhow::Result<()> {
             }
 
             tracing::info!("Deleting agent @{name}...");
-            let client = chorus::utils::http::client();
+            let _cli_token = crate::cli::resolve_cli_token()?;
+            let client = chorus::utils::http::authed_client(&_cli_token);
             let agents = fetch_agent_list(&client, &server_url).await?;
             let agent_id = resolve_agent_id(&agents, &name)?;
             let mode = if wipe {

--- a/src/cli/channel/create.rs
+++ b/src/cli/channel/create.rs
@@ -20,9 +20,11 @@ pub async fn run(
     }
     let description = description.unwrap_or_default();
     let client = super::http::client();
+    let token = crate::cli::resolve_cli_token()?;
     let url = format!("{server_url}/api/channels");
     let res = client
         .post(&url)
+        .bearer_auth(&token)
         .json(&serde_json::json!({
             "name": normalized,
             "description": description,

--- a/src/cli/channel/delete.rs
+++ b/src/cli/channel/delete.rs
@@ -73,10 +73,12 @@ pub async fn run(name: String, yes: bool, server_url: &str) -> anyhow::Result<()
     }
 
     let client = super::http::client();
-    let id = super::resolve_channel_id(&client, server_url, &normalized).await?;
+    let token = crate::cli::resolve_cli_token()?;
+    let id = super::resolve_channel_id(&client, server_url, &normalized, &token).await?;
     let url = format!("{server_url}/api/channels/{id}");
     let res = client
         .delete(&url)
+        .bearer_auth(&token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/cli/channel/history.rs
+++ b/src/cli/channel/history.rs
@@ -10,7 +10,7 @@ use super::surface_http_error;
 
 pub async fn run(name: String, limit: i64, server_url: &str) -> anyhow::Result<()> {
     let client = super::http::client();
-    let me = crate::cli::fetch_authed_user(&client, server_url).await?;
+    let (me, token) = crate::cli::fetch_authed_user_with_token(&client, server_url).await?;
     // Normalize the user input (trim, strip leading `#`, lowercase) and then
     // send it back with a leading `#`. The server's `resolve_history_target`
     // only runs its own normalization on targets that already start with `#`
@@ -23,6 +23,7 @@ pub async fn run(name: String, limit: i64, server_url: &str) -> anyhow::Result<(
     );
     let res = client
         .get(&url)
+        .bearer_auth(&token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/cli/channel/join.rs
+++ b/src/cli/channel/join.rs
@@ -9,9 +9,9 @@ use anyhow::Context;
 
 pub async fn run(name: String, server_url: &str) -> anyhow::Result<()> {
     let client = super::http::client();
-    let me = crate::cli::fetch_authed_user(&client, server_url).await?;
+    let (me, token) = crate::cli::fetch_authed_user_with_token(&client, server_url).await?;
     let normalized = super::normalize_channel_name(&name);
-    let channel_id = super::resolve_channel_id(&client, server_url, &normalized).await?;
+    let channel_id = super::resolve_channel_id(&client, server_url, &normalized, &token).await?;
 
     // Piggybacks on the invite endpoint because there is no dedicated self-join
     // route; server-side self-invites are idempotent joins. The API field is
@@ -19,6 +19,7 @@ pub async fn run(name: String, server_url: &str) -> anyhow::Result<()> {
     let url = format!("{server_url}/api/channels/{channel_id}/members");
     let res = client
         .post(&url)
+        .bearer_auth(&token)
         .json(&serde_json::json!({ "memberName": me.name }))
         .send()
         .await

--- a/src/cli/channel/list.rs
+++ b/src/cli/channel/list.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 
 pub async fn run(all: bool, server_url: &str) -> anyhow::Result<()> {
     let client = super::http::client();
-    let me = crate::cli::fetch_authed_user(&client, server_url).await?;
+    let (me, token) = crate::cli::fetch_authed_user_with_token(&client, server_url).await?;
     // Always request system channels so the default path can surface rooms
     // like `#all` that every human is auto-joined to. The client-side filter
     // below drops rows with `joined=false` when `!all`, which keeps the
@@ -19,6 +19,7 @@ pub async fn run(all: bool, server_url: &str) -> anyhow::Result<()> {
     );
     let res = client
         .get(&url)
+        .bearer_auth(&token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/cli/channel/members.rs
+++ b/src/cli/channel/members.rs
@@ -4,12 +4,14 @@ use anyhow::Context;
 
 pub async fn run(name: String, server_url: &str) -> anyhow::Result<()> {
     let client = super::http::client();
+    let token = crate::cli::resolve_cli_token()?;
     let normalized = super::normalize_channel_name(&name);
-    let channel_id = super::resolve_channel_id(&client, server_url, &normalized).await?;
+    let channel_id = super::resolve_channel_id(&client, server_url, &normalized, &token).await?;
 
     let url = format!("{server_url}/api/channels/{channel_id}/members");
     let res = client
         .get(&url)
+        .bearer_auth(&token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/cli/channel/mod.rs
+++ b/src/cli/channel/mod.rs
@@ -93,11 +93,13 @@ pub(super) async fn resolve_channel_id(
     client: &reqwest::Client,
     server_url: &str,
     name: &str,
+    token: &str,
 ) -> anyhow::Result<String> {
     let normalized = normalize_channel_name(name);
     let url = format!("{server_url}/api/channels?include_archived=true");
     let res = client
         .get(&url)
+        .bearer_auth(token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/cli/credentials.rs
+++ b/src/cli/credentials.rs
@@ -16,6 +16,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 pub const FILE_NAME: &str = "credentials.toml";
+pub const BRIDGE_FILE_NAME: &str = "bridge-credentials.toml";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Credentials {
@@ -26,8 +27,27 @@ pub struct Credentials {
     pub server: String,
 }
 
+/// Bridge credentials. Same shape as CLI credentials plus the machine_id
+/// the token is bound to. Lives in `bridge-credentials.toml` next to
+/// `credentials.toml`. Read by the in-process bridge client at boot and
+/// (in cloud / multi-machine deploys) by `chorus bridge --token-file`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BridgeCredentials {
+    /// Raw bearer token. Sent as `Authorization: Bearer <token>`.
+    pub token: String,
+    /// `machine_id` the token is bound to. The platform's auth layer
+    /// rejects the token if `agents.machine_id` doesn't match.
+    pub machine_id: String,
+    /// Platform URL the bridge connects to (HTTP base or WS URL).
+    pub server: String,
+}
+
 pub fn path_for(data_dir: &Path) -> PathBuf {
     data_dir.join(FILE_NAME)
+}
+
+pub fn bridge_path_for(data_dir: &Path) -> PathBuf {
+    data_dir.join(BRIDGE_FILE_NAME)
 }
 
 /// Returns `Ok(None)` if the file doesn't exist; `Err` only on real I/O
@@ -115,6 +135,80 @@ pub fn default_local_server() -> String {
     "http://127.0.0.1:3001".to_string()
 }
 
+// ── Bridge credentials parallel ──
+//
+// Atomic write + 0600 perms, mirroring the CLI credentials path. Keeps
+// the two file lifecycles separate so a CLI logout doesn't accidentally
+// invalidate the bridge token (and vice versa).
+
+pub fn bridge_load(data_dir: &Path) -> Result<Option<BridgeCredentials>> {
+    let path = bridge_path_for(data_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let creds: BridgeCredentials = toml::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(creds))
+}
+
+pub fn bridge_save(data_dir: &Path, creds: &BridgeCredentials) -> Result<PathBuf> {
+    std::fs::create_dir_all(data_dir)
+        .with_context(|| format!("failed to create {}", data_dir.display()))?;
+    let path = bridge_path_for(data_dir);
+    let suffix = format!(
+        "tmp.{}.{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let tmp = path.with_extension(suffix);
+    let body = format!(
+        "# Chorus bridge credentials — written by `chorus setup`.\n\
+         # Bound to a specific machine_id; do NOT share between machines.\n\
+         # Sensitive: keep mode 0600. Delete this file to disable the\n\
+         # in-process bridge until next setup.\n\n\
+         {}",
+        toml::to_string_pretty(creds)?
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .with_context(|| format!("failed to create {}", tmp.display()))?;
+        f.write_all(body.as_bytes())?;
+        f.flush()?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp, body.as_bytes())?;
+    }
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("failed to move {} → {}", tmp.display(), path.display()))?;
+    Ok(path)
+}
+
+/// Symmetric with `delete`. Currently unused (no `chorus logout --bridge`
+/// command yet); kept for parity so a future revoke flow has the same
+/// shape on disk as the CLI side.
+#[allow(dead_code)]
+pub fn bridge_delete(data_dir: &Path) -> Result<()> {
+    let path = bridge_path_for(data_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("failed to remove {}", path.display())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,6 +244,41 @@ mod tests {
         let meta = std::fs::metadata(&path).unwrap();
         let mode = meta.permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bridge_save_sets_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let creds = BridgeCredentials {
+            token: "chrs_bridge_test".into(),
+            machine_id: "machine-abc".into(),
+            server: "http://127.0.0.1:3001".into(),
+        };
+        let path = bridge_save(tmp.path(), &creds).unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn bridge_save_then_load_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let creds = BridgeCredentials {
+            token: "chrs_bridge_xyz".into(),
+            machine_id: "machine-laptop".into(),
+            server: "http://127.0.0.1:3001".into(),
+        };
+        bridge_save(tmp.path(), &creds).unwrap();
+        let loaded = bridge_load(tmp.path()).unwrap().unwrap();
+        assert_eq!(loaded, creds);
+    }
+
+    #[test]
+    fn bridge_lives_at_different_path_than_cli() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_ne!(path_for(tmp.path()), bridge_path_for(tmp.path()));
     }
 
     #[test]

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -38,18 +38,51 @@ pub fn mint_local_credentials(
         ))
         .into());
     }
-    let account = store
-        .get_local_account()?
-        .ok_or_else(|| CliError("no local account; run `chorus setup` first".into()))?;
-    if account.disabled_at.is_some() {
-        return Err(CliError("local account is disabled".into()).into());
-    }
+    let account = local_account(store)?;
     let minted = store.mint_token(&account.id, "local", Some(label))?;
     let creds = credentials::Credentials {
         token: minted.raw,
         server: credentials::default_local_server(),
     };
     credentials::save(data_dir, &creds)
+}
+
+/// Mint a bridge token bound to (local Account, machine_id) and write
+/// it to `bridge-credentials.toml`. Refuses if the file already exists.
+///
+/// Used by setup (to provision the in-process bridge) and by an
+/// eventual `chorus tokens mint --bridge` admin command.
+pub fn mint_local_bridge_credentials(
+    store: &Store,
+    data_dir: &Path,
+    machine_id: &str,
+    label: &str,
+) -> Result<PathBuf> {
+    if credentials::bridge_load(data_dir)?.is_some() {
+        return Err(CliError(format!(
+            "bridge credentials already present at {}; delete the file to roll",
+            credentials::bridge_path_for(data_dir).display()
+        ))
+        .into());
+    }
+    let account = local_account(store)?;
+    let minted = store.mint_bridge_token(&account.id, machine_id, Some(label))?;
+    let creds = credentials::BridgeCredentials {
+        token: minted.raw,
+        machine_id: machine_id.to_string(),
+        server: credentials::default_local_server(),
+    };
+    credentials::bridge_save(data_dir, &creds)
+}
+
+fn local_account(store: &Store) -> Result<chorus::store::auth::Account> {
+    let account = store
+        .get_local_account()?
+        .ok_or_else(|| CliError("no local account; run `chorus setup` first".into()))?;
+    if account.disabled_at.is_some() {
+        return Err(CliError("local account is disabled".into()).into());
+    }
+    Ok(account)
 }
 
 pub async fn run(data_dir: Option<String>, label: Option<String>) -> Result<()> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -133,7 +133,12 @@ enum Commands {
         /// Platform HTTP base URL (e.g. http://platform.host:3001) for MCP proxy.
         #[arg(long)]
         platform_http: String,
-        /// Bearer token for the WS upgrade (matches platform's CHORUS_BRIDGE_TOKENS).
+        /// Bearer token for the WS upgrade. Must match a row in the
+        /// platform's `api_tokens` table with `machine_id` set to this
+        /// bridge's `--machine-id`. Mint one on the platform host with
+        /// `chorus tokens mint --bridge --machine-id <id>` (or use the
+        /// `bridge-credentials.toml` written by `chorus setup` for the
+        /// local install).
         #[arg(long, env = "CHORUS_BRIDGE_TOKEN")]
         token: Option<String>,
         /// Stable identifier for this bridge instance.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -322,17 +322,20 @@ pub(crate) fn resolve_cli_token() -> anyhow::Result<String> {
 }
 
 /// Fetch the current user's `(id, name)` from a running server, sending
-/// the bearer token resolved by `resolve_cli_token`.
+/// the bearer token resolved by `resolve_cli_token`. Also returns the
+/// token so callers can attach `.bearer_auth(&token)` to follow-up
+/// HTTP calls — the platform requires every `/internal/*` and `/api/*`
+/// request to carry credentials.
 ///
 /// Fails with setup guidance when:
 ///   - no token available (env or file) → tell user to run `chorus setup`
 ///     (or `chorus login --local` to mint a token against an existing
 ///     install)
 ///   - the server returns 401 → token revoked or stale; same recovery.
-pub(crate) async fn fetch_authed_user(
+pub(crate) async fn fetch_authed_user_with_token(
     client: &reqwest::Client,
     server_url: &str,
-) -> anyhow::Result<AuthedUser> {
+) -> anyhow::Result<(AuthedUser, String)> {
     use anyhow::Context;
     let token = resolve_cli_token()?;
     let url = format!("{server_url}/api/whoami");
@@ -367,7 +370,20 @@ pub(crate) async fn fetch_authed_user(
         .filter(|s| !s.trim().is_empty())
         .ok_or_else(|| CliError("server returned empty user name".into()))?
         .to_string();
-    Ok(AuthedUser { id, name })
+    Ok((AuthedUser { id, name }, token))
+}
+
+/// Back-compat shim for callers that only need the user identity. New
+/// code should prefer `fetch_authed_user_with_token` so it can attach
+/// the bearer to follow-up requests.
+#[allow(dead_code)]
+pub(crate) async fn fetch_authed_user(
+    client: &reqwest::Client,
+    server_url: &str,
+) -> anyhow::Result<AuthedUser> {
+    fetch_authed_user_with_token(client, server_url)
+        .await
+        .map(|(u, _)| u)
 }
 
 pub(crate) fn default_model_for_runtime(runtime: &str) -> &str {

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -9,15 +9,18 @@ use anyhow::Context;
 
 pub async fn run(target: String, content: String, server_url: String) -> anyhow::Result<()> {
     let client = chorus::utils::http::client();
-    let me = crate::cli::fetch_authed_user(&client, &server_url).await?;
+    let (me, token) = crate::cli::fetch_authed_user_with_token(&client, &server_url).await?;
 
     // The historical `/internal/agent/{actor_id}/send` route is keyed on
     // sender id and works for either humans or agents — `handle_send`
     // resolves the actor type from the id rather than the route. Sending
     // here uses the local human's id so the resulting row's
-    // `(sender_id, sender_type)` is `(human.id, "human")`.
+    // `(sender_id, sender_type)` is `(human.id, "human")`. The bridge_auth
+    // layer permits CLI tokens on /internal/agent/{user.id}/* because the
+    // actor id matches the token's user_id.
     let res = client
         .post(format!("{server_url}/internal/agent/{}/send", me.id))
+        .bearer_auth(&token)
         .json(&serde_json::json!({ "target": target, "content": content }))
         .send()
         .await

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -134,7 +134,7 @@ pub async fn run(
         .flatten()
         .map(|c| c.token);
     let (bridge_app, bridge_ct) =
-        chorus::bridge::serve::build_bridge_router(&server_url, bridge_token);
+        chorus::bridge::serve::build_bridge_router(&server_url, bridge_token.clone());
     // Cascade the shared shutdown token into the bridge's internal CT so any
     // in-flight MCP sessions (child tokens spawned per request) drain when
     // Ctrl-C fires. Without this, axum stops accepting connections but active
@@ -198,6 +198,9 @@ pub async fn run(
     // accepting on the listener.
     let in_proc_machine_id = chorus::server::resolve_local_machine_id_for_serve(&data_dir);
     let in_proc_ws_url = format!("ws://127.0.0.1:{port}/api/bridge/ws");
+    // Reuse the bridge token loaded above so the WS upgrade passes the
+    // platform's `require_bridge_auth` check.
+    let in_proc_bearer = bridge_token.clone();
     let in_proc_shutdown = shutdown_token.clone();
     let in_proc_manager = manager.clone();
     let in_proc_store = store.clone();
@@ -205,6 +208,7 @@ pub async fn run(
         if let Err(err) = chorus::bridge::client::run_in_process_bridge_client(
             in_proc_ws_url,
             in_proc_machine_id,
+            in_proc_bearer,
             in_proc_manager,
             in_proc_store,
             in_proc_shutdown,

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -167,11 +167,7 @@ pub async fn run(
     let template_path = chorus::agent::templates::expand_tilde(&template_dir_raw);
     let templates = chorus::agent::templates::load_templates(&template_path);
 
-    let bridge_auth = chorus::server::bridge_auth::BridgeAuth::from_env();
-    if bridge_auth.is_enabled() {
-        tracing::info!("Bridge auth enabled (CHORUS_BRIDGE_TOKENS configured)");
-    }
-    let router = chorus::server::build_router_with_services_and_auth(
+    let router = chorus::server::build_router_with_services(
         store.clone(),
         event_bus.clone(),
         data_dir.clone(),
@@ -183,7 +179,6 @@ pub async fn run(
             ),
         ) as chorus::agent::runtime_status::SharedRuntimeStatusProvider,
         templates,
-        bridge_auth,
     );
 
     // Spawn background trace writer for Telescope persistence.

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -125,7 +125,16 @@ pub async fn run(
 
     tracing::info!(port = actual_bridge_port, "shared bridge listening");
 
-    let (bridge_app, bridge_ct) = chorus::bridge::serve::build_bridge_router(&server_url);
+    // The in-process bridge sends every agent HTTP call through this
+    // MCP listener. Load `bridge-credentials.toml` so those calls carry
+    // the bridge's bearer token; when absent (fresh install or test
+    // harness), pass `None` and rely on the platform's passthrough.
+    let bridge_token = super::credentials::bridge_load(&data_dir)
+        .ok()
+        .flatten()
+        .map(|c| c.token);
+    let (bridge_app, bridge_ct) =
+        chorus::bridge::serve::build_bridge_router(&server_url, bridge_token);
     // Cascade the shared shutdown token into the bridge's internal CT so any
     // in-flight MCP sessions (child tokens spawned per request) drain when
     // Ctrl-C fires. Without this, axum stops accepting connections but active

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -722,15 +722,28 @@ pub async fn run(
     let (local_user, local_account) =
         store.ensure_local_identity(&whoami::username())?;
 
+    // Resolve machine_id before credential issuance so the bridge token
+    // can be bound to it in the same step.
+    let machine_id = cfg.ensure_machine_id().to_string();
+
     // Setup defers the actual token mint + credentials write to the
     // login module — keeps "how do I get a token?" defined in exactly
-    // one place. If credentials.toml is already present the call is a
-    // no-op (returns Err with a "run logout first" message; we ignore
-    // it here because re-running setup against a logged-in install
-    // shouldn't punish the user — the existing token still works).
+    // one place. Two files end up on disk:
+    //   credentials.toml         — CLI token (no machine_id)
+    //   bridge-credentials.toml  — bridge token bound to machine_id
+    // Each is skipped if already present so a re-run of setup against a
+    // logged-in install doesn't silently invalidate live credentials.
     let _ = local_account; // touched above; the helper re-reads via get_local_account.
     if super::credentials::load(&data_dir)?.is_none() {
         super::login::mint_local_credentials(&store, &data_dir, "Local CLI")?;
+    }
+    if super::credentials::bridge_load(&data_dir)?.is_none() {
+        super::login::mint_local_bridge_credentials(
+            &store,
+            &data_dir,
+            &machine_id,
+            "Local bridge",
+        )?;
     }
 
     let workspace = if let Some(workspace) = store.get_active_workspace()? {
@@ -740,10 +753,6 @@ pub async fn run(
         ensure_setup_workspace(&store, &workspace_name, &local_user.id)?
     };
 
-    // Persist config — machine_id (stable across re-runs) + template_dir,
-    // so `chorus start` can read the chosen paths without the user re-passing
-    // --template-dir every time.
-    let machine_id = cfg.ensure_machine_id().to_string();
     cfg.agent_template.dir = Some(template_dir_raw.clone());
 
     // Pin runtime binaries to the exact paths detected on this machine,

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -6,9 +6,10 @@
 
 pub async fn run(server_url: String) -> anyhow::Result<()> {
     let client = chorus::utils::http::client();
-    let me = crate::cli::fetch_authed_user(&client, &server_url).await?;
+    let (me, token) = crate::cli::fetch_authed_user_with_token(&client, &server_url).await?;
     let res = client
         .get(format!("{server_url}/internal/agent/{}/server", me.id))
+        .bearer_auth(&token)
         .send()
         .await?;
     let data: serde_json::Value = res.json().await?;

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -145,7 +145,9 @@ async fn request<T: serde::de::DeserializeOwned>(
     path: &str,
 ) -> anyhow::Result<T> {
     let url = format!("{server_url}{path}");
+    let token = crate::cli::resolve_cli_token()?;
     let res = builder
+        .bearer_auth(&token)
         .send()
         .await
         .with_context(|| format!("is the Chorus server running at {server_url}?"))?;

--- a/src/server/bridge_auth.rs
+++ b/src/server/bridge_auth.rs
@@ -42,12 +42,16 @@ use crate::store::Store;
 pub enum AuthOutcome {
     /// No bridge tokens exist in the DB yet. Passes through.
     Disabled,
-    /// Bearer matched a row whose `machine_id` is set; this is the value
-    /// the bridge's hello (and any `/internal/agent/{id}/*` path) must
-    /// be consistent with.
+    /// Bearer matched a bridge token; the bridge's hello (and any
+    /// `/internal/agent/{agent_id}/*` path) must reference an agent
+    /// whose `agents.machine_id` matches.
     Allowed { expected_machine_id: String },
-    /// Missing/malformed header, unknown token, revoked, or CLI token
-    /// (one without a `machine_id`).
+    /// Bearer matched a CLI token. The CLI may only operate on the user
+    /// id the token represents — i.e. `/internal/agent/{actor_id}/*`
+    /// where `actor_id == users.id`. Agents are off-limits to CLI
+    /// tokens; those need bridges.
+    CliAllowed { user_id: String },
+    /// Missing/malformed header, unknown token, or revoked.
     Rejected,
 }
 
@@ -100,10 +104,14 @@ pub fn check(store: &Store, headers: &HeaderMap) -> AuthOutcome {
             expected_machine_id: m,
         },
         _ => {
-            // A CLI token (machine_id NULL) is valid for /api/* but not
-            // for /internal/*. Reject explicitly so the operator sees
-            // that the token they pasted is the wrong kind.
-            AuthOutcome::Rejected
+            // CLI token. Resolve its user_id so the middleware can
+            // enforce "this token can only act as its own user."
+            match store.get_account_by_id(&row.account_id) {
+                Ok(Some(acct)) => AuthOutcome::CliAllowed {
+                    user_id: acct.user_id,
+                },
+                _ => AuthOutcome::Rejected,
+            }
         }
     }
 }
@@ -129,14 +137,13 @@ pub async fn require_bridge_auth(
             match agent_id_from_internal_path(&path) {
                 Some(agent_id) => {
                     let owner = match state.store.get_agent_by_id(agent_id, false) {
-                        Ok(Some(agent)) => agent.machine_id,
+                        Ok(Some(agent)) => Some(agent.machine_id),
                         Ok(None) => {
-                            warn!(
-                                path = %path,
-                                token_machine_id = %expected_machine_id,
-                                "bridge_auth: rejecting /internal request — agent_id not in store"
-                            );
-                            return (StatusCode::FORBIDDEN, "agent not found").into_response();
+                            // No agent row with this id. If the id is the
+                            // CLI user's user_id this would be a CLI-acting-
+                            // as-self path (CliAllowed handles that branch);
+                            // for bridge tokens, an unknown agent is forbidden.
+                            None
                         }
                         Err(err) => {
                             warn!(
@@ -148,28 +155,63 @@ pub async fn require_bridge_auth(
                                 .into_response();
                         }
                     };
-                    if owner != *expected_machine_id {
-                        warn!(
-                            path = %path,
-                            token_machine_id = %expected_machine_id,
-                            agent_owner = %owner,
-                            "bridge_auth: rejecting /internal request — token's machine_id does not own this agent"
-                        );
-                        return (StatusCode::FORBIDDEN, "token not authorized for this agent")
-                            .into_response();
+                    match owner {
+                        Some(owner) if owner == *expected_machine_id => next.run(req).await,
+                        Some(owner) => {
+                            warn!(
+                                path = %path,
+                                token_machine_id = %expected_machine_id,
+                                agent_owner = %owner,
+                                "bridge_auth: rejecting /internal request — token's machine_id does not own this agent"
+                            );
+                            (StatusCode::FORBIDDEN, "token not authorized for this agent")
+                                .into_response()
+                        }
+                        None => {
+                            warn!(
+                                path = %path,
+                                token_machine_id = %expected_machine_id,
+                                "bridge_auth: rejecting /internal request — agent_id not in store"
+                            );
+                            (StatusCode::FORBIDDEN, "agent not found").into_response()
+                        }
                     }
-                    next.run(req).await
                 }
                 None => {
-                    // Path doesn't match the expected `/internal/agent/<id>/...`
-                    // shape. The route_layer should only attach this middleware
-                    // to agent-scoped routes, so reaching here means a routing
-                    // wiring change. Fail closed.
                     warn!(
                         path = %path,
                         "bridge_auth: rejecting /internal request — no agent_id in path"
                     );
                     (StatusCode::FORBIDDEN, "no agent scope in path").into_response()
+                }
+            }
+        }
+        AuthOutcome::CliAllowed { user_id } => {
+            // CLI token: may only act under its own user_id. The classic
+            // case is `chorus send` posting to /internal/agent/{me.id}/send
+            // where `me.id` is the human's user id, not an agent id.
+            let path = req.uri().path().to_string();
+            match agent_id_from_internal_path(&path) {
+                Some(actor_id) if actor_id == user_id => next.run(req).await,
+                Some(actor_id) => {
+                    warn!(
+                        path = %path,
+                        token_user_id = %user_id,
+                        actor_id = %actor_id,
+                        "bridge_auth: rejecting /internal request — CLI token can only act as its own user"
+                    );
+                    (
+                        StatusCode::FORBIDDEN,
+                        "CLI token not authorized for this actor",
+                    )
+                        .into_response()
+                }
+                None => {
+                    warn!(
+                        path = %path,
+                        "bridge_auth: rejecting /internal request — no actor scope in path"
+                    );
+                    (StatusCode::FORBIDDEN, "no actor scope in path").into_response()
                 }
             }
         }
@@ -258,18 +300,26 @@ mod tests {
     }
 
     #[test]
-    fn rejects_cli_token_at_bridge_endpoint() {
-        // CLI tokens have machine_id = NULL → invalid for /internal/*.
+    fn cli_token_resolves_to_cli_allowed_with_user_id() {
+        // CLI tokens (machine_id = NULL) are NOT outright rejected at
+        // /internal/* — they're returned as `CliAllowed { user_id }`
+        // so the middleware can let `chorus send` post as the user
+        // itself while still gating bridges by machine_id.
         let s = Store::open(":memory:").unwrap();
         let user = s.create_user("alice").unwrap();
         let acct = s.create_local_account(&user.id).unwrap();
-        // Also mint a bridge token so passthrough doesn't kick in.
+        // Mint a bridge token so passthrough doesn't kick in.
         let _ = s
             .mint_bridge_token(&acct.id, "machine-x", Some("bridge"))
             .unwrap();
         let cli = s.mint_token(&acct.id, "local", Some("CLI")).unwrap();
         let h = mk_headers(&[("Authorization", &format!("Bearer {}", cli.raw))]);
-        assert_eq!(check(&s, &h), AuthOutcome::Rejected);
+        match check(&s, &h) {
+            AuthOutcome::CliAllowed {
+                user_id: resolved,
+            } => assert_eq!(resolved, user.id),
+            other => panic!("expected CliAllowed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/server/bridge_auth.rs
+++ b/src/server/bridge_auth.rs
@@ -4,40 +4,27 @@
 //!
 //! 1. **Bearer token required on WS upgrade.** Anyone reaching
 //!    `/api/bridge/ws` with no `Authorization` header gets `401`.
-//! 2. **`machine_id` is pinned to a token.** The platform looks up the
-//!    token to find its bound `machine_id`; the bridge can no longer
-//!    claim an arbitrary `machine_id` in `bridge.hello`. If the hello
-//!    payload's `machine_id` doesn't match the token's binding, the
-//!    connection is closed.
+//! 2. **`machine_id` is pinned to a token.** The token row in
+//!    `api_tokens` carries the `machine_id` it's bound to; the bridge
+//!    can't claim an arbitrary id in `bridge.hello`. If the hello
+//!    payload's `machine_id` doesn't match, the connection is closed.
 //! 3. **`/internal/agent/<id>/*` is scoped to the token's `machine_id`.**
 //!    A valid token alone is not enough — the agent named in the URL
 //!    must be owned by the same `machine_id` the token is bound to.
 //!    Prevents one bridge's token from acting on another bridge's agents.
 //!
-//! Tokens are configured via the `CHORUS_BRIDGE_TOKENS` env var:
+//! Tokens live in `api_tokens` (with `machine_id` set; CLI tokens have
+//! `machine_id IS NULL` and are rejected here). Setup mints the initial
+//! local bridge token via `chorus::cli::login::mint_local_bridge_credentials`.
+//! Future tokens come from a `chorus tokens mint --bridge --machine-id`
+//! admin command (not yet implemented).
 //!
-//! ```text
-//! CHORUS_BRIDGE_TOKENS="dev-token-1:machine-alpha,dev-token-2:machine-beta"
-//! ```
-//!
-//! Comma-separates entries; each is `token:machine_id`. Whitespace is
-//! trimmed. Empty values, malformed pairs, and duplicate tokens are
-//! logged as warnings and ignored — startup never fails for a bad
-//! token-list, the operator just sees an empty (= disabled) auth state.
-//!
-//! When the parsed map is empty (env unset or unparseable),
-//! authentication is **disabled** entirely — the WS endpoint accepts
-//! any client and trusts the `bridge.hello.machine_id` it sees. This
-//! matches the loopback default and keeps existing tests working
-//! without env-var fiddling.
-//!
-//! Deliberately out of scope:
-//!   - Token rotation/revocation. Tokens are static for the process
-//!     lifetime; restart `chorus serve` to roll them.
-//!   - Anomaly detection (IP flapping, rate-limiting).
-
-use std::collections::HashMap;
-use std::sync::Arc;
+//! Passthrough mode: when the `api_tokens` table contains **zero** rows
+//! with a non-null `machine_id`, the middleware passes every request
+//! through unauthenticated. This keeps test harnesses and pre-setup
+//! installs working without forcing every consumer to mint a bridge
+//! token. Once any bridge token exists in the DB the middleware switches
+//! to "all bridge requests require a valid token."
 
 use axum::extract::{Request, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -46,155 +33,94 @@ use axum::response::{IntoResponse, Response};
 use tracing::warn;
 
 use super::handlers::AppState;
+use crate::store::auth::api_tokens::hash_token;
+use crate::store::Store;
 
-/// Outcome of validating an incoming `Authorization` header.
+/// Outcome of validating an incoming `Authorization` header against the
+/// `api_tokens` table.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthOutcome {
-    /// Auth is disabled (empty token map). The bridge may declare any
-    /// `machine_id` in its hello frame.
+    /// No bridge tokens exist in the DB yet. Passes through.
     Disabled,
-    /// Auth is enabled and the header matched a known token. The
-    /// bridge's `bridge.hello.machine_id` MUST equal `expected_machine_id`.
+    /// Bearer matched a row whose `machine_id` is set; this is the value
+    /// the bridge's hello (and any `/internal/agent/{id}/*` path) must
+    /// be consistent with.
     Allowed { expected_machine_id: String },
-    /// Auth is enabled and the request must be rejected (missing or
-    /// malformed `Authorization` header, or unknown token).
+    /// Missing/malformed header, unknown token, revoked, or CLI token
+    /// (one without a `machine_id`).
     Rejected,
 }
 
-/// Token map for the bridge endpoint. Cheap to clone; held inside an
-/// `Arc` on `AppState`.
-#[derive(Debug, Default)]
-pub struct BridgeAuth {
-    /// `token → machine_id`. Empty when auth is disabled.
-    tokens: HashMap<String, String>,
-}
-
-impl BridgeAuth {
-    pub fn empty() -> Arc<Self> {
-        Arc::new(Self::default())
-    }
-
-    /// Construct directly from a `(token, machine_id)` iterator. Useful
-    /// for tests that want to inject specific tokens without touching
-    /// the process environment.
-    pub fn from_pairs<I, S1, S2>(pairs: I) -> Arc<Self>
-    where
-        I: IntoIterator<Item = (S1, S2)>,
-        S1: Into<String>,
-        S2: Into<String>,
-    {
-        let tokens: HashMap<String, String> = pairs
-            .into_iter()
-            .map(|(t, m)| (t.into(), m.into()))
-            .collect();
-        Arc::new(Self { tokens })
-    }
-
-    /// Read `CHORUS_BRIDGE_TOKENS` from the process environment. Always
-    /// returns `Some(Arc<Self>)` — the inner map may be empty if the
-    /// variable is unset or unparseable, which means auth is disabled.
-    pub fn from_env() -> Arc<Self> {
-        let raw = match std::env::var("CHORUS_BRIDGE_TOKENS") {
-            Ok(v) if !v.trim().is_empty() => v,
-            _ => return Self::empty(),
-        };
-        let mut tokens: HashMap<String, String> = HashMap::new();
-        for entry in raw.split(',') {
-            let entry = entry.trim();
-            if entry.is_empty() {
-                continue;
-            }
-            let Some((token, machine)) = entry.split_once(':') else {
-                warn!(
-                    entry = %entry,
-                    "bridge_auth: ignoring malformed CHORUS_BRIDGE_TOKENS entry (expected token:machine_id)"
-                );
-                continue;
-            };
-            let token = token.trim();
-            let machine = machine.trim();
-            if token.is_empty() || machine.is_empty() {
-                warn!(
-                    entry = %entry,
-                    "bridge_auth: ignoring CHORUS_BRIDGE_TOKENS entry with empty token or machine_id"
-                );
-                continue;
-            }
-            if tokens
-                .insert(token.to_string(), machine.to_string())
-                .is_some()
-            {
-                warn!(
-                    token_prefix = %&token[..token.len().min(6)],
-                    "bridge_auth: duplicate token in CHORUS_BRIDGE_TOKENS — last wins"
-                );
-            }
-        }
-        Arc::new(Self { tokens })
-    }
-
-    /// Whether any tokens are configured. `false` means auth is disabled.
-    pub fn is_enabled(&self) -> bool {
-        !self.tokens.is_empty()
-    }
-
-    /// Look up a token's bound `machine_id` directly. Returns `None`
-    /// when auth is disabled or the token is unknown.
-    #[cfg(test)]
-    pub fn machine_id_for_token(&self, token: &str) -> Option<&str> {
-        self.tokens.get(token).map(|s| s.as_str())
-    }
-
-    /// Inspect the request's `Authorization` header against the
-    /// configured token map.
-    pub fn check(&self, headers: &HeaderMap) -> AuthOutcome {
-        if !self.is_enabled() {
-            return AuthOutcome::Disabled;
-        }
-        let Some(value) = headers
-            .get(axum::http::header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-        else {
-            return AuthOutcome::Rejected;
-        };
-        // Standard "Bearer <token>" parse. Tolerate extra whitespace.
-        let token = match value.trim().strip_prefix("Bearer ") {
-            Some(rest) => rest.trim(),
-            None => return AuthOutcome::Rejected,
-        };
-        if token.is_empty() {
+/// Look up the bearer token in `api_tokens` and decide.
+///
+/// `headers`: incoming request headers.
+/// `store`: the canonical token table.
+pub fn check(store: &Store, headers: &HeaderMap) -> AuthOutcome {
+    let any_bridge_token = match store.has_any_bridge_token() {
+        Ok(b) => b,
+        Err(err) => {
+            warn!(err = %err, "bridge_auth: store lookup failed; failing closed");
             return AuthOutcome::Rejected;
         }
-        match self.tokens.get(token) {
-            Some(machine_id) => AuthOutcome::Allowed {
-                expected_machine_id: machine_id.clone(),
-            },
-            None => AuthOutcome::Rejected,
+    };
+    if !any_bridge_token {
+        return AuthOutcome::Disabled;
+    }
+    let Some(value) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return AuthOutcome::Rejected;
+    };
+    let (scheme, rest) = match value.trim().split_once(char::is_whitespace) {
+        Some(pair) => pair,
+        None => return AuthOutcome::Rejected,
+    };
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return AuthOutcome::Rejected;
+    }
+    let raw = rest.trim();
+    if raw.is_empty() {
+        return AuthOutcome::Rejected;
+    }
+    let token_hash = hash_token(raw);
+    let row = match store.get_token_by_hash(&token_hash) {
+        Ok(Some(r)) => r,
+        Ok(None) => return AuthOutcome::Rejected,
+        Err(err) => {
+            warn!(err = %err, "bridge_auth: token lookup failed");
+            return AuthOutcome::Rejected;
+        }
+    };
+    if row.revoked_at.is_some() {
+        return AuthOutcome::Rejected;
+    }
+    match row.machine_id {
+        Some(m) if !m.trim().is_empty() => AuthOutcome::Allowed {
+            expected_machine_id: m,
+        },
+        _ => {
+            // A CLI token (machine_id NULL) is valid for /api/* but not
+            // for /internal/*. Reject explicitly so the operator sees
+            // that the token they pasted is the wrong kind.
+            AuthOutcome::Rejected
         }
     }
 }
 
 /// Axum middleware that protects `/internal/agent/*` (and any other
-/// route it's applied to) the same way as `handle_bridge_ws`: when
-/// tokens are configured, require a valid `Authorization: Bearer <t>`
-/// header. With a valid token, the middleware additionally verifies
-/// that the `agent_id` in the URL is owned by the token's bound
-/// `machine_id` — preventing one bridge's token from acting on another
-/// bridge's agents. When tokens are unset (loopback default), the
-/// request passes through unchanged.
-///
-/// FUTURE: `bridge_auth` is a parallel auth registry to the new
-/// `api_tokens` table. Both work today (the new layer covers `/api/*`,
-/// this layer covers `/internal/*` + `/api/bridge/ws`). Unifying them
-/// requires adding a `machine_id` column to `api_tokens` and a
-/// token-issuance story for bridge instances — deferred to a follow-up.
+/// route it's applied to). When passthrough is active (no bridge tokens
+/// in DB), the request flows through unchanged. Otherwise a valid
+/// `Authorization: Bearer <token>` is required, the token must be a
+/// bridge token (non-null `machine_id`), and the `agent_id` in the URL
+/// must be owned by that machine.
 pub async fn require_bridge_auth(
     State(state): State<AppState>,
     headers: HeaderMap,
     req: Request,
     next: Next,
 ) -> Response {
-    match state.bridge_auth.check(&headers) {
+    match check(state.store.as_ref(), &headers) {
         AuthOutcome::Disabled => next.run(req).await,
         AuthOutcome::Allowed {
             expected_machine_id,
@@ -263,11 +189,11 @@ pub async fn require_bridge_auth(
 /// input.
 fn agent_id_from_internal_path(path: &str) -> Option<&str> {
     let after = path.split_once("/agent/")?.1;
-    let segment = after.split('/').next()?;
-    if segment.is_empty() {
+    let id = after.split('/').next()?;
+    if id.is_empty() {
         None
     } else {
-        Some(segment)
+        Some(id)
     }
 }
 
@@ -276,76 +202,107 @@ mod tests {
     use super::*;
     use axum::http::HeaderValue;
 
-    fn headers_with_auth(value: &str) -> HeaderMap {
+    fn mk_headers(pairs: &[(&str, &str)]) -> HeaderMap {
         let mut h = HeaderMap::new();
-        h.insert(
-            axum::http::header::AUTHORIZATION,
-            HeaderValue::from_str(value).unwrap(),
-        );
+        for (k, v) in pairs {
+            h.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
         h
     }
 
-    #[test]
-    fn disabled_when_empty() {
-        let auth = BridgeAuth::empty();
-        assert!(!auth.is_enabled());
-        assert_eq!(auth.check(&HeaderMap::new()), AuthOutcome::Disabled);
-        assert_eq!(
-            auth.check(&headers_with_auth("Bearer anything")),
-            AuthOutcome::Disabled
-        );
+    fn mk_store_with_bridge_token() -> (Store, String, String) {
+        let s = Store::open(":memory:").unwrap();
+        let user = s.create_user("alice").unwrap();
+        let acct = s.create_local_account(&user.id).unwrap();
+        let machine_id = "machine-x".to_string();
+        let minted = s
+            .mint_bridge_token(&acct.id, &machine_id, Some("test"))
+            .unwrap();
+        (s, minted.raw, machine_id)
     }
 
     #[test]
-    fn allowed_with_valid_bearer() {
-        let auth = BridgeAuth::from_pairs([("tok-1", "machine-alpha")]);
-        let h = headers_with_auth("Bearer tok-1");
-        assert_eq!(
-            auth.check(&h),
+    fn passthrough_when_no_bridge_tokens_in_db() {
+        let s = Store::open(":memory:").unwrap();
+        // No bridge tokens minted.
+        let outcome = check(&s, &HeaderMap::new());
+        assert_eq!(outcome, AuthOutcome::Disabled);
+    }
+
+    #[test]
+    fn rejects_missing_auth_when_bridge_tokens_exist() {
+        let (s, _raw, _m) = mk_store_with_bridge_token();
+        assert_eq!(check(&s, &HeaderMap::new()), AuthOutcome::Rejected);
+    }
+
+    #[test]
+    fn rejects_unknown_token() {
+        let (s, _raw, _m) = mk_store_with_bridge_token();
+        let h = mk_headers(&[("Authorization", "Bearer chrs_bridge_unknown")]);
+        assert_eq!(check(&s, &h), AuthOutcome::Rejected);
+    }
+
+    #[test]
+    fn allows_valid_bridge_token_and_returns_machine_id() {
+        let (s, raw, machine_id) = mk_store_with_bridge_token();
+        let h = mk_headers(&[("Authorization", &format!("Bearer {raw}"))]);
+        match check(&s, &h) {
             AuthOutcome::Allowed {
-                expected_machine_id: "machine-alpha".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn rejected_when_header_missing() {
-        let auth = BridgeAuth::from_pairs([("tok-1", "m")]);
-        assert_eq!(auth.check(&HeaderMap::new()), AuthOutcome::Rejected);
-    }
-
-    #[test]
-    fn rejected_when_token_unknown() {
-        let auth = BridgeAuth::from_pairs([("tok-1", "m")]);
-        let h = headers_with_auth("Bearer not-the-token");
-        assert_eq!(auth.check(&h), AuthOutcome::Rejected);
-    }
-
-    #[test]
-    fn rejected_when_scheme_not_bearer() {
-        let auth = BridgeAuth::from_pairs([("tok-1", "m")]);
-        let h = headers_with_auth("Basic tok-1");
-        assert_eq!(auth.check(&h), AuthOutcome::Rejected);
-    }
-
-    #[test]
-    fn rejected_when_bearer_value_empty() {
-        let auth = BridgeAuth::from_pairs([("tok-1", "m")]);
-        let h = headers_with_auth("Bearer ");
-        assert_eq!(auth.check(&h), AuthOutcome::Rejected);
-    }
-
-    // `CHORUS_BRIDGE_TOKENS` is process-wide. Serialize on `bridge_env` so this
-    // test doesn't race a future parallel test that sets the same var.
-    #[test]
-    #[serial_test::serial(bridge_env)]
-    fn from_env_handles_empty_var() {
-        // SAFETY: env mutation is serialized by the `#[serial(bridge_env)]`
-        // attribute above; no other test in this group runs concurrently.
-        unsafe {
-            std::env::remove_var("CHORUS_BRIDGE_TOKENS");
+                expected_machine_id,
+            } => assert_eq!(expected_machine_id, machine_id),
+            other => panic!("expected Allowed, got {other:?}"),
         }
-        let auth = BridgeAuth::from_env();
-        assert!(!auth.is_enabled());
+    }
+
+    #[test]
+    fn rejects_cli_token_at_bridge_endpoint() {
+        // CLI tokens have machine_id = NULL → invalid for /internal/*.
+        let s = Store::open(":memory:").unwrap();
+        let user = s.create_user("alice").unwrap();
+        let acct = s.create_local_account(&user.id).unwrap();
+        // Also mint a bridge token so passthrough doesn't kick in.
+        let _ = s
+            .mint_bridge_token(&acct.id, "machine-x", Some("bridge"))
+            .unwrap();
+        let cli = s.mint_token(&acct.id, "local", Some("CLI")).unwrap();
+        let h = mk_headers(&[("Authorization", &format!("Bearer {}", cli.raw))]);
+        assert_eq!(check(&s, &h), AuthOutcome::Rejected);
+    }
+
+    #[test]
+    fn rejects_revoked_bridge_token() {
+        let (s, raw, _) = mk_store_with_bridge_token();
+        assert!(s.revoke_token_by_raw(&raw).unwrap());
+        let h = mk_headers(&[("Authorization", &format!("Bearer {raw}"))]);
+        assert_eq!(check(&s, &h), AuthOutcome::Rejected);
+    }
+
+    #[test]
+    fn case_insensitive_bearer_scheme() {
+        let (s, raw, machine_id) = mk_store_with_bridge_token();
+        let h = mk_headers(&[("Authorization", &format!("bearer {raw}"))]);
+        match check(&s, &h) {
+            AuthOutcome::Allowed {
+                expected_machine_id,
+            } => assert_eq!(expected_machine_id, machine_id),
+            other => panic!("expected Allowed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_id_extraction() {
+        assert_eq!(
+            agent_id_from_internal_path("/internal/agent/alice/send"),
+            Some("alice")
+        );
+        assert_eq!(
+            agent_id_from_internal_path("/internal/agent/alice"),
+            Some("alice")
+        );
+        assert!(agent_id_from_internal_path("/internal/foo/bar").is_none());
+        assert!(agent_id_from_internal_path("/internal/agent/").is_none());
     }
 }

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -39,7 +39,6 @@ use crate::agent::templates::AgentTemplate;
 use crate::agent::AgentLifecycle;
 use crate::agent::AgentRuntime;
 use crate::config::ChorusConfig;
-use crate::server::bridge_auth::BridgeAuth;
 use crate::server::bridge_registry::BridgeRegistry;
 use crate::server::error::{app_err, internal_err, ApiResult, ErrorResponse};
 use crate::server::event_bus::EventBus;
@@ -63,7 +62,6 @@ pub struct AppState {
     pub transitioning_agents: Arc<Mutex<HashSet<String>>>,
     pub templates: Arc<Vec<AgentTemplate>>,
     pub bridge_registry: Arc<BridgeRegistry>,
-    pub bridge_auth: Arc<BridgeAuth>,
 }
 
 impl AppState {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,40 +69,6 @@ pub fn build_router_with_services(
     runtime_status_provider: SharedRuntimeStatusProvider,
     templates: Vec<AgentTemplate>,
 ) -> Router {
-    build_router_with_services_and_auth(
-        store,
-        event_bus,
-        data_dir,
-        agents_dir,
-        lifecycle,
-        runtime_status_provider,
-        templates,
-        bridge_auth::BridgeAuth::empty(),
-    )
-}
-
-/// Same as `build_router_with_services`, but accepts a pre-built
-/// `BridgeAuth`. The CLI binary calls this with `BridgeAuth::from_env()`
-/// so the deployed `chorus serve` enforces tokens; tests inject explicit
-/// `BridgeAuth::from_pairs(...)` to exercise the auth path without
-/// touching process env vars.
-///
-/// `clippy::too_many_arguments` is silenced here because this signature
-/// is purely additive over `build_router_with_services` (which already
-/// hits the 7-arg limit). Folding the existing args into a config
-/// struct is the right long-term answer but would touch every test
-/// harness + CLI caller in one go — out of scope for this PR.
-#[allow(clippy::too_many_arguments)]
-pub fn build_router_with_services_and_auth(
-    store: Arc<Store>,
-    event_bus: Arc<EventBus>,
-    data_dir: std::path::PathBuf,
-    agents_dir: std::path::PathBuf,
-    lifecycle: Arc<dyn AgentLifecycle>,
-    runtime_status_provider: SharedRuntimeStatusProvider,
-    templates: Vec<AgentTemplate>,
-    bridge_auth: Arc<bridge_auth::BridgeAuth>,
-) -> Router {
     use handlers::*;
     use transport::bridge_ws::handle_bridge_ws;
     use transport::realtime::handle_events_ws;
@@ -150,7 +116,6 @@ pub fn build_router_with_services_and_auth(
         transitioning_agents: Arc::new(Mutex::new(HashSet::new())),
         templates: Arc::new(templates),
         bridge_registry: bridge_registry::BridgeRegistry::new(),
-        bridge_auth,
     };
 
     // Spawn a single forwarder task that subscribes once to the event

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -71,16 +71,18 @@ pub async fn handle_bridge_ws(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> axum::response::Response {
-    let expected_machine_id = match state.bridge_auth.check(&headers) {
-        AuthOutcome::Disabled => None,
-        AuthOutcome::Allowed {
-            expected_machine_id,
-        } => Some(expected_machine_id),
-        AuthOutcome::Rejected => {
-            warn!("bridge_ws: rejecting upgrade — invalid or missing bearer token");
-            return (StatusCode::UNAUTHORIZED, "missing or invalid bearer token").into_response();
-        }
-    };
+    let expected_machine_id =
+        match crate::server::bridge_auth::check(state.store.as_ref(), &headers) {
+            AuthOutcome::Disabled => None,
+            AuthOutcome::Allowed {
+                expected_machine_id,
+            } => Some(expected_machine_id),
+            AuthOutcome::Rejected => {
+                warn!("bridge_ws: rejecting upgrade — invalid or missing bearer token");
+                return (StatusCode::UNAUTHORIZED, "missing or invalid bearer token")
+                    .into_response();
+            }
+        };
     ws.on_upgrade(move |socket| {
         bridge_session(
             socket,

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -77,6 +77,14 @@ pub async fn handle_bridge_ws(
             AuthOutcome::Allowed {
                 expected_machine_id,
             } => Some(expected_machine_id),
+            AuthOutcome::CliAllowed { .. } => {
+                // CLI tokens are not allowed to open a bridge WS session
+                // — they're for `chorus send` and friends, not for
+                // bridges hosting agents.
+                warn!("bridge_ws: rejecting upgrade — CLI token cannot open bridge session");
+                return (StatusCode::FORBIDDEN, "CLI token not allowed on bridge upgrade")
+                    .into_response();
+            }
             AuthOutcome::Rejected => {
                 warn!("bridge_ws: rejecting upgrade — invalid or missing bearer token");
                 return (StatusCode::UNAUTHORIZED, "missing or invalid bearer token")

--- a/src/server/transport/bridge_ws.rs
+++ b/src/server/transport/bridge_ws.rs
@@ -15,7 +15,7 @@
 //! otherwise silently mark the live new instance dead.
 //!
 //! Auth: when the platform has tokens configured (via
-//! `CHORUS_BRIDGE_TOKENS` env var or explicit `BridgeAuth`), the request
+//! `api_tokens` rows minted via `mint_bridge_token`), the request
 //! must include `Authorization: Bearer <token>` and the
 //! `bridge.hello.machine_id` must match the token's bound `machine_id`.
 //! With no tokens configured, auth is disabled (loopback default).

--- a/src/store/auth/api_tokens.rs
+++ b/src/store/auth/api_tokens.rs
@@ -16,10 +16,15 @@ use sha2::{Digest, Sha256};
 use crate::store::{parse_datetime, Store};
 
 /// Row in `api_tokens`. Never carries the raw token.
+///
+/// `machine_id == None` ⇒ CLI token (acts as its `account_id`'s User).
+/// `machine_id == Some(_)` ⇒ bridge token (additionally restricted to
+/// agents whose `agents.machine_id` matches).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiToken {
     pub token_hash: String,
     pub account_id: String,
+    pub machine_id: Option<String>,
     pub label: Option<String>,
     pub created_at: DateTime<Utc>,
     pub last_used_at: Option<DateTime<Utc>>,
@@ -54,8 +59,9 @@ pub fn generate_raw_token(provider: &str) -> String {
 }
 
 impl Store {
-    /// Mint a token bound to an Account. Returns the raw token (caller
-    /// must persist it — we don't keep it) plus the persisted row.
+    /// Mint a CLI token bound to an Account (`machine_id = NULL`).
+    /// Returns the raw token (caller must persist it — we don't keep it)
+    /// plus the persisted row.
     pub fn mint_token(
         &self,
         account_id: &str,
@@ -63,13 +69,27 @@ impl Store {
         label: Option<&str>,
     ) -> Result<MintedToken> {
         let conn = self.lock_conn();
-        Self::mint_token_inner(&conn, account_id, provider, label)
+        Self::mint_token_inner(&conn, account_id, provider, None, label)
+    }
+
+    /// Mint a bridge token bound to an Account *and* a `machine_id`.
+    /// The auth layer additionally enforces that the token only acts on
+    /// agents whose `agents.machine_id` matches.
+    pub fn mint_bridge_token(
+        &self,
+        account_id: &str,
+        machine_id: &str,
+        label: Option<&str>,
+    ) -> Result<MintedToken> {
+        let conn = self.lock_conn();
+        Self::mint_token_inner(&conn, account_id, "bridge", Some(machine_id), label)
     }
 
     pub(crate) fn mint_token_inner(
         conn: &Connection,
         account_id: &str,
         provider: &str,
+        machine_id: Option<&str>,
         label: Option<&str>,
     ) -> Result<MintedToken> {
         if Self::get_account_by_id_inner(conn, account_id)?.is_none() {
@@ -78,8 +98,9 @@ impl Store {
         let raw = generate_raw_token(provider);
         let token_hash = hash_token(&raw);
         conn.execute(
-            "INSERT INTO api_tokens (token_hash, account_id, label) VALUES (?1, ?2, ?3)",
-            params![token_hash, account_id, label],
+            "INSERT INTO api_tokens (token_hash, account_id, machine_id, label)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![token_hash, account_id, machine_id, label],
         )?;
         let row = Self::get_token_by_hash_inner(conn, &token_hash)?
             .ok_or_else(|| anyhow::anyhow!("token not found after insert"))?;
@@ -131,7 +152,7 @@ impl Store {
         let conn = self.lock_conn();
         let rows = conn
             .prepare(
-                "SELECT token_hash, account_id, label, created_at, last_used_at, revoked_at
+                "SELECT token_hash, account_id, machine_id, label, created_at, last_used_at, revoked_at
                  FROM api_tokens WHERE account_id = ?1 ORDER BY created_at",
             )?
             .query_map(params![account_id], Self::token_from_row)?
@@ -145,7 +166,7 @@ impl Store {
         token_hash: &str,
     ) -> Result<Option<ApiToken>> {
         conn.query_row(
-            "SELECT token_hash, account_id, label, created_at, last_used_at, revoked_at
+            "SELECT token_hash, account_id, machine_id, label, created_at, last_used_at, revoked_at
              FROM api_tokens WHERE token_hash = ?1",
             params![token_hash],
             Self::token_from_row,
@@ -155,13 +176,14 @@ impl Store {
     }
 
     fn token_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ApiToken> {
-        let last_used_raw: Option<String> = row.get(4)?;
-        let revoked_raw: Option<String> = row.get(5)?;
+        let last_used_raw: Option<String> = row.get(5)?;
+        let revoked_raw: Option<String> = row.get(6)?;
         Ok(ApiToken {
             token_hash: row.get(0)?,
             account_id: row.get(1)?,
-            label: row.get(2)?,
-            created_at: parse_datetime(&row.get::<_, String>(3)?),
+            machine_id: row.get(2)?,
+            label: row.get(3)?,
+            created_at: parse_datetime(&row.get::<_, String>(4)?),
             last_used_at: last_used_raw.as_deref().map(parse_datetime),
             revoked_at: revoked_raw.as_deref().map(parse_datetime),
         })
@@ -333,5 +355,42 @@ mod tests {
         let _m2 = s.mint_token(&acct.id, "local", Some("Bridge")).unwrap();
         let tokens = s.list_tokens_for_account(&acct.id).unwrap();
         assert_eq!(tokens.len(), 2);
+    }
+
+    #[test]
+    fn cli_token_has_no_machine_id() {
+        let s = store();
+        let acct = make_account(&s);
+        let minted = s.mint_token(&acct.id, "local", Some("CLI")).unwrap();
+        assert!(minted.row.machine_id.is_none());
+    }
+
+    #[test]
+    fn bridge_token_is_bound_to_machine_id() {
+        let s = store();
+        let acct = make_account(&s);
+        let minted = s
+            .mint_bridge_token(&acct.id, "machine-abc", Some("Local bridge"))
+            .unwrap();
+        assert_eq!(minted.row.machine_id.as_deref(), Some("machine-abc"));
+        // Round-trip the hash → row lookup to confirm machine_id persists.
+        let row = s.touch_active_token(&minted.raw).unwrap().unwrap();
+        assert_eq!(row.machine_id.as_deref(), Some("machine-abc"));
+    }
+
+    #[test]
+    fn bridge_and_cli_tokens_coexist_on_one_account() {
+        let s = store();
+        let acct = make_account(&s);
+        let cli = s.mint_token(&acct.id, "local", Some("CLI")).unwrap();
+        let bridge = s
+            .mint_bridge_token(&acct.id, "machine-xyz", Some("Local bridge"))
+            .unwrap();
+        assert_ne!(cli.raw, bridge.raw);
+        let tokens = s.list_tokens_for_account(&acct.id).unwrap();
+        assert_eq!(tokens.len(), 2);
+        let machine_ids: Vec<_> = tokens.iter().map(|t| t.machine_id.clone()).collect();
+        assert!(machine_ids.contains(&None));
+        assert!(machine_ids.contains(&Some("machine-xyz".to_string())));
     }
 }

--- a/src/store/auth/api_tokens.rs
+++ b/src/store/auth/api_tokens.rs
@@ -148,6 +148,28 @@ impl Store {
         Ok(affected > 0)
     }
 
+    /// Public lookup by SHA-256 hash. Returns the row without any
+    /// validity checks (caller decides what's acceptable).
+    pub fn get_token_by_hash(&self, token_hash: &str) -> Result<Option<ApiToken>> {
+        let conn = self.lock_conn();
+        Self::get_token_by_hash_inner(&conn, token_hash)
+    }
+
+    /// Cheap "has any bridge token ever been minted on this install?"
+    /// probe. Used by `bridge_auth` to flip between passthrough mode
+    /// (no tokens ever) and enforcing mode (tokens exist — possibly all
+    /// revoked, which is a deliberate lock-down rather than an invite
+    /// for unauthenticated access).
+    pub fn has_any_bridge_token(&self) -> Result<bool> {
+        let conn = self.lock_conn();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM api_tokens WHERE machine_id IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
     pub fn list_tokens_for_account(&self, account_id: &str) -> Result<Vec<ApiToken>> {
         let conn = self.lock_conn();
         let rows = conn

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -176,17 +176,27 @@ CREATE TABLE IF NOT EXISTS sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_account_id ON sessions(account_id);
 
--- CLI / bridge bearer tokens. D5=B: one shape, no kind discriminator;
--- label distinguishes usage for the user.
+-- CLI / bridge bearer tokens.
+--
+-- `machine_id` distinguishes a bridge token from a CLI token:
+--   NULL    → CLI token. Acts as the User in all `/api/*` calls.
+--   SET     → bridge token bound to that machine. The auth layer (in
+--             bridge_auth.rs) restricts the bearer to operating on
+--             agents whose `agents.machine_id` matches this value.
+--
+-- One shape, two semantics — the label string carries the human-readable
+-- distinction ("Local CLI" / "Local bridge" / "Laptop bridge" / "CI").
 CREATE TABLE IF NOT EXISTS api_tokens (
     token_hash      TEXT PRIMARY KEY,                   -- SHA-256(raw_token); raw never stored
     account_id      TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-    label           TEXT,                               -- 'Local CLI', 'Laptop bridge', 'CI'
+    machine_id      TEXT,                               -- NULL = CLI; set = bridge
+    label           TEXT,
     created_at      TEXT NOT NULL DEFAULT (datetime('now')),
     last_used_at    TEXT,
     revoked_at      TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_api_tokens_account_id ON api_tokens(account_id);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_machine_id ON api_tokens(machine_id);
 
 -- Tasks tracked within channels.
 CREATE TABLE IF NOT EXISTS tasks (

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -6,16 +6,38 @@
 
 use std::time::Duration;
 
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+
 /// Default per-request timeout for CLI HTTP calls.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Build a `reqwest::Client` with [`DEFAULT_TIMEOUT`].
+/// Build a `reqwest::Client` with [`DEFAULT_TIMEOUT`] and no default auth
+/// header. Use [`authed_client`] for CLI commands that need to talk to
+/// the platform — every `/api/*` and `/internal/*` endpoint requires
+/// authentication now.
 ///
 /// The builder only fails on TLS init errors, which are not reachable with the
 /// default feature set; the expect is deliberate.
 pub fn client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(DEFAULT_TIMEOUT)
+        .build()
+        .expect("reqwest client builder with static config cannot fail")
+}
+
+/// Build a `reqwest::Client` that automatically sends
+/// `Authorization: Bearer <token>` on every request. Every CLI command
+/// that talks to the platform should call this so individual request
+/// builders don't need `.bearer_auth(&token)`.
+pub fn authed_client(token: &str) -> reqwest::Client {
+    let mut headers = HeaderMap::new();
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))
+        .expect("bearer token contains only ASCII chars");
+    value.set_sensitive(true);
+    headers.insert(AUTHORIZATION, value);
+    reqwest::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .default_headers(headers)
         .build()
         .expect("reqwest client builder with static config cannot fail")
 }

--- a/tests/agent_cli_tests.rs
+++ b/tests/agent_cli_tests.rs
@@ -28,6 +28,11 @@ async fn run_agent(args: &[&str]) -> std::process::Output {
             .arg("agent")
             .args(&args)
             .env("RUST_LOG", "chorus=info")
+            // Auth: the spawned binary reads `CHORUS_TOKEN` first, then
+            // credentials.toml on disk. The harness's default test
+            // identity matches this token; the in-process server router
+            // accepts it via the new auth layer.
+            .env("CHORUS_TOKEN", harness::TEST_AUTH_TOKEN)
             .output()
             .expect("failed to run chorus binary")
     })

--- a/tests/bridge_serve_tests.rs
+++ b/tests/bridge_serve_tests.rs
@@ -46,7 +46,7 @@ async fn start_bridge() -> (String, tokio_util::sync::CancellationToken) {
 async fn start_bridge_with_server(
     server_url: &str,
 ) -> (String, tokio_util::sync::CancellationToken) {
-    let (app, ct) = build_bridge_router(server_url);
+    let (app, ct) = build_bridge_router(server_url, None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();

--- a/tests/bridge_ws_tests.rs
+++ b/tests/bridge_ws_tests.rs
@@ -11,7 +11,6 @@ mod harness;
 use std::sync::Arc;
 
 use anyhow::Context;
-use chorus::server::bridge_auth::BridgeAuth;
 use chorus::store::channels::ChannelType;
 use chorus::store::AgentRecordUpsert;
 use chorus::store::Store;
@@ -522,7 +521,9 @@ async fn bridge_ws_pushes_to_multiple_connected_bridges() {
 
 // ── bearer auth on WS upgrade ──────────────────────────────────────────
 
-async fn start_test_server_with_auth(auth: Arc<BridgeAuth>) -> (String, String) {
+async fn start_test_server_with_auth(
+    pairs: Vec<(&'static str, &'static str)>,
+) -> (String, String) {
     let store = Arc::new(Store::open(":memory:").unwrap());
     store
         .create_channel(
@@ -535,7 +536,7 @@ async fn start_test_server_with_auth(auth: Arc<BridgeAuth>) -> (String, String) 
     store
         .create_channel("general", Some("General"), ChannelType::Channel, None)
         .unwrap();
-    let router = harness::build_router_with_bridge_auth(store.clone(), auth);
+    let router = harness::build_router_with_bridge_tokens(store.clone(), pairs);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let ws_url = format!("ws://{addr}");
@@ -547,8 +548,8 @@ async fn start_test_server_with_auth(auth: Arc<BridgeAuth>) -> (String, String) 
 
 #[tokio::test]
 async fn bridge_ws_rejects_upgrade_when_token_missing() {
-    let auth = BridgeAuth::from_pairs([("good-token", "machine-alpha")]);
-    let (ws_url, _http_url) = start_test_server_with_auth(auth).await;
+    let pairs = vec![("good-token", "machine-alpha")];
+    let (ws_url, _http_url) = start_test_server_with_auth(pairs).await;
 
     // No Authorization header at all → 401, no upgrade.
     let result = connect_async(format!("{ws_url}/api/bridge/ws")).await;
@@ -563,8 +564,8 @@ async fn bridge_ws_rejects_upgrade_when_token_missing() {
 
 #[tokio::test]
 async fn bridge_ws_rejects_upgrade_when_token_unknown() {
-    let auth = BridgeAuth::from_pairs([("good-token", "machine-alpha")]);
-    let (ws_url, _http_url) = start_test_server_with_auth(auth).await;
+    let pairs = vec![("good-token", "machine-alpha")];
+    let (ws_url, _http_url) = start_test_server_with_auth(pairs).await;
 
     let mut req = format!("{ws_url}/api/bridge/ws")
         .into_client_request()
@@ -583,8 +584,8 @@ async fn bridge_ws_rejects_upgrade_when_token_unknown() {
 
 #[tokio::test]
 async fn bridge_ws_accepts_valid_token_and_matches_machine_id() {
-    let auth = BridgeAuth::from_pairs([("good-token", "machine-alpha")]);
-    let (ws_url, _http_url) = start_test_server_with_auth(auth).await;
+    let pairs = vec![("good-token", "machine-alpha")];
+    let (ws_url, _http_url) = start_test_server_with_auth(pairs).await;
 
     let mut req = format!("{ws_url}/api/bridge/ws")
         .into_client_request()
@@ -601,8 +602,8 @@ async fn bridge_ws_accepts_valid_token_and_matches_machine_id() {
 
 #[tokio::test]
 async fn bridge_ws_drops_session_on_machine_id_spoof() {
-    let auth = BridgeAuth::from_pairs([("good-token", "machine-alpha")]);
-    let (ws_url, _http_url) = start_test_server_with_auth(auth).await;
+    let pairs = vec![("good-token", "machine-alpha")];
+    let (ws_url, _http_url) = start_test_server_with_auth(pairs).await;
 
     let mut req = format!("{ws_url}/api/bridge/ws")
         .into_client_request()
@@ -1064,8 +1065,8 @@ async fn internal_agent_endpoints_require_bearer_when_auth_enabled() {
             env_vars: &[],
         })
         .unwrap();
-    let auth = BridgeAuth::from_pairs([("internal-tok", "machine-x")]);
-    let router = harness::build_router_with_bridge_auth(store.clone(), auth);
+    let pairs = vec![("internal-tok", "machine-x")];
+    let router = harness::build_router_with_bridge_tokens(store.clone(), pairs);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let http_url = format!("http://{addr}");
@@ -1134,8 +1135,8 @@ async fn internal_agent_endpoints_reject_cross_bridge_tampering() {
         })
         .unwrap();
     // Tokens: one bound to machine-x, one to machine-y.
-    let auth = BridgeAuth::from_pairs([("x-tok", "machine-x"), ("y-tok", "machine-y")]);
-    let router = harness::build_router_with_bridge_auth(store.clone(), auth);
+    let pairs = vec![("x-tok", "machine-x"), ("y-tok", "machine-y")];
+    let router = harness::build_router_with_bridge_tokens(store.clone(), pairs);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let http_url = format!("http://{addr}");

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -227,6 +227,10 @@ pub fn build_router_with_event_bus_and_dir(
 /// `Authorization: Bearer` header on its bridge-auth-enforcing
 /// requests.
 ///
+/// Does NOT layer the auto-inject auth middleware — bridge_auth tests
+/// need precise control over which credential each request carries
+/// (e.g. testing that a missing `Authorization` header → 401).
+///
 /// Mirrors the old `BridgeAuth::from_pairs` shape — bridges no longer
 /// have a separate registry; everything goes through `api_tokens`.
 pub fn build_router_with_bridge_tokens<I, S1, S2>(store: Arc<Store>, pairs: I) -> Router
@@ -254,7 +258,7 @@ where
     let data_dir = unique_test_data_dir();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
-    let router = build_router_with_services(
+    build_router_with_services(
         store,
         Arc::new(EventBus::new()),
         data_dir,
@@ -264,8 +268,7 @@ where
             chorus::agent::manager::build_driver_registry(),
         )) as SharedRuntimeStatusProvider,
         vec![],
-    );
-    router.layer(axum::middleware::from_fn(inject_test_auth))
+    )
 }
 
 /// Per-call unique tempdir so parallel cargo tests don't collide on

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -13,9 +13,8 @@ use axum::Router;
 use chorus::agent::activity_log::ActivityLogResponse;
 use chorus::agent::runtime_status::{SharedRuntimeStatusProvider, SystemRuntimeStatusProvider};
 use chorus::agent::AgentLifecycle;
-use chorus::server::bridge_auth::BridgeAuth;
 use chorus::server::event_bus::EventBus;
-use chorus::server::{build_router_with_services, build_router_with_services_and_auth};
+use chorus::server::build_router_with_services;
 use chorus::store::auth::api_tokens::hash_token;
 use chorus::store::Store;
 use rusqlite::params;
@@ -221,16 +220,41 @@ pub fn build_router_with_event_bus_and_dir(
     )
 }
 
-/// Build a router with an explicit `BridgeAuth` for tests that exercise
-/// the auth path. Unlike the env-driven default in `chorus serve`, this
-/// keeps token state out of process-global env vars so parallel tests
-/// don't interfere with one another.
-pub fn build_router_with_bridge_auth(store: Arc<Store>, bridge_auth: Arc<BridgeAuth>) -> Router {
+/// Build a router for tests that exercise the bridge auth path. Mints
+/// the supplied `(raw_token, machine_id)` pairs into the store's
+/// `api_tokens` table so the platform-side `bridge_auth::check` finds
+/// them. Returns the router. The caller passes the raw token in the
+/// `Authorization: Bearer` header on its bridge-auth-enforcing
+/// requests.
+///
+/// Mirrors the old `BridgeAuth::from_pairs` shape — bridges no longer
+/// have a separate registry; everything goes through `api_tokens`.
+pub fn build_router_with_bridge_tokens<I, S1, S2>(store: Arc<Store>, pairs: I) -> Router
+where
+    I: IntoIterator<Item = (S1, S2)>,
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+{
     ensure_default_test_identity(&store);
+    // Mint each (token, machine_id) pair into api_tokens, bound to the
+    // default test account.
+    let account_id = format!("acc_{}", TEST_USER_ID);
+    {
+        let conn = store.conn_for_test();
+        for (raw, machine) in pairs {
+            let token_hash = hash_token(raw.as_ref());
+            conn.execute(
+                "INSERT OR IGNORE INTO api_tokens (token_hash, account_id, machine_id, label)
+                 VALUES (?1, ?2, ?3, 'test-bridge')",
+                params![token_hash, account_id, machine.as_ref()],
+            )
+            .ok();
+        }
+    }
     let data_dir = unique_test_data_dir();
     let agents_dir = data_dir.join("agents");
     std::fs::create_dir_all(&agents_dir).ok();
-    let router = build_router_with_services_and_auth(
+    let router = build_router_with_services(
         store,
         Arc::new(EventBus::new()),
         data_dir,
@@ -240,7 +264,6 @@ pub fn build_router_with_bridge_auth(store: Arc<Store>, bridge_auth: Arc<BridgeA
             chorus::agent::manager::build_driver_registry(),
         )) as SharedRuntimeStatusProvider,
         vec![],
-        bridge_auth,
     );
     router.layer(axum::middleware::from_fn(inject_test_auth))
 }

--- a/tests/live_multi_session_tests.rs
+++ b/tests/live_multi_session_tests.rs
@@ -159,7 +159,7 @@ async fn start_chorus_server() -> anyhow::Result<(String, Arc<Store>)> {
 async fn start_bridge_with_server(
     server_url: &str,
 ) -> anyhow::Result<(String, tokio_util::sync::CancellationToken)> {
-    let (app, ct) = build_bridge_router(server_url);
+    let (app, ct) = build_bridge_router(server_url, None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();

--- a/tests/live_runtime_tests.rs
+++ b/tests/live_runtime_tests.rs
@@ -149,7 +149,7 @@ async fn start_chorus_server() -> anyhow::Result<(String, Arc<Store>, String)> {
 async fn start_bridge_with_server(
     server_url: &str,
 ) -> anyhow::Result<(String, tokio_util::sync::CancellationToken)> {
-    let (app, ct) = build_bridge_router(server_url);
+    let (app, ct) = build_bridge_router(server_url, None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();

--- a/tests/workspace_cli_tests.rs
+++ b/tests/workspace_cli_tests.rs
@@ -29,6 +29,7 @@ async fn run_workspace(server_url: &str, args: &[&str]) -> std::process::Output 
             .arg("--server-url")
             .arg(&server_url)
             .env("RUST_LOG", "chorus=info")
+            .env("CHORUS_TOKEN", harness::TEST_AUTH_TOKEN)
             .output()
             .expect("failed to run chorus binary")
     })


### PR DESCRIPTION
## ⚠️ Do not merge — stacks on #157

This PR depends on #157 (identity-and-auth redesign). It targets that branch as its base, not main. Re-target to `main` after #157 lands and force-push as a rebase.

## Summary

Folds the bridge auth registry into the new `api_tokens` table introduced by #157. After this PR, there is exactly one bearer-token table that gates both the CLI auth layer and the bridge auth layer; their behaviours differ by whether the token row's `machine_id` is set, not by which registry they live in.

```
api_tokens
├── machine_id IS NULL   → CLI token. Acts as account.user_id.
└── machine_id IS SET    → Bridge token. Acts as account.user_id, AND
                            restricted to agents whose machine_id matches.
```

## What changed

| Area | Before | After |
| --- | --- | --- |
| Bridge token store | In-memory `HashMap` parsed from `CHORUS_BRIDGE_TOKENS` env at boot | `api_tokens` table row with non-null `machine_id` |
| Bridge token issuance | Operator hand-crafts env var | `Store::mint_bridge_token(account, machine_id, label)`; setup mints one as `Local bridge` |
| CLI tokens on `/internal/agent/{user.id}/*` | Rejected (CLI never had a path) | Allowed — CLI token's `AuthOutcome::CliAllowed { user_id }` resolves to "this user can act as themselves" |
| In-process bridge auth | Implicit (env unset → passthrough) | Reads `~/.chorus/bridge-credentials.toml` at boot; sends Bearer on every WS + HTTP call |
| `bridge_auth::BridgeAuth` struct | Lived in `AppState`, parsed from env | Deleted; `check(&Store, &headers)` is the only entry point |
| Test harness for bridge auth | `BridgeAuth::from_pairs([("tok", "machine")])` | `harness::build_router_with_bridge_tokens(store, [("tok", "machine")])` — mints into `api_tokens` |

## What setup now produces

```
~/.chorus/credentials.toml         # CLI token; what `chorus send`/`status`/… read
~/.chorus/bridge-credentials.toml  # Bridge token bound to config.machine_id;
                                   #   read by the in-process bridge client
                                   #   at chorus serve boot
```

Both 0600. Both written atomically. Both go through `login::mint_local_credentials` and `login::mint_local_bridge_credentials` — the boundary the user asked for between setup and credential minting is preserved.

## Manual smoke (verified)

```
$ rm -rf /tmp/chorus-bridge-smoke && chorus setup --yes --data-dir /tmp/chorus-bridge-smoke
$ chorus serve --port 31347 --data-dir /tmp/chorus-bridge-smoke --bridge-port 31348 &
$ CHORUS_TOKEN=$(grep ^token /tmp/chorus-bridge-smoke/credentials.toml | cut -d'"' -f2) chorus send "#all" "hi"
   INFO  Message sent to #all as @zht. ID: 93833922-...
$ sqlite3 /tmp/chorus-bridge-smoke/data/chorus.db "SELECT seq, content, sender_id, sender_type FROM messages"
   1|hi|usr_4c277a2c-...-71829bf1beed|human
$ grep "bridge_ws: bridge connected" /tmp/smoke3-serve.log
   ... auth=true machine_id=56da7298-... agents_alive=0
```

End-to-end: CLI sends bearer → platform auth layer accepts → message lands attributed to the right user. In-process bridge auths to the platform with its own bearer and receives the bridge.target frame. No environment variables involved.

## Verification

- `cargo test`: green
- `cargo clippy -- -D warnings`: clean
- 5 new bridge_auth unit tests + 2 store-level bridge-token tests
- Bridge ws integration tests still pass with the new shape

## What this PR does NOT do (still deferred)

- `chorus tokens` CRUD command (mint additional / list / revoke from CLI). The store API exists; surfacing it as a subcommand is its own PR.
- Settings → Tokens UI page. Same.
- Remote-bridge `chorus bridge --token-file` flag. The remote case still uses `--token` (env or flag); the file convention can land later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)