### PR TITLE
ci: drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,17 @@ jobs:
         include:
           # Native compilation for every target — no `cross`, no Docker.
           # The aarch64-musl box uses a native arm64 runner (GA on
-          # GitHub Actions as of 2025), which removes the cross-compile
-          # toolchain and openssl-on-musl pain entirely.
+          # GitHub Actions as of 2025).
+          #
+          # Apple Silicon only for macOS: GitHub is phasing out macos-13
+          # (Intel) runners and the queue routinely stalls for 15+ min,
+          # which blocks the release aggregator. Apple has shipped
+          # Apple Silicon since 2020; Intel-mac bridge users can fall
+          # back to `cargo install --git … --bin chorus`.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: aarch64-apple-darwin
             os: macos-14
     steps:


### PR DESCRIPTION
## Why

The `v0.0.12.0-rc2` run produced this:

| Target | Status |
|---|---|
| `x86_64-unknown-linux-musl` | ✅ done in ~4 min |
| `aarch64-unknown-linux-musl` | ✅ done in ~4 min |
| `aarch64-apple-darwin` | ✅ done in ~5 min |
| `x86_64-apple-darwin` | ⏳ queued for 15+ min, no movement |

`macos-13` (Intel) runners are being phased out by GitHub; the queue stalls and blocks the release aggregator job (it `needs: build` on every matrix entry). The fourth job pinning the release is worse than not shipping that target.

## What

Drop `x86_64-apple-darwin` from the matrix. The remaining three cover cloud VMs (musl x86_64 + aarch64) and modern Macs (Apple Silicon).

Intel-mac users still have a path: `cargo install --git https://github.com/Fullstop000/Chorus --bin chorus`.

If we want to re-add it later, the right shape is `continue-on-error: true` so a single slow runner can't pin the release.

## Test plan

- [ ] Squash-merge.
- [ ] Delete `v0.0.12.0-rc2` tag.
- [ ] Push `v0.0.12.0-rc3`.
- [ ] Confirm three matrix jobs run + release aggregator publishes a tarball trio + sha256 trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)