### PR TITLE
ci: release workflow for chorus + chorus-server binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release Binaries
+
+# Triggers on tag push (`v*`). The `workflow_dispatch` path lets you
+# rebuild artifacts for an already-existing tag (e.g. after a runner
+# flake) without needing a new tag.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (must already exist, e.g. v0.0.12.0)'
+        required: true
+
+jobs:
+  release:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      # Don't cancel siblings on first failure — we want every target
+      # we can ship, even if one is flaking.
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Build embedded UI bundle
+        # `chorus-server` embeds `ui/dist/` via `rust-embed`; the
+        # bundle must exist on disk before cargo build runs.
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: chorus,chorus-server
+          target: ${{ matrix.target }}
+          archive: chorus-$tag-$target
+          tar: unix
+          zip: none
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,13 @@ base64 = "0.22"
 sha2 = "0.10"
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 
+# Release artifacts go through `.github/workflows/release.yml` and ship to
+# end-user machines (bridge devices) and cloud VMs — strip symbols so the
+# tarballs stay small without sacrificing panic backtraces (those use the
+# at-runtime backtrace formatter, not symbol tables on disk).
+[profile.release]
+strip = "symbols"
+
 [dev-dependencies]
 tempfile = "3"
 tower = "0.5"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` that builds and uploads release artifacts for the two binaries shipped by PR #160 (`chorus`, `chorus-server`) on every `v*` tag push.

**Targets:**

| Triple | Use |
|---|---|
| `x86_64-unknown-linux-musl` | cloud VMs (GCP, AWS), statically linked |
| `aarch64-unknown-linux-musl` | ARM cloud VMs (Graviton, Tau T2A) |
| `x86_64-apple-darwin` | macOS Intel laptops |
| `aarch64-apple-darwin` | macOS Apple Silicon |

Each matrix entry produces one `chorus-<tag>-<target>.tar.gz` containing both binaries side by side, plus a SHA256 checksum file.

**UI bundle:** built explicitly via `npm ci && npm run build` before `cargo build` runs — `chorus-server` embeds `ui/dist/` via `rust-embed`, which reads the bundle at compile time. Skipping this step would ship a `chorus-server` that serves an empty UI.

**Cross-compile:** delegated to `taiki-e/upload-rust-binary-action` (handles `cross` for non-native targets, strip, tar, sha256, and release-asset upload in one step).

**Manual trigger:** `workflow_dispatch` with a `tag` input lets you rebuild artifacts for an existing tag without needing a new one — useful for runner-flake retries.

## Cargo.toml change

Adds `[profile.release] strip = \"symbols\"`. Stripped binaries are ~16–18 MB; unstripped were ~60–80 MB. Backtraces still work because they use the at-runtime backtrace formatter, not on-disk symbol tables.

## Test plan

- [x] `cargo build --release` locally — 16 MB `chorus`, 18 MB `chorus-server`, both stripped (verified via `file`).
- [ ] **After merge:** push a `v0.0.12.0-rc1` tag and confirm:
  - all 4 matrix jobs succeed
  - tarball contents extract `chorus` + `chorus-server` binaries that run on the target host
  - SHA256 file is present and correct
  - GitHub release page lists 4 tarballs + 4 sha256 files
- [ ] **After first clean release:** open follow-up PR to swap `render_onboarding_script` from `cargo install --git ... --bin chorus` to `curl -L https://github.com/Fullstop000/Chorus/releases/latest/download/chorus-<target>.tar.gz | tar -xz -C \$INSTALL_DIR chorus`, with `uname -s -m` → target-triple mapping.

## Follow-ups (not in this PR)

- Onboarding-script swap (depends on a clean release tag existing).
- Optional: a CHANGELOG.md generator step in the workflow (currently the release body is whatever the action emits by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)