### PR TITLE
feat(onboarding): fetch chorus from release tarball instead of cargo install

### DIFF
--- a/src/server/handlers/devices.rs
+++ b/src/server/handlers/devices.rs
@@ -329,10 +329,52 @@ fn render_onboarding_script(host: &str, bearer: &str) -> String {
         r#"#!/usr/bin/env bash
 set -euo pipefail
 
+INSTALL_DIR="${{CHORUS_INSTALL_DIR:-$HOME/.local/bin}}"
+REPO="Fullstop000/Chorus"
+
 if ! command -v chorus >/dev/null 2>&1; then
-  echo 'Install the Chorus CLI first:'
-  echo '  cargo install --git https://github.com/Fullstop000/Chorus --bin chorus'
-  exit 1
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)   TARGET=x86_64-unknown-linux-musl ;;
+    Linux-aarch64)  TARGET=aarch64-unknown-linux-musl ;;
+    Linux-arm64)    TARGET=aarch64-unknown-linux-musl ;;
+    Darwin-arm64)   TARGET=aarch64-apple-darwin ;;
+    Darwin-x86_64)
+      echo 'Intel macOS is not in the release matrix. Install from source:' >&2
+      echo "  cargo install --git https://github.com/$REPO --bin chorus" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unsupported platform: $(uname -s) $(uname -m)" >&2
+      echo "Browse releases: https://github.com/$REPO/releases/latest" >&2
+      exit 1
+      ;;
+  esac
+
+  TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+  if [ -z "$TAG" ]; then
+    echo "Failed to resolve latest release tag from GitHub API." >&2
+    exit 1
+  fi
+
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' EXIT
+  URL="https://github.com/$REPO/releases/download/$TAG/chorus-$TAG-$TARGET.tar.gz"
+  echo "Installing chorus $TAG ($TARGET) → $INSTALL_DIR ..."
+  curl -fsSL "$URL" | tar -xz -C "$TMP"
+  # Tarball layout: chorus-$TAG-$TARGET/{{chorus,chorus-server}}; copy
+  # just the device binary out of the staging subdir.
+  mkdir -p "$INSTALL_DIR"
+  mv "$TMP"/*/chorus "$INSTALL_DIR/chorus"
+  chmod +x "$INSTALL_DIR/chorus"
+
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+      echo "Note: $INSTALL_DIR is not in your PATH. Add it to your shell rc to keep using \`chorus\`." >&2
+      export PATH="$INSTALL_DIR:$PATH"
+      ;;
+  esac
 fi
 
 DATA_DIR="${{XDG_DATA_HOME:-$HOME/.local/share}}/chorus/bridge"
@@ -360,6 +402,32 @@ mod tests {
         assert!(s.contains(r#"token = "chrs_bridge_xyz""#));
         assert!(s.contains("exec chorus bridge"));
         assert!(s.contains("command -v chorus"));
+    }
+
+    #[test]
+    fn install_step_targets_the_release_pipeline() {
+        // Guards against accidentally regressing back to `cargo install`
+        // for native platforms or breaking the target-triple mapping.
+        // The script must:
+        //   - point at the Fullstop000/Chorus releases API
+        //   - select one of the three targets shipped in
+        //     .github/workflows/release.yml (Intel macOS deliberately
+        //     out of the matrix; that case errors with a cargo-install
+        //     hint)
+        //   - download the versioned tarball under the resolved tag
+        let s = render_onboarding_script("chorus.test", "chrs_bridge_xyz");
+        assert!(s.contains(r#"REPO="Fullstop000/Chorus""#));
+        assert!(s.contains("api.github.com/repos/$REPO/releases/latest"));
+        for target in [
+            "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-musl",
+            "aarch64-apple-darwin",
+        ] {
+            assert!(s.contains(target), "missing target mapping for {target}");
+        }
+        assert!(s.contains("releases/download/$TAG/chorus-$TAG-$TARGET.tar.gz"));
+        // Intel macOS falls back to cargo install (out of release matrix).
+        assert!(s.contains("Intel macOS is not in the release matrix"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Settings → Devices generates a bash one-liner the operator pastes on a bridge machine. Until now it required Rust on the device:

\`\`\`bash
cargo install --git https://github.com/Fullstop000/Chorus --bin chorus
\`\`\`

With the release pipeline (PRs #160–#163) now publishing per-target tarballs, the device only needs \`curl\` and \`tar\`. The new install step:

- Detects OS+arch via \`uname -s -m\` and maps to one of the three triples shipped by \`.github/workflows/release.yml\`:
  - Linux x86_64 → \`x86_64-unknown-linux-musl\`
  - Linux aarch64/arm64 → \`aarch64-unknown-linux-musl\`
  - Darwin arm64 → \`aarch64-apple-darwin\`
- **Intel macOS** falls back to \`cargo install\` (out of the release matrix per #163).
- Resolves the latest release tag through the GitHub releases API, then downloads \`chorus-\$TAG-\$TARGET.tar.gz\`.
- Installs user-local at \`\$HOME/.local/bin\` (overridable via \`CHORUS_INSTALL_DIR\`). No sudo.
- Warns when \`\$HOME/.local/bin\` is not already in \`\$PATH\`.

## Verification (end-to-end against \`v0.0.12.0-rc3\`)

Booted a fresh local platform, minted a token through \`/api/devices/mint\`, captured the rendered script, and ran it in an isolated shell:

\`\`\`
Installing chorus v0.0.12.0-rc3 (x86_64-unknown-linux-musl) → /tmp/chorus-e2e-install ...
Note: /tmp/chorus-e2e-install is not in your PATH. Add it to your shell rc to keep using \`chorus\`.
Connecting → localhost:4101 …
bridge: embedded MCP bridge listening endpoint=http://127.0.0.1:44240
bridge: dialing platform url=ws://localhost:4101/api/bridge/ws
bridge: hello sent machine=ppcc
\`\`\`

Platform's \`/api/devices\` immediately after:

\`\`\`json
{
  \"has_token\": true,
  \"devices\": [{
    \"machine_id\": \"ppcc\",
    \"hostname_hint\": \"ppcc\",
    \"first_seen_at\": \"2026-05-15T11:05:41Z\",
    \"active\": true
  }]
}
\`\`\`

Verified individually: \`command -v\` early-out works, \`uname\` mapping correct, GitHub API tag resolution, tarball download + extraction, \`\$CHORUS_INSTALL_DIR\` override honored, PATH-warning branch fires, credentials written under \`\$XDG_DATA_HOME\`, \`exec chorus bridge\` connects upstream, platform observes the active device.

Not exercised on this host: aarch64-musl and aarch64-apple-darwin install paths (different architectures), Intel-macOS fallback message.

## Tests

- \`cargo test\` — 4 device-handler unit tests + 7 device integration tests pass.
- \`cargo clippy --all-targets -- -D warnings\` clean.
- New regression test \`install_step_targets_the_release_pipeline\` asserts the rendered script targets the three shipped triples, the correct URL pattern, and the Intel-macOS fallback message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)